### PR TITLE
Fixup tests against 3.1

### DIFF
--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -28,17 +28,17 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(instrumentation.compatible?).must_equal false
       end
 
-      Gem.stub(:loaded_specs, 'aws-sdk-core' => nil, 'aws-sdk' => Gem::Specification.new { |s| s.version = '1.0.0' }) do
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => nil, 'aws-sdk' => Gem::Specification.new { |s| s.version = '1.0.0' } }) do
         hide_const('::Aws::CORE_GEM_VERSION')
         _(instrumentation.compatible?).must_equal false
       end
 
-      Gem.stub(:loaded_specs, 'aws-sdk-core' => Gem::Specification.new { |s| s.version = '1.0.0' }, 'aws-sdk' => nil) do
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => Gem::Specification.new { |s| s.version = '1.0.0' }, 'aws-sdk' => nil }) do
         hide_const('::Aws::CORE_GEM_VERSION')
         _(instrumentation.compatible?).must_equal false
       end
 
-      Gem.stub(:loaded_specs, 'aws-sdk-core' => nil, 'aws-sdk' => nil) do
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => nil, 'aws-sdk' => nil }) do
         stub_const('::Aws::CORE_GEM_VERSION', '1.9.9')
         _(instrumentation.compatible?).must_equal false
       end

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# rubocop:disable Style/BracesAroundHashParameters
+
 require 'test_helper'
 
 describe OpenTelemetry::Instrumentation::AwsSdk do

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -23,7 +23,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
   describe '#compatible' do
     it 'returns false for unsupported gem versions' do
-      Gem.stub(:loaded_specs, 'aws-sdk-core' => nil, 'aws-sdk' => nil) do
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => nil, 'aws-sdk' => nil }) do
         hide_const('::Aws::CORE_GEM_VERSION')
         _(instrumentation.compatible?).must_equal false
       end

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -238,3 +238,5 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
     end
   end
 end
+
+# rubocop:enable Style/BracesAroundHashParameters

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -28,13 +28,13 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
 
   describe 'compatible' do
     it 'when older gem version installed' do
-      Gem.stub(:loaded_specs, 'delayed_job' => Gem::Specification.new { |s| s.version = '4.0.3' }) do
+      Gem.stub(:loaded_specs, { 'delayed_job' => Gem::Specification.new { |s| s.version = '4.0.3' } }) do
         _(instrumentation.compatible?).must_equal false
       end
     end
 
     it 'when future gem version installed' do
-      Gem.stub(:loaded_specs, 'delayed_job' => Gem::Specification.new { |s| s.version = '5.3.0' }) do
+      Gem.stub(:loaded_specs, { 'delayed_job' => Gem::Specification.new { |s| s.version = '5.3.0' } }) do
         _(instrumentation.compatible?).must_equal true
       end
     end

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# rubocop:disable Style/BracesAroundHashParameters
+
 require_relative '../../test_helper'
 
 describe OpenTelemetry::Instrumentation::DelayedJob do

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -77,3 +77,5 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
     end
   end
 end
+
+# rubocop:enable Style/BracesAroundHashParameters

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -44,7 +44,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
     describe 'when the installing application bypasses RubyGems' do
       it 'falls back to the VERSION constant' do
         stub_const('Kafka::VERSION', '0.6.9')
-        Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
+        Gem.stub(:loaded_specs, { 'ruby-kafka' => nil }) do
           _(instrumentation.compatible?).must_equal false
         end
 

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -66,3 +66,5 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
     end
   end
 end
+
+# rubocop:enable Style/BracesAroundHashParameters

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -50,7 +50,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
 
         version = ::OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
         stub_const('Kafka::VERSION', version)
-        Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
+        Gem.stub(:loaded_specs, { 'ruby-kafka' => nil}) do
           _(instrumentation.compatible?).must_equal true
         end
       end

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# rubocop:disable Style/BracesAroundHashParameters
+
 require 'test_helper'
 
 require_relative '../../../../lib/opentelemetry/instrumentation/ruby_kafka'
@@ -50,7 +52,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
 
         version = ::OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
         stub_const('Kafka::VERSION', version)
-        Gem.stub(:loaded_specs, { 'ruby-kafka' => nil}) do
+        Gem.stub(:loaded_specs, { 'ruby-kafka' => nil }) do
           _(instrumentation.compatible?).must_equal true
         end
       end


### PR DESCRIPTION
Looks like specs are failing for a few instrumentations on `main` when run against Ruby 3.1. Not sure why this started right now, but here's a shot at fixing it.