### PR TITLE
feat: use rack middleware in sinatra middleware

### DIFF
--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -10,4 +10,5 @@ gemspec
 
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-rack', path: '../rack'
 end

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
@@ -28,7 +28,7 @@ module OpenTelemetry
                 end
               end
             end
-
+            app.use OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
             app.use Middlewares::TracerMiddleware
           end
         end

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/instrumentation.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/instrumentation.rb
@@ -13,6 +13,8 @@ module OpenTelemetry
       # instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         install do |_|
+          OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.install({})
+
           ::Sinatra::Base.register Extensions::TracerExtension
         end
 

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -16,7 +16,9 @@ module OpenTelemetry
           end
 
           def call(env)
-            @app.call(env).tap { trace_response(env) }
+            @app.call(env)
+          ensure
+            trace_response(env)
           end
 
           def trace_response(env)

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
+  spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -85,10 +85,12 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       get '/one/endpoint'
 
       _(exporter.finished_spans.first.attributes).must_equal(
+        'http.host' => 'example.org',
         'http.method' => 'GET',
-        'http.url' => '/endpoint',
+        'http.route' => '/endpoint',
+        'http.scheme' => 'http',
         'http.status_code' => 200,
-        'http.route' => '/endpoint'
+        'http.target' => '/endpoint'
       )
     end
 
@@ -112,8 +114,10 @@ describe OpenTelemetry::Instrumentation::Sinatra do
 
       _(exporter.finished_spans.size).must_equal 1
       _(exporter.finished_spans.first.attributes).must_equal(
+        'http.host' => 'example.org',
         'http.method' => 'GET',
-        'http.url' => '/api/v1/foo/janedoe/',
+        'http.target' => '/api/v1/foo/janedoe/',
+        'http.scheme' => 'http',
         'http.status_code' => 200,
         'http.route' => '/api/v1/foo/:myname/?'
       )
@@ -128,9 +132,11 @@ describe OpenTelemetry::Instrumentation::Sinatra do
 
       _(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       _(exporter.finished_spans.first.attributes).must_equal(
+        'http.host' => 'example.org',
         'http.method' => 'GET',
-        'http.url' => '/missing_example/not_present',
-        'http.status_code' => 404
+        'http.scheme' => 'http',
+        'http.status_code' => 404,
+        'http.target' => '/missing_example/not_present'
       )
     end
   end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -18,6 +18,10 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         '1'
       end
 
+      get '/error' do
+        raise
+      end
+
       template :foo_template do
         'Foo Template'
       end
@@ -137,6 +141,19 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         'http.scheme' => 'http',
         'http.status_code' => 404,
         'http.target' => '/missing_example/not_present'
+      )
+    end
+
+    it 'does correctly name spans when the app raises errors' do
+      get '/one/error'
+
+      _(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      _(exporter.finished_spans.first.attributes).must_equal(
+        'http.host' => 'example.org',
+        'http.method' => 'GET',
+        'http.route' => '/error',
+        'http.scheme' => 'http',
+        'http.target' => '/error'
       )
     end
   end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -144,10 +144,11 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       )
     end
 
-    it 'does correctly name spans when the app raises errors' do
+    it 'does correctly name spans and add attributes when the app raises errors' do
       get '/one/error'
 
       _(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      _(exporter.finished_spans.first.name).must_equal('GET /error')
       _(exporter.finished_spans.first.attributes).must_equal(
         'http.host' => 'example.org',
         'http.method' => 'GET',


### PR DESCRIPTION
Copied from https://github.com/open-telemetry/opentelemetry-ruby/pull/1278

> This commit switches the Sinatra instrumentation to run on top of the Rack instrumentation, which is desgined is to be integrated as an extension of other instrumentations.
>
> Extending Rack unlocks some useful configuration options for Sinatra users such as the ability to not trace selected endpoints.
>
> This PR takes a similar approach to the ActionPack instrumentation for integrating with the Rack middleware.