### PR TITLE
Fix: make sidekiq instrumentation rake task compatible with TruffleRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,6 @@ jobs:
           [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-redis"      ]] && echo "::set-output name=skip::true"
           [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-resque"     ]] && echo "::set-output name=skip::true"
           [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-sidekiq"    ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test Truffleruby"

--- a/instrumentation/sidekiq/Rakefile
+++ b/instrumentation/sidekiq/Rakefile
@@ -13,7 +13,7 @@ RuboCop::RakeTask.new
 
 task :start_redis do
   redis_exists = `which redis-server`.lines.any?
-  @redis_pid = fork { exec 'redis-server test/redis.conf' } if redis_exists
+  @redis_pid = Process.spawn('redis-server test/redis.conf') if redis_exists
 end
 
 Rake::TestTask.new test: :start_redis do |t|


### PR DESCRIPTION
## Context

This PR starts to fix issues related to supporting TruffleRuby (added in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/59) by fixing the Sidekiq implementation test issues.

This should fix https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/46

### Fixing Sidekiq Instrumentation issues in testing

This commit fixes the following error from the Rakefile due to using `fork` for starting
redis:

```
NotImplementedError: fork is not available
```

According to the TruffleRuby compatibility docs, `fork` is not compatible in TruffleRuby:

> You cannot fork the TruffleRuby interpreter. The feature is unlikely to ever be supported when running on the JVM but could be supported in the future in the native configuration. 

After fixing that issue, I was able to successfully run a passing test suite for the Sidekiq implementation.