### PR TITLE
feat: add net http instrumentation hooks config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ instrumentation/active_record/db
 **/vendor/**/*
 
 # IDE Settings
-/.idea/
+**/.idea/
 
 # rbenv configuration
 .ruby-version

--- a/instrumentation/net_http/README.md
+++ b/instrumentation/net_http/README.md
@@ -38,7 +38,7 @@ OpenTelemetry::SDK.configure do |c|
     request_hook: lambda { |span, request, request_body|
       # Extract custom attributes from request
     },
-    response_hook: lambda { |span, request|
+    response_hook: lambda { |span, response|
       # Extract custom attributes from response
     }
   }

--- a/instrumentation/net_http/README.md
+++ b/instrumentation/net_http/README.md
@@ -30,6 +30,21 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Net::HTTP', {
+    request_hook: lambda { |span, request, request_body|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, request|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## Example
 
 An example of usage can be seen in [`example/net_http.rb`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/net_http/example/net_http.rb).

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
@@ -20,6 +20,9 @@ module OpenTelemetry
             defined?(::Net::HTTP)
           end
 
+          option :request_hook, default: nil, validate: :callable
+          option :response_hook, default: nil, validate: :callable
+
           private
 
           def require_dependencies

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -55,7 +55,7 @@ module OpenTelemetry
 
               hook.call(*args)
             rescue StandardError => e
-              OpenTelemetry.logger.debug(e.message)
+              OpenTelemetry.handle_error(exception: e)
             end
 
             def connect

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -167,8 +167,8 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         before do
           instrumentation.instance_variable_set(:@installed, false)
           config = {
-            request_hook: lambda { |_span| puts 1234 },
-            response_hook: lambda { |_span| puts 4321 },
+            request_hook: lambda { |_span| nil },
+            response_hook: lambda { |_span| nil },
           }
 
           instrumentation.install(config)
@@ -186,8 +186,8 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         before do
           instrumentation.instance_variable_set(:@installed, false)
           config = {
-            request_hook: lambda { |_span, _request, _request_body| raise StandardError.new('err1') },
-            response_hook: lambda { |_span, _response| StandardError.new('err2') },
+            request_hook: lambda { |_span, _request, _request_body| raise StandardError, 'err1' },
+            response_hook: lambda { |_span, _response| raise StandardError, 'err2' },
           }
 
           instrumentation.install(config)

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -164,58 +164,63 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       end
 
       describe 'invalid hook - wrong number of args' do
+        let(:received_exceptions) { [] }
+
         before do
           instrumentation.instance_variable_set(:@installed, false)
           config = {
-            request_hook: -> (_span) { nil },
-            response_hook: -> (_span) { nil }
+            request_hook: ->(_span) { nil },
+            response_hook: ->(_span) { nil }
           }
 
           instrumentation.install(config)
-        end
-
-        after { OpenTelemetry::TestHelpers.reset_opentelemetry }
-
-        it 'should not fail the instrumentation' do
-          received_exceptions = []
-          OpenTelemetry.error_handler = lambda do |exception: nil, message: nil|
+          OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
             received_exceptions << exception
           end
+        end
+
+        after do
+          OpenTelemetry.error_handler = nil
+        end
+
+        it 'should not fail the instrumentation' do
           ::Net::HTTP.get('example.com', '/body')
           _(exporter.finished_spans.size).must_equal 1
           _(span.name).must_equal 'HTTP GET'
           _(span.attributes['http.method']).must_equal 'GET'
-          error_messages = received_exceptions.map { |e| e.message }
-          _(error_messages.all? { |em| em.start_with?('wrong number of arguments')}).must_equal true
+          error_messages = received_exceptions.map(&:message)
+          _(error_messages.all? { |em| em.start_with?('wrong number of arguments') }).must_equal true
         end
       end
 
       describe 'invalid hooks - throws an error' do
         let(:error1) { 'err1' }
         let(:error2) { 'err2' }
+        let(:received_exceptions) { [] }
 
         before do
           instrumentation.instance_variable_set(:@installed, false)
           config = {
-            request_hook: -> (_span, _request, _request_body) { raise StandardError, error1 },
-            response_hook: -> (_span, _response) { raise StandardError, error2 }
+            request_hook: ->(_span, _request, _request_body) { raise StandardError, error1 },
+            response_hook: ->(_span, _response) { raise StandardError, error2 }
           }
 
           instrumentation.install(config)
-        end
-
-        after { OpenTelemetry::TestHelpers.reset_opentelemetry }
-
-        it 'should not fail the instrumentation' do
-          received_exceptions = []
-          OpenTelemetry.error_handler = lambda do |exception: nil, message: nil|
+          OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
             received_exceptions << exception
           end
+        end
+
+        after do
+          OpenTelemetry.error_handler = nil
+        end
+
+        it 'should not fail the instrumentation' do
           ::Net::HTTP.get('example.com', '/body')
           _(exporter.finished_spans.size).must_equal 1
           _(span.name).must_equal 'HTTP GET'
           _(span.attributes['http.method']).must_equal 'GET'
-          error_messages = received_exceptions.map { |e| e.message }
+          error_messages = received_exceptions.map(&:message)
           _(error_messages).must_equal([error1, error2])
         end
       end


### PR DESCRIPTION
Add support for `request_hook` and `response_hook` that allow adding user-customizable attributes to the span. This capability is common across http client instrumentations in other languages (see https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http and https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3 in node and python, respectively).

For example, this capability can be used to collect data from request/response headers.