### PR TITLE
fix: suppress invalid span attribute value type warning in aws-sdk instrumentation

### DIFF
--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/messaging_helper.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/messaging_helper.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
             attributes[SemanticConventions::Trace::MESSAGING_SYSTEM] = 'aws.sqs'
             attributes[SemanticConventions::Trace::MESSAGING_DESTINATION_KIND] = 'queue'
             attributes[SemanticConventions::Trace::MESSAGING_DESTINATION] = queue_name(context)
-            attributes[SemanticConventions::Trace::MESSAGING_URL] = context.params[:queue_url]
+            attributes[SemanticConventions::Trace::MESSAGING_URL] = context.params[:queue_url] if context.params[:queue_url]
 
             attributes[SemanticConventions::Trace::MESSAGING_OPERATION] = 'receive' if client_method == 'SQS.ReceiveMessage'
           end

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -172,6 +172,18 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['messaging.destination']).must_equal 'queue-name'
         _(last_span.attributes['messaging.url']).must_equal 'https://sqs.fake.amazonaws.com/1/queue-name'
       end
+
+      it 'should have messaging attributes for get_queue_url' do
+        sqs_client = Aws::SQS::Client.new(stub_responses: true)
+
+        sqs_client.get_queue_url queue_name: 'queue-name'
+
+        _(last_span.attributes['rpc.system']).must_equal 'aws-api'
+        _(last_span.attributes['messaging.system']).must_equal 'aws.sqs'
+        _(last_span.attributes['messaging.destination_kind']).must_equal 'queue'
+        _(last_span.attributes['messaging.destination']).must_equal 'unknown'
+        _(last_span.attributes).wont_include('messaging.url')
+      end
     end
 
     describe 'sns' do


### PR DESCRIPTION
fixes #63 