### PR TITLE
fix: Ensure untraced blocks suppress spans

### DIFF
--- a/instrumentation/net_http/example/Gemfile
+++ b/instrumentation/net_http/example/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 
 gem 'opentelemetry-api'
 gem 'opentelemetry-common'
-gem 'opentelemetry-instrumentation-net_http'
+gem 'opentelemetry-instrumentation-net_http', path: '../'
 gem 'opentelemetry-sdk'

--- a/instrumentation/net_http/example/net_http.rb
+++ b/instrumentation/net_http/example/net_http.rb
@@ -12,3 +12,13 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 Net::HTTP.get(URI('http://example.com'))
+
+OpenTelemetry.tracer_provider.tracer.in_span('activate') do
+  Net::HTTP.get(URI('http://example.com'))
+end
+
+OpenTelemetry.tracer_provider.tracer.in_span('deactivate') do
+  OpenTelemetry::Common::Utilities.untraced do
+    Net::HTTP.get(URI('http://example.com'))
+  end
+end

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -16,8 +16,7 @@ module OpenTelemetry
 
             def request(req, body = nil, &block) # rubocop:disable Metrics/AbcSize
               # Do not trace recursive call for starting the connection
-              return super(req, body, &block) unless started?
-              return super(req, body, &block) unless OpenTelemetry::Trace.current_span.recording?
+              return super(req, body, &block) unless started? && OpenTelemetry::Trace.current_span.recording?
 
               attributes = {
                 OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => req.method,

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -17,6 +17,7 @@ module OpenTelemetry
             def request(req, body = nil, &block) # rubocop:disable Metrics/AbcSize
               # Do not trace recursive call for starting the connection
               return super(req, body, &block) unless started?
+              return super(req, body, &block) unless OpenTelemetry::Trace.current_span.recording?
 
               attributes = {
                 OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => req.method,
@@ -54,6 +55,8 @@ module OpenTelemetry
             end
 
             def connect
+              return super unless OpenTelemetry::Trace.current_span.recording?
+
               if proxy?
                 conn_address = proxy_address
                 conn_port    = proxy_port

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
 
             def request(req, body = nil, &block) # rubocop:disable Metrics/AbcSize
               # Do not trace recursive call for starting the connection
-              return super(req, body, &block) unless started? && OpenTelemetry::Trace.current_span.recording?
+              return super(req, body, &block) unless started? && OpenTelemetry::Trace.current_span.context.trace_flags.sampled?
 
               attributes = {
                 OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => req.method,

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -3,11 +3,11 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+ENV['OTEL_TRACES_SAMPLER'] = 'always_on'
 
 require 'net/http'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:development)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -3,7 +3,6 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-ENV['OTEL_TRACES_SAMPLER'] = 'always_on'
 
 require 'net/http'
 require 'bundler/setup'


### PR DESCRIPTION
Prior to this change, the Net::HTTP instrumentation would defer to the sampling strategy
to determine if it should generate a span, however the sampling strategy
is not aware of the `untraced` block and it will always generate a span
even though the parent span is untraced.

The question here is... should the `untraced` block override the logic in the sampling strategy?

Also... a side effect of checking that the `current_span.recording?` is that the instrumentation
will never be allowed to generate a root span.

Related to https://github.com/open-telemetry/opentelemetry-ruby/discussions/1333