### PR TITLE
feat: add request/response hooks to more http clients

### DIFF
--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -35,7 +35,7 @@ end
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Faraday', {
-    request_hook: lambda { |span, request|
+    request_hook: lambda { |span, env|
       # Extract custom attributes from request
     },
     response_hook: lambda { |span, response|

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -30,6 +30,21 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Faraday', {
+    request_hook: lambda { |span, request|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, response|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## Examples
 
 Example usage of faraday can be seen in the `./example/faraday.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/faraday/example/faraday.rb)

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -21,6 +21,8 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
+        option :request_hook, default: nil, validate: :callable
+        option :response_hook, default: nil, validate: :callable
 
         private
 

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
               "HTTP #{http_method}", attributes: attributes, kind: :client
             ) do |span|
               OpenTelemetry.propagation.inject(env.request_headers)
-              safe_execute_hook(config[:request_hook], span, env) unless config[:request_hook].nil?
+              safe_execute_hook(instrumentation_config[:request_hook], span, env) unless instrumentation_config[:request_hook].nil?
 
               app.call(env).on_complete { |resp| trace_response(span, resp) }
             end
@@ -42,7 +42,7 @@ module OpenTelemetry
 
           attr_reader :app
 
-          def config
+          def instrumentation_config
             Faraday::Instrumentation.instance.config
           end
 
@@ -72,7 +72,7 @@ module OpenTelemetry
           def trace_response(span, response)
             span.set_attribute('http.status_code', response.status)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(response.status.to_i)
-            safe_execute_hook(config[:response_hook], span, response) unless config[:response_hook].nil?
+            safe_execute_hook(instrumentation_config[:response_hook], span, response) unless instrumentation_config[:response_hook].nil?
           end
         end
       end

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -23,7 +23,7 @@ module OpenTelemetry
             trace: 'TRACE'
           }.freeze
 
-          def call(env)
+          def call(env) # rubocop:disable Metrics/AbcSize
             http_method = HTTP_METHODS_SYMBOL_TO_STRING[env.method]
             attributes = span_creation_attributes(
               http_method: http_method, url: env.url
@@ -32,6 +32,7 @@ module OpenTelemetry
               "HTTP #{http_method}", attributes: attributes, kind: :client
             ) do |span|
               OpenTelemetry.propagation.inject(env.request_headers)
+              safe_execute_hook(config[:request_hook], span, env) unless config[:request_hook].nil?
 
               app.call(env).on_complete { |resp| trace_response(span, resp) }
             end
@@ -40,6 +41,16 @@ module OpenTelemetry
           private
 
           attr_reader :app
+
+          def config
+            Faraday::Instrumentation.instance.config
+          end
+
+          def safe_execute_hook(hook, *args)
+            hook.call(*args)
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+          end
 
           def span_creation_attributes(http_method:, url:)
             instrumentation_attrs = {
@@ -61,6 +72,7 @@ module OpenTelemetry
           def trace_response(span, response)
             span.set_attribute('http.status_code', response.status)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(response.status.to_i)
+            safe_execute_hook(config[:response_hook], span, response) unless config[:response_hook].nil?
           end
         end
       end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -166,7 +166,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       end
     end
 
-    describe 'invalid hook - wrong number of args' do
+    describe 'when hooks are configured with incorrect number of args' do
       let(:received_exceptions) { [] }
 
       before do
@@ -196,7 +196,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       end
     end
 
-    describe 'invalid hooks - throws an error' do
+    describe 'when exceptions are thrown in hooks' do
       let(:error1) { 'err1' }
       let(:error2) { 'err2' }
       let(:received_exceptions) { [] }

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -30,6 +30,21 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::HTTP', {
+    request_hook: lambda { |span, request|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, response|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/http/example/trace_demonstration.rb)

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -18,6 +18,9 @@ module OpenTelemetry
           !(defined?(::HTTP::Client).nil? || defined?(::HTTP::Connection).nil?)
         end
 
+        option :request_hook, default: nil, validate: :callable
+        option :response_hook, default: nil, validate: :callable
+
         def patch
           ::HTTP::Client.prepend(Patches::Client)
           ::HTTP::Connection.prepend(Patches::Connection)

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
@@ -25,12 +25,10 @@ module OpenTelemetry
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
               OpenTelemetry.propagation.inject(req.headers)
-              request_hook = instrumentation_config[:request_hook]
-              safe_execute_hook(request_hook, span, req) unless request_hook.nil?
+              safe_execute_hook(instrumentation_config[:request_hook], span, req) unless instrumentation_config[:request_hook].nil?
               super.tap do |response|
                 annotate_span_with_response!(span, response)
-                response_hook = instrumentation_config[:response_hook]
-                safe_execute_hook(response_hook, span, response) unless response_hook.nil?
+                safe_execute_hook(instrumentation_config[:response_hook], span, response) unless instrumentation_config[:response_hook].nil?
               end
             end
           end

--- a/instrumentation/http/test/instrumentation/http/patches/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/client_test.rb
@@ -116,4 +116,108 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       )
     end
   end
+
+  describe 'hooks' do
+    let(:response_body) { 'abcd1234' }
+    let(:headers_attribute) { 'headers' }
+    let(:response_body_attribute) { 'response_body' }
+
+    before do
+      stub_request(:get, 'http://example.com/body').to_return(status: 200, body: response_body)
+    end
+
+    describe 'valid hooks' do
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: lambda do |span, request|
+            headers = {}
+            request.headers.each do |k, v|
+              headers[k] = v
+            end
+            span.set_attribute(headers_attribute, headers.to_json)
+          end,
+          response_hook: lambda do |span, response|
+            span.set_attribute(response_body_attribute, response.body.to_s)
+          end
+        }
+
+        instrumentation.install(config)
+      end
+
+      it 'collects data in request hook' do
+        ::HTTP.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        headers = span.attributes[headers_attribute]
+        _(headers).wont_be_nil
+        parsed_headers = JSON.parse(headers)
+        _(parsed_headers['Traceparent']).wont_be_nil
+        _(span.attributes[response_body_attribute]).must_equal response_body
+      end
+    end
+
+    describe 'invalid hook - wrong number of args' do
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span) { nil },
+          response_hook: ->(_span) { nil }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        ::HTTP.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages.all? { |em| em.start_with?('wrong number of arguments') }).must_equal true
+      end
+    end
+
+    describe 'invalid hooks - throws an error' do
+      let(:error1) { 'err1' }
+      let(:error2) { 'err2' }
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span, _request) { raise StandardError, error1 },
+          response_hook: ->(_span, _response) { raise StandardError, error2 }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        ::HTTP.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages).must_equal([error1, error2])
+      end
+    end
+  end
 end

--- a/instrumentation/http/test/instrumentation/http/patches/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/client_test.rb
@@ -158,7 +158,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       end
     end
 
-    describe 'invalid hook - wrong number of args' do
+    describe 'when hooks are configured with incorrect number of args' do
       let(:received_exceptions) { [] }
 
       before do
@@ -188,7 +188,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       end
     end
 
-    describe 'invalid hooks - throws an error' do
+    describe 'when exceptions are thrown in hooks' do
       let(:error1) { 'err1' }
       let(:error2) { 'err2' }
       let(:received_exceptions) { [] }

--- a/instrumentation/http_client/README.md
+++ b/instrumentation/http_client/README.md
@@ -30,6 +30,21 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::HttpClient', {
+    request_hook: lambda { |span, request|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, response|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/http_client/example/trace_demonstration.rb)

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/instrumentation.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/instrumentation.rb
@@ -20,6 +20,9 @@ module OpenTelemetry
           defined?(::HTTPClient)
         end
 
+        option :request_hook, default: nil, validate: :callable
+        option :response_hook, default: nil, validate: :callable
+
         private
 
         def patch

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
@@ -12,6 +12,16 @@ module OpenTelemetry
         module Client
           private
 
+          def config
+            HttpClient::Instrumentation.instance.config
+          end
+
+          def safe_execute_hook(hook, *args)
+            hook.call(*args)
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+          end
+
           def do_get_block(req, proxy, conn, &block) # rubocop:disable Metrics/AbcSize
             uri = req.header.request_uri
             url = "#{uri.scheme}://#{uri.host}"
@@ -28,6 +38,7 @@ module OpenTelemetry
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
               OpenTelemetry.propagation.inject(req.header)
+              safe_execute_hook(config[:request_hook], span, req) unless config[:request_hook].nil?
               super.tap do
                 response = conn.pop
                 annotate_span_with_response!(span, response)
@@ -43,6 +54,7 @@ module OpenTelemetry
 
             span.set_attribute('http.status_code', status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(status_code.to_i)
+            safe_execute_hook(config[:response_hook], span, response) unless config[:response_hook].nil?
           end
 
           def tracer

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
@@ -12,7 +12,7 @@ module OpenTelemetry
         module Client
           private
 
-          def config
+          def instrumentation_config
             HttpClient::Instrumentation.instance.config
           end
 
@@ -38,7 +38,7 @@ module OpenTelemetry
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
               OpenTelemetry.propagation.inject(req.header)
-              safe_execute_hook(config[:request_hook], span, req) unless config[:request_hook].nil?
+              safe_execute_hook(instrumentation_config[:request_hook], span, req) unless instrumentation_config[:request_hook].nil?
               super.tap do
                 response = conn.pop
                 annotate_span_with_response!(span, response)
@@ -54,7 +54,7 @@ module OpenTelemetry
 
             span.set_attribute('http.status_code', status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(status_code.to_i)
-            safe_execute_hook(config[:response_hook], span, response) unless config[:response_hook].nil?
+            safe_execute_hook(instrumentation_config[:response_hook], span, response) unless instrumentation_config[:response_hook].nil?
           end
 
           def tracer

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
@@ -124,4 +124,114 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       )
     end
   end
+
+  describe 'hooks' do
+    let(:response_body) { 'abcd1234' }
+    let(:headers_attribute) { 'headers' }
+    let(:response_body_attribute) { 'response_body' }
+
+    before do
+      stub_request(:get, 'http://example.com/body').to_return(status: 200, body: response_body)
+    end
+
+    describe 'valid hooks' do
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: lambda do |span, request|
+            headers = {}
+            request.headers.each do |k, v|
+              headers[k] = v
+            end
+            span.set_attribute(headers_attribute, headers.to_json)
+          end,
+          response_hook: lambda do |span, response|
+            span.set_attribute(response_body_attribute, response.body)
+          end
+        }
+
+        instrumentation.install(config)
+      end
+
+      it 'collects data in request hook' do
+        http = HTTPClient.new
+        http.receive_timeout = 1
+        http.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        headers = span.attributes[headers_attribute]
+        _(headers).wont_be_nil
+        parsed_headers = JSON.parse(headers)
+        _(parsed_headers['traceparent']).wont_be_nil
+        _(span.attributes[response_body_attribute]).must_equal response_body
+      end
+    end
+
+    describe 'invalid hook - wrong number of args' do
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span) { nil },
+          response_hook: ->(_span) { nil }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        http = HTTPClient.new
+        http.receive_timeout = 1
+        http.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages.all? { |em| em.start_with?('wrong number of arguments') }).must_equal true
+      end
+    end
+
+    describe 'invalid hooks - throws an error' do
+      let(:error1) { 'err1' }
+      let(:error2) { 'err2' }
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span, _request) { raise StandardError, error1 },
+          response_hook: ->(_span, _response) { raise StandardError, error2 }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        http = HTTPClient.new
+        http.receive_timeout = 1
+        http.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages).must_equal([error1, error2])
+      end
+    end
+  end
 end

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
@@ -168,7 +168,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       end
     end
 
-    describe 'invalid hook - wrong number of args' do
+    describe 'when hooks are configured with incorrect number of args' do
       let(:received_exceptions) { [] }
 
       before do
@@ -200,7 +200,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       end
     end
 
-    describe 'invalid hooks - throws an error' do
+    describe 'when exceptions are thrown in hooks' do
       let(:error1) { 'err1' }
       let(:error2) { 'err2' }
       let(:received_exceptions) { [] }

--- a/instrumentation/restclient/README.md
+++ b/instrumentation/restclient/README.md
@@ -30,6 +30,21 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::RestClient', {
+    request_hook: lambda { |span, request|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, response|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## How can I get involved?
 
 The `opentelemetry-instrumentation-restclient` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.

--- a/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/instrumentation.rb
+++ b/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/instrumentation.rb
@@ -20,6 +20,8 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
+        option :request_hook, default: nil, validate: :callable
+        option :response_hook, default: nil, validate: :callable
 
         private
 

--- a/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/patches/request.rb
+++ b/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/patches/request.rb
@@ -34,8 +34,8 @@ module OpenTelemetry
               'http.method' => http_method.to_s,
               'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url)
             }
-            config = RestClient::Instrumentation.instance.config
-            instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
+            instrumentation_config = RestClient::Instrumentation.instance.config
+            instrumentation_attrs['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
             span = tracer.start_span(
               "HTTP #{http_method}",
               attributes: instrumentation_attrs.merge(
@@ -47,7 +47,7 @@ module OpenTelemetry
             OpenTelemetry::Trace.with_span(span) do
               OpenTelemetry.propagation.inject(processed_headers)
             end
-            safe_execute_hook(config[:request_hook], span, self) unless config[:request_hook].nil?
+            safe_execute_hook(instrumentation_config[:request_hook], span, self) unless instrumentation_config[:request_hook].nil?
 
             span
           end

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
@@ -153,7 +153,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
       end
     end
 
-    describe 'invalid hook - wrong number of args' do
+    describe 'when hooks are configured with incorrect number of args' do
       let(:received_exceptions) { [] }
 
       before do
@@ -183,7 +183,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
       end
     end
 
-    describe 'invalid hooks - throws an error' do
+    describe 'when exceptions are thrown in hooks' do
       let(:error1) { 'err1' }
       let(:error2) { 'err2' }
       let(:received_exceptions) { [] }

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
@@ -111,4 +111,108 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
       _(span.attributes['http.method']).must_equal 'GET'
     end
   end
+
+  describe 'hooks' do
+    let(:response_body) { 'abcd1234' }
+    let(:headers_attribute) { 'headers' }
+    let(:response_body_attribute) { 'response_body' }
+
+    before do
+      stub_request(:get, 'http://example.com/body').to_return(status: 200, body: response_body)
+    end
+
+    describe 'valid hooks' do
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: lambda do |span, request|
+            headers = {}
+            request.processed_headers.each do |k, v|
+              headers[k] = v
+            end
+            span.set_attribute(headers_attribute, headers.to_json)
+          end,
+          response_hook: lambda do |span, response|
+            span.set_attribute(response_body_attribute, response.body)
+          end
+        }
+
+        instrumentation.install(config)
+      end
+
+      it 'collects data in request hook' do
+        ::RestClient.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        headers = span.attributes[headers_attribute]
+        _(headers).wont_be_nil
+        parsed_headers = JSON.parse(headers)
+        _(parsed_headers['User-Agent']).must_include 'rest-client'
+        _(span.attributes[response_body_attribute]).must_equal response_body
+      end
+    end
+
+    describe 'invalid hook - wrong number of args' do
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span) { nil },
+          response_hook: ->(_span) { nil }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        ::RestClient.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages.all? { |em| em.start_with?('wrong number of arguments') }).must_equal true
+      end
+    end
+
+    describe 'invalid hooks - throws an error' do
+      let(:error1) { 'err1' }
+      let(:error2) { 'err2' }
+      let(:received_exceptions) { [] }
+
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        config = {
+          request_hook: ->(_span, _request) { raise StandardError, error1 },
+          response_hook: ->(_span, _response) { raise StandardError, error2 }
+        }
+
+        instrumentation.install(config)
+        OpenTelemetry.error_handler = lambda do |exception: nil, message: nil| # rubocop:disable Lint/UnusedBlockArgument
+          received_exceptions << exception
+        end
+      end
+
+      after do
+        OpenTelemetry.error_handler = nil
+      end
+
+      it 'should not fail the instrumentation' do
+        ::RestClient.get('http://example.com/body')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        error_messages = received_exceptions.map(&:message)
+        _(error_messages).must_equal([error1, error2])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Same as the case in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/62 - align the functionality of all http clients.