### PR TITLE
feat: Add simple opentelemetry-collector config for use in dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ To test using Docker:
      2. Run the tests for the sdk
          *  `docker-compose run sdk bundle exec rake test`
 
-## OpenTelemetry Collector
+## Processing and visualizing traces locally
 
 You may wish to test your changes against an [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector). To facilitate this, we provide configuration in `docker-compose.yml` that should be sufficient.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,15 @@ To test using Docker:
      2. Run the tests for the sdk
          *  `docker-compose run sdk bundle exec rake test`
 
+## OpenTelemetry Collector
+
+You may wish to test your changes against an [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector). To facilitate this, we provide configuration in `docker-compose.yml` that should be sufficient.
+
+By default, docker-compose launches all services, including the collector - `docker-compose up` from the repository root is sufficient.
+However, if you only wish to launch the collector, run `docker-compose up jaeger otelcol` instead.
+
+The collector listens on the default HTTP and GRPC ports (`4318` and `4317`, respectively). You can visualize the traces from your work via the Jaeger trace UI by visiting `localhost:16686` in your browser.
+
 ## Make your modifications
 
 Some important tips to keep in mind when making your modifications.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,22 @@ services:
     depends_on:
       - zookeeper
 
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"
+
+  otelcol:
+    image: otel/opentelemetry-collector:0.54.0
+    command: [ "--config=/etc/otelcol-config.yml" ]
+    volumes:
+      - ./otelcol-config.yml:/etc/otelcol-config.yml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    depends_on:
+      - jaeger
+
 volumes:
   bundle:
   redis_data:

--- a/otelcol-config.yml
+++ b/otelcol-config.yml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  jaeger:
+    endpoint: "jaeger:14250"
+    tls:
+      insecure: true
+  logging:
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]


### PR DESCRIPTION
Mostly this is borrowed from open-telemetry/opentelemetry-demo-webstore.

This commit adds the opentelemetry-collector and the jaeger all-in-one
image to the docker-compose file. This allows us to export traces in
development to a collector and then visualize them in the Jaeger UI.

Fixes #74
