### PR TITLE
add rack hooks

### DIFF
--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -49,6 +49,23 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Request/response hooks
+
+You can pass hooks to extract additional attributes from the requests/responses.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Rack', {
+    request_hook: lambda { |span, env|
+      # Extract custom attributes from request
+    },
+    response_hook: lambda { |span, response|
+      # Extract custom attributes from response
+    }
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/rack/example/trace_demonstration.rb)

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -30,6 +30,8 @@ module OpenTelemetry
         option :untraced_endpoints,       default: [],    validate: :array
         option :url_quantization,         default: nil,   validate: :callable
         option :untraced_requests,        default: nil,   validate: :callable
+        option :request_hook, default: nil, validate: :callable
+        option :response_hook, default: nil, validate: :callable
 
         private
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -79,6 +79,7 @@ module OpenTelemetry
               tracer.in_span(request_span_name,
                              attributes: request_span_attributes(env: env),
                              kind: request_span_kind) do |request_span|
+                safe_execute_hook(config[:request_hook], request_span, original_env) unless config[:request_hook].nil?
                 OpenTelemetry::Instrumentation::Rack.with_span(request_span) do
                   @app.call(env).tap do |status, headers, response|
                     set_attributes_after_request(request_span, status, headers, response)
@@ -91,6 +92,12 @@ module OpenTelemetry
           end
 
           private
+
+          def safe_execute_hook(hook, *args)
+            hook.call(*args)
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+          end
 
           def untraced_request?(env)
             return true if @untraced_endpoints.include?(env['PATH_INFO'])
@@ -150,7 +157,7 @@ module OpenTelemetry
             end
           end
 
-          def set_attributes_after_request(span, status, headers, _response)
+          def set_attributes_after_request(span, status, headers, response)
             span.status = OpenTelemetry::Trace::Status.error unless (100..499).include?(status.to_i)
             span.set_attribute('http.status_code', status)
 
@@ -159,6 +166,7 @@ module OpenTelemetry
             # e.g., "/users/:userID?
 
             allowed_response_headers(headers).each { |k, v| span.set_attribute(k, v) }
+            safe_execute_hook(config[:response_hook], span, response) unless config[:response_hook].nil?
           end
 
           def allowed_request_headers(env)


### PR DESCRIPTION
Add support for request_hook and response_hook that allow adding user-customizable attributes to the span. This capability is common across http server instrumentations in other languages (e.g., [FastAPI in Python](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/ff412c6d40837c2332bd93991d207c433076dd22/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py#L54)).