### PR TITLE
feat: Add GraphQL query context based tracing

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -4,6 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+appraise 'graphql-1.13' do
+  gem 'graphql', '~> 1.13.0'
+end
+
 appraise 'graphql-1.11' do
   gem 'graphql', '~> 1.11.0'
 end

--- a/instrumentation/graphql/README.md
+++ b/instrumentation/graphql/README.md
@@ -53,6 +53,27 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+#### GraphQL context configuration
+
+Optionally, GraphQL execution context can include tracing option keys to control tracing behaviour independently per execution.
+
+An option's global configuration must be enabled for the associated context option to be respected. This is supported for `graphql-ruby` version `>= 1.13.13 < 2` or `>= 2.0.9`.
+
+| | Global Enabled | Global Disabled |
+|:---:|:---:|:---:|
+| **Context Unset** | ✅ | ❌ |
+| **Context Enabled** | ✅ | ❌ |
+| **Context Disabled** | ❌ | ❌ |
+
+```ruby
+query = GraphQL::Query.new(MyAppSchema, 'query { foo }')
+
+opentelemetry_context = query.context.namespace(:opentelemetry)
+opentelemetry_context[:enable_platform_field] = true
+opentelemetry_context[:enable_platform_authorized] = true
+opentelemetry_context[:enable_platform_resolve_type] = true
+```
+
 ## Examples
 
 An example of usage can be seen in [`example/graphql.rb`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/graphql/example/graphql.rb).

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -49,14 +49,20 @@ module OpenTelemetry
           end
 
           def platform_field_key(type, field)
+            return unless config[:enable_platform_field]
+
             "#{type.graphql_name}.#{field.graphql_name}"
           end
 
           def platform_authorized_key(type)
+            return unless config[:enable_platform_authorized]
+
             "#{type.graphql_name}.authorized"
           end
 
           def platform_resolve_type_key(type)
+            return unless config[:enable_platform_resolve_type]
+
             "#{type.graphql_name}.resolve_type"
           end
 
@@ -81,26 +87,24 @@ module OpenTelemetry
             attributes
           end
 
-          def cached_platform_key(ctx, key, trace_phase)
+          def cached_platform_key(ctx, key, trace_phase = nil)
             cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
-
             cache.fetch(key) do
-              cache[key] = begin
-                return unless platform_key_enabled?(ctx, TRACE_PHASE_TO_TYPE.fetch(trace_phase))
-
-                yield
-              end
+              cache[key] = if trace_phase.nil?
+                             # Backwards compatibility for graphql-ruby < 1.13.13 and >= 2 < 2.0.9
+                             # Relates to https://github.com/rmosolgo/graphql-ruby/pull/4077
+                             yield
+                           else
+                             ns = ctx.namespace(:opentelemetry)
+                             if ns.empty?
+                               # Execution context not provided so no request specific config to check
+                               yield
+                             else
+                               config_key = TRACE_PHASE_TO_TYPE.fetch(trace_phase)
+                               yield if ns.fetch(config_key, true)
+                             end
+                           end
             end
-          end
-
-          def platform_key_enabled?(ctx, key)
-            return false unless config[key]
-
-            ns = ctx.namespace(:opentelemetry)
-            return true if ns.empty? # restores original behavior so that keys are returned if tracing is not set in context.
-            return false unless ns.key?(key) && ns[key]
-
-            true
           end
         end
       end

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'graphql', '~> 1.11'
+  spec.add_development_dependency 'graphql', '~> 1.13.15'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'


### PR DESCRIPTION
`opentelemetry-instrumentation-graphql` provides a `GraphQLTracer` ([source](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/37696bd2c5c8c58c072937e69834b562bf2c42a5/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb)) based on `GraphQL::Tracing::PlatformTracing` ([source](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/tracing/platform_tracing.rb)). This includes [several schema level configuration options](https://github.com/open-telemetry/opentelemetry-ruby/blob/opentelemetry-instrumentation-graphql/v0.19.2/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb#L38-L40) that can enable/disable specific parts of tracing.

The current options are global, but we could benefit from also having per request configuration. For example, a HTTP header may request verbose traces be recorded, ideally enabling `enable_platform_field` for only this request’s GraphQL execution. This way a client can be permitted to opt into tracing, without having to enable it for all requests.

To make this possible, the GraphQL execution context seemed like an ideal place to have this request specific configuration. Access to context is now possible as of graphql-ruby 1.13.13 and 2.0.9 (see [changelog](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md), added in [#4077](https://github.com/rmosolgo/graphql-ruby/pull/4077)), meaning we have this option going forward, but potentially need to remain backwards compatible.

In `cached_platform_key`, the newer versions of graphql-ruby have both `context` and `trace_phase`, so we can determine which setting to check and which of `platform_field_key`, `platform_authorized_key`, `platform_resolve_type_key` would be called on a cache miss.

If we were to release a new version of `opentelemetry-instrumentation-graphql`, how should we handle checking the version of graphql-ruby, either being backwards compatible or having a minimum version?

The [CI failures](https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/2619340318) have come up since `cached_patform_key` now expects 3 arguments (`trace_phase` being the new one) in newer versions of graphql-ruby.

cc @ravangen