### PR TITLE
Run rubocop against ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.1"
+          rubocop: true
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
@@ -42,7 +43,6 @@ jobs:
           gem: "${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
-          rubocop: true
           build: true
       - name: "Test JRuby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
@@ -77,6 +77,7 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.1"
+          rubocop: true
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
@@ -90,7 +91,6 @@ jobs:
           gem: "${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
-          rubocop: true
           build: true
       - name: "Test JRuby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
@@ -160,6 +160,7 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.1"
+          rubocop: true
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
@@ -173,7 +174,6 @@ jobs:
           gem: "${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
-          rubocop: true
           build: true
       - name: "JRuby Filter"
         id: jruby_skip
@@ -250,6 +250,7 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.1"
+          rubocop: true
       - name: "Test Ruby 3.0"
         uses: ./.github/actions/test_gem
         with:
@@ -261,7 +262,6 @@ jobs:
           gem: "${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
-          rubocop: true
           build: true
       - name: "JRuby Filter"
         id: jruby_skip

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/.rubocop-examples.yml
+++ b/instrumentation/.rubocop-examples.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
   Max: 18
   Exclude:
     - "**/test/**/*"
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'pry'
 require 'minitest/autorun'
 require 'rack/test'
 
-require 'test_helpers/app_config.rb'
+require 'test_helpers/app_config'
 require_relative '../lib/opentelemetry/instrumentation'
 
 # Global opentelemetry-sdk setup

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -42,12 +42,13 @@ end
 class PositionalOnlyArgsJob < ::ActiveJob::Base
   def perform(arg1, arg2 = 'default'); end
 end
+
 class KeywordOnlyArgsJob < ::ActiveJob::Base
-  def perform(keyword1: 'default', keyword2:); end
+  def perform(keyword2:, keyword1: 'default'); end
 end
 
 class MixedArgsJob < ::ActiveJob::Base
-  def perform(arg1, arg2, keyword1: 'default', keyword2:); end
+  def perform(arg1, arg2, keyword2:, keyword1: 'default'); end
 end
 
 class CallbacksJob < TestJob

--- a/instrumentation/active_model_serializers/example/active_model_serializers.rb
+++ b/instrumentation/active_model_serializers/example/active_model_serializers.rb
@@ -13,11 +13,11 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::ActiveModelSerializers'
 end
 
-class TestModel < ActiveModelSerializers::Model #:nodoc:
+class TestModel < ActiveModelSerializers::Model # :nodoc:
   attr_accessor :name
 end
 
-class TestModelSerializer < ActiveModel::Serializer #:nodoc:
+class TestModelSerializer < ActiveModel::Serializer # :nodoc:
   attributes :name
 end
 

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_record/example/trace_demonstration.rb
+++ b/instrumentation/active_record/example/trace_demonstration.rb
@@ -25,7 +25,7 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.logger = Logger.new($stdout)
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
   end

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
@@ -108,9 +108,10 @@ module OpenTelemetry
 
         # We'll accept symbols as values, but stringify them; and we'll stringify symbols within an array.
         def sanitized_value(value)
-          if value.is_a?(Array)
+          case value
+          when Array
             value.map { |v| v.is_a?(Symbol) ? v.to_s : v }
-          elsif value.is_a?(Symbol)
+          when Symbol
             value.to_s
           else
             value

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
@@ -66,7 +66,7 @@ module OpenTelemetry
         end
 
         SEND_MESSAGE_CLIENT_METHODS = [SQS_SEND_MESSAGE, SQS_SEND_MESSAGE_BATCH, SNS_PUBLISH].freeze
-        def inject_context(context, client_method)
+        def inject_context(context, client_method) # rubocop:disable Metrics/AbcSize
           return unless SEND_MESSAGE_CLIENT_METHODS.include? client_method
           return unless instrumentation_config[:inject_messaging_context]
 

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# rubocop:disable Style/BracesAroundHashParameters
-
 require 'test_helper'
 
 describe OpenTelemetry::Instrumentation::AwsSdk do
@@ -250,5 +248,3 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
     end
   end
 end
-
-# rubocop:enable Style/BracesAroundHashParameters

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -72,9 +72,9 @@ module OpenTelemetry
 
         private_constant :NAME_REGEX, :VALIDATORS
 
-        private :new # rubocop:disable Style/AccessModifierDeclarations
+        private :new
 
-        def inherited(subclass)
+        def inherited(subclass) # rubocop:disable Lint/MissingSuper
           OpenTelemetry::Instrumentation.registry.register(subclass)
         end
 
@@ -321,7 +321,7 @@ module OpenTelemetry
         ENV[var_name] != 'false'
       end
 
-      def config_overrides_from_env
+      def config_overrides_from_env # rubocop:disable Metrics/AbcSize
         var_name = name.dup.tap do |n|
           n.upcase!
           n.gsub!('::', '_')

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/base/test/.rubocop.yml
+++ b/instrumentation/base/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false

--- a/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
+++ b/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/channel_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/channel_test.rb
@@ -14,8 +14,8 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Channel do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Bunny::Instrumentation.instance }
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
-  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST') { 'localhost' } }
-  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT') { '5672' } }
+  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST', 'localhost') }
+  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT', '5672') }
   let(:url) { ENV.fetch('TEST_RABBITMQ_URL') { "amqp://guest:guest@#{host}:#{port}" } }
   let(:bunny) { Bunny.new(url) }
   let(:topic) { "topic-#{SecureRandom.uuid}" }

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
@@ -14,8 +14,8 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Consumer do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Bunny::Instrumentation.instance }
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
-  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST') { 'localhost' } }
-  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT') { '5672' } }
+  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST', 'localhost') }
+  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT', '5672') }
   let(:url) { ENV.fetch('TEST_RABBITMQ_URL') { "amqp://guest:guest@#{host}:#{port}" } }
   let(:bunny) { Bunny.new(url) }
   let(:topic) { "topic-#{SecureRandom.uuid}" }

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
@@ -15,8 +15,8 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Queue do
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
 
-  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST') { 'localhost' } }
-  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT') { '5672' } }
+  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST', 'localhost') }
+  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT', '5672') }
   let(:url) { ENV.fetch('TEST_RABBITMQ_URL') { "amqp://guest:guest@#{host}:#{port}" } }
   let(:bunny) { Bunny.new(url) }
   let(:topic) { "topic-#{SecureRandom.uuid}" }

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/dalli/.rubocop.yml
+++ b/instrumentation/dalli/.rubocop.yml
@@ -3,5 +3,9 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-dalli.rb"
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Metrics/AbcSize:
   Enabled: false

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -13,8 +13,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Dalli::Instrumentation.instance }
   let(:exporter) { EXPORTER }
   let(:span) { exporter.finished_spans.first }
-  let(:host) { ENV.fetch('TEST_MEMCACHED_HOST') { '127.0.0.1' } }
-  let(:port) { (ENV.fetch('TEST_MEMCACHED_PORT') { 11_211 }).to_i }
+  let(:host) { ENV.fetch('TEST_MEMCACHED_HOST', '127.0.0.1') }
+  let(:port) { ENV.fetch('TEST_MEMCACHED_PORT', 11_211).to_i }
   let(:dalli) { ::Dalli::Client.new("#{host}:#{port}", {}) }
 
   before do

--- a/instrumentation/delayed_job/.rubocop.yml
+++ b/instrumentation/delayed_job/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: ../.rubocop-examples.yml
 
+Metrics/AbcSize:
+  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-delayed_job.rb"

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# rubocop:disable Style/BracesAroundHashParameters
-
 require_relative '../../test_helper'
 
 describe OpenTelemetry::Instrumentation::DelayedJob do
@@ -77,5 +75,3 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
     end
   end
 end
-
-# rubocop:enable Style/BracesAroundHashParameters

--- a/instrumentation/ethon/.rubocop.yml
+++ b/instrumentation/ethon/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: ../.rubocop-examples.yml
 
+Metrics/AbcSize:
+  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-ethon.rb"

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -63,7 +63,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
         it 'creates a span' do
           ::Ethon::Curl.stub(:easy_perform, 0) do
-            # Note: suppress call to #complete to isolate #perform functionality
+            # NOTE: suppress call to #complete to isolate #perform functionality
             easy.stub(:complete, nil) do
               easy.perform
 
@@ -80,7 +80,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
         def stub_response(options)
           easy.stub(:mirror, ::Ethon::Easy::Mirror.new(options)) do
             easy.otel_before_request
-            # Note: perform calls complete
+            # NOTE: perform calls complete
             easy.complete
 
             yield

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -70,7 +70,7 @@ module OpenTelemetry
 
           private
 
-          def handle_response(datum) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity:
+          def handle_response(datum) # rubocop:disable Metrics/AbcSize, :
             if datum.key?(:otel_span)
               datum[:otel_span].tap do |span|
                 return span if span.end_timestamp

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/graphql/.rubocop.yml
+++ b/instrumentation/graphql/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-graphql.rb"
+Lint/ConstantDefinitionInBlock:
+  Enabled: false

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -24,7 +24,7 @@ module OpenTelemetry
             'execute_multiplex' => 'graphql.execute_multiplex'
           }
 
-          def platform_trace(platform_key, key, data)
+          def platform_trace(platform_key, key, data) # rubocop:disable Metrics/CyclomaticComplexity
             return yield if platform_key.nil?
 
             tracer.in_span(platform_key, attributes: attributes_for(key, data)) do |span|

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/mongo/.rubocop.yml
+++ b/instrumentation/mongo/.rubocop.yml
@@ -1,5 +1,14 @@
-inherit_from: ../.rubocop-examples.yml
+inherit_from:
+  - ../.rubocop-examples.yml
 
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-mongo.rb"
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Exclude:
+    - 'lib/opentelemetry/instrumentation/mongo/command_serializer.rb'
+Style/HashTransformValues:
+  Exclude:
+    - 'lib/opentelemetry/instrumentation/mongo/command_serializer.rb'

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/mysql2/.rubocop.yml
+++ b/instrumentation/mysql2/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-mysql2.rb"
+Style/RedundantRegexpEscape:
+  Enabled: false

--- a/instrumentation/mysql2/example/mysql2.rb
+++ b/instrumentation/mysql2/example/mysql2.rb
@@ -11,11 +11,11 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 client = Mysql2::Client.new(
-  host: ENV.fetch('TEST_MYSQL_HOST') { '127.0.0.1' },
-  port: ENV.fetch('TEST_MYSQL_PORT') { '3306' },
-  database: ENV.fetch('TEST_MYSQL_DB') { 'mysql' },
-  username: ENV.fetch('TEST_MYSQL_USER') { 'root' },
-  password: ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' }
+  host: ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1'),
+  port: ENV.fetch('TEST_MYSQL_PORT', '3306'),
+  database: ENV.fetch('TEST_MYSQL_DB', 'mysql'),
+  username: ENV.fetch('TEST_MYSQL_USER', 'root'),
+  password: ENV.fetch('TEST_MYSQL_PASSWORD', 'root')
 )
 
 client.query("SELECT * FROM users WHERE group='x'")

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -44,11 +44,11 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       )
     end
 
-    let(:host) { ENV.fetch('TEST_MYSQL_HOST') { '127.0.0.1' } }
-    let(:port) { ENV.fetch('TEST_MYSQL_PORT') { '3306' } }
-    let(:database) { ENV.fetch('TEST_MYSQL_DB') { 'mysql' } }
-    let(:username) { ENV.fetch('TEST_MYSQL_USER') { 'root' } }
-    let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' } }
+    let(:host) { ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1') }
+    let(:port) { ENV.fetch('TEST_MYSQL_PORT', '3306') }
+    let(:database) { ENV.fetch('TEST_MYSQL_DB', 'mysql') }
+    let(:username) { ENV.fetch('TEST_MYSQL_USER', 'root') }
+    let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD', 'root') }
 
     before do
       instrumentation.install(config)

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.0.1'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.11.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/pg/.rubocop.yml
+++ b/instrumentation/pg/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-pg.rb"
+Style/RedundantRegexpEscape:
+  Enabled: false

--- a/instrumentation/pg/example/pg.rb
+++ b/instrumentation/pg/example/pg.rb
@@ -11,11 +11,11 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 conn = PG::Connection.open(
-  host: ENV.fetch('TEST_POSTGRES_HOST') { '127.0.0.1' },
-  port: ENV.fetch('TEST_POSTGRES_PORT') { '5432' },
-  user: ENV.fetch('TEST_POSTGRES_USER') { 'postgres' },
-  dbname: ENV.fetch('TEST_POSTGRES_DB') { 'postgres' },
-  password: ENV.fetch('TEST_POSTGRES_PASSWORD') { 'postgres' }
+  host: ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1'),
+  port: ENV.fetch('TEST_POSTGRES_PORT', '5432'),
+  user: ENV.fetch('TEST_POSTGRES_USER', 'postgres'),
+  dbname: ENV.fetch('TEST_POSTGRES_DB', 'postgres'),
+  password: ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres')
 )
 
 # Spans will be printed to your terminal when this statement executes:

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg', '>= 1.1.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -46,11 +46,11 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       )
     end
 
-    let(:host) { ENV.fetch('TEST_POSTGRES_HOST') { '127.0.0.1' } }
-    let(:port) { ENV.fetch('TEST_POSTGRES_PORT') { '5432' } }
-    let(:user) { ENV.fetch('TEST_POSTGRES_USER') { 'postgres' } }
-    let(:dbname) { ENV.fetch('TEST_POSTGRES_DB') { 'postgres' } }
-    let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD') { 'postgres' } }
+    let(:host) { ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1') }
+    let(:port) { ENV.fetch('TEST_POSTGRES_PORT', '5432') }
+    let(:user) { ENV.fetch('TEST_POSTGRES_USER', 'postgres') }
+    let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
+    let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
 
     before do
       instrumentation.install(config)

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg', '~> 1.1'
   spec.add_development_dependency 'que', '~> 1.0.0.beta4'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/rack/.rubocop.yml
+++ b/instrumentation/rack/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-rack.rb"
+Lint/ConstantDefinitionInBlock:
+  Enabled: false

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 2.0.8'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -131,7 +131,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
     describe 'config[:untraced_requests]' do
       describe 'when a callable is passed in' do
         let(:untraced_callable) do
-          ->(env) { env['PATH_INFO'] =~ %r{^\/assets} }
+          ->(env) { env['PATH_INFO'] =~ %r{^/assets} }
         end
         let(:config) { default_config.merge(untraced_requests: untraced_callable) }
 

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -12,7 +12,7 @@ require 'opentelemetry-test-helpers'
 require 'pry'
 require 'minitest/autorun'
 require 'rack/test'
-require 'test_helpers/app_config.rb'
+require 'test_helpers/app_config'
 
 require_relative '../../lib/opentelemetry/instrumentation'
 

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rdkafka'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'redis', '~> 4.1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'resque'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rest-client', '~> 2.1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
+++ b/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'ruby-kafka'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'sidekiq', '~> 5.2.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sinatra', '~> 2.0.7'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'trilogy', '>= 2.0', '< 3.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
+++ b/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/propagator/xray/opentelemetry-propagator-xray.gemspec
+++ b/propagator/xray/opentelemetry-propagator-xray.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'


### PR DESCRIPTION
We currently run Rubocop against Ruby 2.7 in CI. We do not run it against any other versions. I think we should run against Ruby 3.1 for the following reasons:

- I suspect most folks developing locally will be running the latest Ruby (3.1), and will run Rubocop against that. We should have CI match that workflow.
- Ruby is at version 3.1, so we should default to running our static analysis against that version.