### PR TITLE
ci: run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'releases/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
We noticed when attempting to release a gem from this repo that the workflow to create release PRs [did not have the CI workflow run](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/91/checks) on them. This ought to make CI run on release branches in this repo.