### PR TITLE
ci: release is not plural in release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
+      - 'release/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Followup to #92, turns out "release" in release branch names is not plural. 