### PR TITLE
chore: promote Robb Kidd to Approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam
+* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ requests.
 The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 [community page][ruby-sig] repo for information on this and other language SIGs.
 
+Approvers ([@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-approvers)):
+
+- [Robb Kidd](https://github.com/robbkidd), Honeycomb
+
+*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
+
 Maintainers ([@open-telemetry/ruby-maintainers](https://github.com/orgs/open-telemetry/teams/ruby-maintainers)):
 
 - [Ariel Valentin](https://github.com/arielvalentin), GitHub

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Approvers ([@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 
-Maintainers ([@open-telemetry/ruby-maintainers](https://github.com/orgs/open-telemetry/teams/ruby-maintainers)):
+Maintainers ([@open-telemetry/ruby-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-maintainers)):
 
 - [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Daniel Azuma](https://github.com/dazuma), Google


### PR DESCRIPTION
Follow-up to [the conversation in CNCF Slack #otel-ruby](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1657664615160479) and [the comment](https://github.com/open-telemetry/opentelemetry-ruby/pull/1342#pullrequestreview-1039111788) on the similar PR on otel-ruby itself.

If approved, TODO outside this PR before merge:
- [x] Write access granted to @robbkidd (or added as member of [@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-approvers))