### PR TITLE
fix: bring http.request.header and http.response.header in line with …

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -21,17 +21,17 @@ module OpenTelemetry
                 key = header.to_s.upcase.gsub(/[-\s]/, '_')
                 case key
                 when 'CONTENT_TYPE', 'CONTENT_LENGTH'
-                  memo[key] = build_attribute_name('http.request.headers.', header)
+                  memo[key] = build_attribute_name('http.request.header.', header)
                 else
-                  memo["HTTP_#{key}"] = build_attribute_name('http.request.headers.', header)
+                  memo["HTTP_#{key}"] = build_attribute_name('http.request.header.', header)
                 end
               end
             end
 
             def allowed_response_headers
               @allowed_response_headers ||= Array(config[:allowed_response_headers]).each_with_object({}) do |header, memo|
-                memo[header] = build_attribute_name('http.response.headers.', header)
-                memo[header.to_s.upcase] = build_attribute_name('http.response.headers.', header)
+                memo[header] = build_attribute_name('http.response.header.', header)
+                memo[header.to_s.upcase] = build_attribute_name('http.response.header.', header)
               end
             end
 

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -171,14 +171,14 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       end
 
       it 'defaults to nil' do
-        _(first_span.attributes['http.request.headers.foo_bar']).must_be_nil
+        _(first_span.attributes['http.request.header.foo_bar']).must_be_nil
       end
 
       describe 'when configured' do
         let(:config) { default_config.merge(allowed_request_headers: ['foo_BAR']) }
 
         it 'returns attribute' do
-          _(first_span.attributes['http.request.headers.foo_bar']).must_equal 'http foo bar value'
+          _(first_span.attributes['http.request.header.foo_bar']).must_equal 'http foo bar value'
         end
       end
 
@@ -186,7 +186,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
         let(:config) { default_config.merge(allowed_request_headers: ['CONTENT_TYPE']) }
 
         it 'returns attribute' do
-          _(first_span.attributes['http.request.headers.content_type']).must_equal 'application/json'
+          _(first_span.attributes['http.request.header.content_type']).must_equal 'application/json'
         end
       end
 
@@ -194,7 +194,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
         let(:config) { default_config.merge(allowed_request_headers: ['CONTENT_LENGTH']) }
 
         it 'returns attribute' do
-          _(first_span.attributes['http.request.headers.content_length']).must_equal '123'
+          _(first_span.attributes['http.request.header.content_length']).must_equal '123'
         end
       end
     end
@@ -205,21 +205,21 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       end
 
       it 'defaults to nil' do
-        _(first_span.attributes['http.response.headers.foo_bar']).must_be_nil
+        _(first_span.attributes['http.response.header.foo_bar']).must_be_nil
       end
 
       describe 'when configured' do
         let(:config) { default_config.merge(allowed_response_headers: ['Foo-Bar']) }
 
         it 'returns attribute' do
-          _(first_span.attributes['http.response.headers.foo_bar']).must_equal 'foo bar response header'
+          _(first_span.attributes['http.response.header.foo_bar']).must_equal 'foo bar response header'
         end
 
         describe 'case-sensitively' do
           let(:config) { default_config.merge(allowed_response_headers: ['fOO-bAR']) }
 
           it 'returns attribute' do
-            _(first_span.attributes['http.response.headers.foo_bar']).must_equal 'foo bar response header'
+            _(first_span.attributes['http.response.header.foo_bar']).must_equal 'foo bar response header'
           end
         end
       end


### PR DESCRIPTION
…semantic conventions.

Fixes: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/110