### PR TITLE
Ensures the correct route is add to http.route span attribute

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -27,11 +27,11 @@ module OpenTelemetry
             private
 
             def add_rails_route(rack_span, request)
-              matching_routes = []
               ::Rails.application.routes.router.recognize(request) do |route, _params|
-                matching_routes << route.path.spec.to_s
+                rack_span.set_attribute('http.route', route.path.spec.to_s)
+                # Rails will match on the first route - see https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions
+                break
               end
-              rack_span.set_attribute('http.route', matching_routes.max_by(&:length))
             end
 
             def instrumentation_config

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -27,9 +27,11 @@ module OpenTelemetry
             private
 
             def add_rails_route(rack_span, request)
+              matching_routes = []
               ::Rails.application.routes.router.recognize(request) do |route, _params|
-                rack_span.set_attribute('http.route', route.path.spec.to_s)
+                matching_routes << route.path.spec.to_s
               end
+              rack_span.set_attribute('http.route', matching_routes.max_by(&:length))
             end
 
             def instrumentation_config

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
@@ -79,10 +79,10 @@ describe OpenTelemetry::Instrumentation::ActionPack::Patches::ActionController::
     end
 
     it 'sets the span name to ControllerName#action' do
-      get '/ok'
-      _(last_response.body).must_equal 'actually ok'
+      get '/items/new'
+      _(last_response.body).must_equal 'created new item'
       _(last_response.ok?).must_equal true
-      _(span.name).must_equal 'ExampleController#ok'
+      _(span.name).must_equal 'ExampleController#new_item'
       _(span.kind).must_equal :server
       _(span.status.ok?).must_equal true
 
@@ -92,10 +92,10 @@ describe OpenTelemetry::Instrumentation::ActionPack::Patches::ActionController::
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.host']).must_equal 'example.org'
       _(span.attributes['http.scheme']).must_equal 'http'
-      _(span.attributes['http.target']).must_equal '/ok'
+      _(span.attributes['http.target']).must_equal '/items/new'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.user_agent']).must_be_nil
-      _(span.attributes['http.route']).must_equal '/ok(.:format)'
+      _(span.attributes['http.route']).must_equal '/items/new(.:format)'
     end
   end
 

--- a/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
+++ b/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
@@ -11,6 +11,14 @@ class ExampleController < ActionController::Base
     render plain: 'actually ok'
   end
 
+  def item
+    render plain: "this is item #{params[:id]}"
+  end
+
+  def new_item
+    render plain: 'created new item'
+  end
+
   def internal_server_error
     raise :internal_server_error
   end

--- a/instrumentation/action_pack/test/test_helpers/routes.rb
+++ b/instrumentation/action_pack/test/test_helpers/routes.rb
@@ -7,6 +7,8 @@
 def draw_routes(rails_app)
   rails_app.routes.draw do
     get '/ok', to: 'example#ok'
+    get '/items/new', to: 'example#new_item'
+    get '/items/:id', to: 'example#item'
     get '/internal_server_error', to: 'example#internal_server_error'
   end
 end


### PR DESCRIPTION
The current implementation for the `enable_recognize_route` option will add the last of all matching routes to the `http.route` span attribute. In our experience, this has not been the correct route and we see all traces with a `http.route` of `/`. This fix sets the value based the longest match, rather than the last, which is working for us.

Update: To clarify the routing scenario this fix addresses, we have mounted rails engines on `/` and from further testing in our app it's _these_ routes that are being matched and turning up last in the order of matched routes and results in an incorrect value for `http.route`.