### PR TITLE
feat: support mongodb db statement without obfuscation

### DIFF
--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -35,10 +35,10 @@ end
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Mongo', {
-    # The obfuscation of arguments in the db.statement attribute is enabled by default.
-    # To include the full query, set db_statement to :include.
-    # To obfuscate, set db_statement to :obfuscate.
-    # To omit the attribute, set db_statement to :omit.
+    # Sets how db_statement appears in your traces. The options are:
+    # :obfuscate - (default) query parameters are visible, but values are masked.
+    # :include - query parameters and values are both fully visible.
+    # :omit - db_statement is omitted entirely.
     db_statement: :include,
   }
 end

--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -30,6 +30,20 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Mongo', {
+    # The obfuscation of arguments in the db.statement attribute is enabled by default.
+    # To include the full query, set db_statement to :include.
+    # To obfuscate, set db_statement to :obfuscate.
+    # To omit the attribute, set db_statement to :omit.
+    db_statement: :include,
+  }
+end
+```
+
 ## Example
 
 To run the example:

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/command_serializer.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/command_serializer.rb
@@ -18,7 +18,6 @@ module OpenTelemetry
           @command = command
           @command_name, @collection = command.first
           @obfuscate = obfuscate
-          @collection = MASK_VALUE if @obfuscate && !(@collection.is_a?(String) || @collection.is_a?(Integer))
           @payload = {}
         end
 

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: %I[omit include]
+        option :db_statement, default: :obfuscate, validate: %I[omit obfuscate include]
 
         private
 

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/subscriber.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/subscriber.rb
@@ -33,7 +33,9 @@ module OpenTelemetry
           config = Mongo::Instrumentation.instance.config
           attributes['peer.service'] = config[:peer_service] if config[:peer_service]
           # attributes['db.statement'] = CommandSerializer.new(event.command).serialize
-          attributes['db.statement'] = CommandSerializer.new(event.command).serialize if config[:db_statement] == :include
+          omit = config[:db_statement] == :omit
+          obfuscate = config[:db_statement] == :obfuscate
+          attributes['db.statement'] = CommandSerializer.new(event.command, obfuscate).serialize unless omit
           attributes['db.mongodb.collection'] = collection if collection
           attributes.compact!
 

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -300,7 +300,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
     end
   end
 
-  describe 'db_statement option' do
+  describe 'db_statement omit option' do
     let(:collection) { :people }
     let(:config) { { db_statement: :omit } }
 
@@ -319,6 +319,28 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       _(span.attributes['db.operation']).must_equal 'find'
       _(span.attributes['db.mongodb.collection']).must_equal 'people'
       _(span.attributes).wont_include 'db.statement'
+    end
+  end
+
+  describe 'db_statement include option' do
+    let(:collection) { :people }
+    let(:config) { { db_statement: :include } }
+
+    before do
+      # insert a document
+      client[collection].insert_one(name: 'Steve', hobbies: ['hiking'])
+      exporter.reset
+
+      # do #find operation
+      result = client[collection].find(name: 'Steve').first[:hobbies]
+      _(result).must_equal ['hiking']
+    end
+
+    it 'obfuscates db.statement attribute' do
+      _(span.name).must_equal 'people.find'
+      _(span.attributes['db.operation']).must_equal 'find'
+      _(span.attributes['db.mongodb.collection']).must_equal 'people'
+      _(span.attributes['db.statement']).must_equal '{"filter":{"name":"Steve"}}'
     end
   end
 


### PR DESCRIPTION
Other Ruby instrumentation (e.g. Redis) support three db statement modes: omit, include and obfuscate. Currently, the include mode behaves like obfuscate. The change isn't backwards compatible (in case someone explicitly used "include"), but it's consistent with other instrumentations. Also, the current state is misleading as I'd expect "include" not to do anything with the statement