### PR TITLE
redis-rb 5.0 and redis-client support

### DIFF
--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
         end
 
         present do
-          defined?(::Redis)
+          defined?(::Redis) || defined?(::RedisClient)
         end
 
         option :peer_service,                 default: nil,   validate: :string
@@ -26,11 +26,13 @@ module OpenTelemetry
         private
 
         def require_dependencies
-          require_relative 'patches/client'
+          require_relative 'patches/redis_v4_client' if defined?(::Redis) && ::Redis::VERSION < '5'
+          require_relative 'middlewares/redis_client' if defined?(::RedisClient)
         end
 
         def patch_client
-          ::Redis::Client.prepend(Patches::Client)
+          ::RedisClient.register(Middlewares::RedisClientInstrumentation) if defined?(::RedisClient)
+          ::Redis::Client.prepend(Patches::RedisV4Client) if defined?(::Redis) && ::Redis::VERSION < '5'
         end
       end
     end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/middlewares/redis_client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/middlewares/redis_client.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module Redis
+      module Middlewares
+        # Adapter for redis-client instrumentation interface
+        module RedisClientInstrumentation
+          MAX_STATEMENT_LENGTH = 500
+          private_constant :MAX_STATEMENT_LENGTH
+
+          def call(command, redis_config)
+            return super unless instrumentation.config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
+
+            attributes = span_attributes(redis_config)
+
+            attributes['db.statement'] = serialize_commands([command]) unless instrumentation.config[:db_statement] == :omit
+
+            span_name = command[0].to_s.upcase
+            instrumentation.tracer.in_span(span_name, attributes: attributes, kind: :client) do
+              super
+            end
+          end
+
+          def call_pipelined(commands, redis_config)
+            return super unless instrumentation.config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
+
+            attributes = span_attributes(redis_config)
+
+            attributes['db.statement'] = serialize_commands(commands) unless instrumentation.config[:db_statement] == :omit
+
+            instrumentation.tracer.in_span('PIPELINED', attributes: attributes, kind: :client) do
+              super
+            end
+          end
+
+          private
+
+          def span_attributes(redis_config)
+            attributes = {
+              'db.system' => 'redis',
+              'net.peer.name' => redis_config.host,
+              'net.peer.port' => redis_config.port
+            }
+
+            attributes['db.redis.database_index'] = redis_config.db unless redis_config.db.zero?
+            attributes['peer.service'] = instrumentation.config[:peer_service] if instrumentation.config[:peer_service]
+            attributes.merge!(OpenTelemetry::Instrumentation::Redis.attributes)
+            attributes
+          end
+
+          def serialize_commands(commands)
+            obfuscate = instrumentation.config[:db_statement] == :obfuscate
+
+            serialized_commands = commands.map do |command|
+              # If we receive an authentication request command we want to obfuscate it
+              if obfuscate || command[0].match?(/\A(AUTH|HELLO)\z/)
+                command[0].to_s.upcase + ' ?' * (command.size - 1)
+              else
+                command_copy = command.dup
+                command_copy[0] = command_copy[0].to_s.upcase
+                command_copy.join(' ')
+              end
+            end.join("\n")
+            serialized_commands = OpenTelemetry::Common::Utilities.truncate(serialized_commands, MAX_STATEMENT_LENGTH)
+            OpenTelemetry::Common::Utilities.utf8_encode(serialized_commands, binary: true)
+          end
+
+          def instrumentation
+            Redis::Instrumentation.instance
+          end
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/redis_v4_client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/redis_v4_client.rb
@@ -9,12 +9,12 @@ module OpenTelemetry
     module Redis
       module Patches
         # Module to prepend to Redis::Client for instrumentation
-        module Client
+        module RedisV4Client
           MAX_STATEMENT_LENGTH = 500
           private_constant :MAX_STATEMENT_LENGTH
 
           def process(commands) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-            return super unless config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
+            return super unless instrumentation_config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
 
             host = options[:host]
             port = options[:port]
@@ -26,10 +26,10 @@ module OpenTelemetry
             }
 
             attributes['db.redis.database_index'] = options[:db] unless options[:db].zero?
-            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+            attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
             attributes.merge!(OpenTelemetry::Instrumentation::Redis.attributes)
 
-            unless config[:db_statement] == :omit
+            unless instrumentation_config[:db_statement] == :omit
               parsed_commands = parse_commands(commands)
               parsed_commands = OpenTelemetry::Common::Utilities.truncate(parsed_commands, MAX_STATEMENT_LENGTH)
               parsed_commands = OpenTelemetry::Common::Utilities.utf8_encode(parsed_commands, binary: true)
@@ -42,7 +42,7 @@ module OpenTelemetry
                           'PIPELINED'
                         end
 
-            tracer.in_span(span_name, attributes: attributes, kind: :client) do |s|
+            instrumentation_tracer.in_span(span_name, attributes: attributes, kind: :client) do |s|
               super(commands).tap do |reply|
                 if reply.is_a?(::Redis::CommandError)
                   s.record_exception(reply)
@@ -71,7 +71,7 @@ module OpenTelemetry
               # and return the obfuscated command
               return 'AUTH ?' if command[0] == :auth
 
-              if config[:db_statement] == :obfuscate
+              if instrumentation_config[:db_statement] == :obfuscate
                 command[0].to_s.upcase + ' ?' * (command.size - 1)
               else
                 command_copy = command.dup
@@ -81,11 +81,11 @@ module OpenTelemetry
             end.join("\n")
           end
 
-          def tracer
+          def instrumentation_tracer
             Redis::Instrumentation.instance.tracer
           end
 
-          def config
+          def instrumentation_config
             Redis::Instrumentation.instance.config
           end
         end

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'redis', '~> 4.1.0'
+  spec.add_development_dependency 'redis-client', '~> 0.7'
   spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -7,7 +7,7 @@
 require 'test_helper'
 
 require_relative '../../../../lib/opentelemetry/instrumentation/redis'
-require_relative '../../../../lib/opentelemetry/instrumentation/redis/patches/client'
+require_relative '../../../../lib/opentelemetry/instrumentation/redis/patches/redis_v4_client'
 
 describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Redis::Instrumentation.instance }

--- a/instrumentation/redis/test/test_helper.rb
+++ b/instrumentation/redis/test/test_helper.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'redis'
+require 'redis-client'
 
 require 'opentelemetry/sdk'
 require 'opentelemetry-test-helpers'


### PR DESCRIPTION
redis-rb 5.0 ditched its internal client and now simply delegate to the `redis-client` gem.

@fbogsany @robertlaurin 