### PR TITLE
feat: add public_endpoint option to rack middleware

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -30,6 +30,7 @@ module OpenTelemetry
         option :untraced_endpoints,       default: [],    validate: :array
         option :url_quantization,         default: nil,   validate: :callable
         option :untraced_requests,        default: nil,   validate: :callable
+        option :public_endpoint,          default: nil,   validate: :callable
 
         private
 


### PR DESCRIPTION
Public endpoints may receive requests that include an external `traceparent` header, making the SDK believe there is a parent span, when that span will never be found in the system, since it was emitted by whatever client made the request.

Example: A public API, where the client is using tracing as well, and therefore sends trace headers with every request.

This fix proposal is similar to what the [Go SDK is doing](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/61ea3c1c30be3f63628aa72c02f9570c9ed11b85/instrumentation/net/http/otelhttp/handler.go#L132-L138).

It introduces a new `public_endpoint` option for the rack instrumentation, which is a lambda that takes two arguments: `env` from rack, and the context we just computed.

In our case for example, we inject some specific key/value to tracestate to identify that a request is coming from our internal systems.