### PR TITLE
fix: Windows Ruby 3.1 Native Extensions Installs

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -9,21 +9,21 @@ inputs:
     description: Ruby version to use
     required: true
     type: string
-  yard:
-    description: Run YARD documentation
-    required: false
-    type: boolean
-    default: false
-  rubocop:
-    description: Run Rubocop
-    required: false
-    type: boolean
-    default: false
-  build:
-    description: Build gem
-    required: false
-    type: boolean
-    default: false
+  # yard:
+  #   description: Run YARD documentation
+  #   required: false
+  #   type: boolean
+  #   default: false
+  # rubocop:
+  #   description: Run Rubocop
+  #   required: false
+  #   type: boolean
+  #   default: false
+  # build:
+  #   description: Build gem
+  #   required: false
+  #   type: boolean
+  #   default: false
 
 runs:
   using: composite
@@ -62,8 +62,8 @@ runs:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.dir }}"
         bundler: "latest"
-        bundler-cache: true
-        cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
+        # bundler-cache: true
+        # cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
@@ -77,6 +77,7 @@ runs:
       shell: bash
       run: |
         cd "${{ steps.setup.outputs.dir }}"
+        ruby -e 'puts "Windows Gem Platform #{Gem::Platform.local.to_s}"'
         bundle install
         bundle exec appraisal install
 
@@ -112,23 +113,23 @@ runs:
         TEST_REDIS_HOST: localhost
         TEST_REDIS_PORT: 6379
 
-    - name: YARD
-      shell: bash
-      if: "${{ inputs.yard == 'true' }}"
-      run: |
-        cd "${{ steps.setup.outputs.dir }}"
-        bundle exec rake yard
+    # - name: YARD
+    #   shell: bash
+    #   if: "${{ inputs.yard == 'true' }}"
+    #   run: |
+    #     cd "${{ steps.setup.outputs.dir }}"
+    #     bundle exec rake yard
 
-    - name: Rubocop
-      shell: bash
-      if: "${{ inputs.rubocop == 'true' }}"
-      run: |
-        cd "${{ steps.setup.outputs.dir }}"
-        bundle exec rake rubocop
+    # - name: Rubocop
+    #   shell: bash
+    #   if: "${{ inputs.rubocop == 'true' }}"
+    #   run: |
+    #     cd "${{ steps.setup.outputs.dir }}"
+    #     bundle exec rake rubocop
 
-    - name: Build Gem
-      shell: bash
-      if: "${{ inputs.build == 'true' }}"
-      run: |
-        cd "${{ steps.setup.outputs.dir }}"
-        gem build ${{ inputs.gem }}.gemspec
+    # - name: Build Gem
+    #   shell: bash
+    #   if: "${{ inputs.build == 'true' }}"
+    #   run: |
+    #     cd "${{ steps.setup.outputs.dir }}"
+    #     gem build ${{ inputs.gem }}.gemspec

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -61,6 +61,7 @@ runs:
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.dir }}"
+        bundler: "latest"
         bundler-cache: true
         cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
@@ -70,6 +71,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
+        bundler: "latest"
     - name: Install dependencies and appraisals
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -61,7 +61,7 @@ runs:
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.dir }}"
-        bundler: "latest"
+        bundler: "2.3.22"
         # bundler-cache: true
         # cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
@@ -71,7 +71,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
-        bundler: "latest"
+        bundler: "2.3.22"
     - name: Install dependencies and appraisals
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,17 +140,17 @@ jobs:
           # - ubuntu-latest
           # - macos-latest
           - windows-latest
-        exclude:
-          - os: windows-latest
-            gem: opentelemetry-instrumentation-ethon
-          - os: windows-latest
-            gem: opentelemetry-instrumentation-action_pack
-          - os: windows-latest
-            gem: opentelemetry-instrumentation-restclient
-          - os: windows-latest
-            gem: opentelemetry-instrumentation-rails
-          - os: macos-latest
-            gem: opentelemetry-instrumentation-lmdb
+        # exclude:
+        #   - os: windows-latest
+        #     gem: opentelemetry-instrumentation-ethon
+        #   - os: windows-latest
+        #     gem: opentelemetry-instrumentation-action_pack
+        #   - os: windows-latest
+        #     gem: opentelemetry-instrumentation-restclient
+        #   - os: windows-latest
+        #     gem: opentelemetry-instrumentation-rails
+        #   - os: macos-latest
+        #     gem: opentelemetry-instrumentation-lmdb
 
     name: ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         os:
           # - ubuntu-latest
           # - macos-latest
-          - windows-latest
+          - windows-2019
         # exclude:
         #   - os: windows-latest
         #     gem: opentelemetry-instrumentation-ethon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         os:
           # - ubuntu-latest
           # - macos-latest
-          - windows-2019
+          - windows-latest
         # exclude:
         #   - os: windows-latest
         #     gem: opentelemetry-instrumentation-ethon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,100 +11,100 @@ on:
       - main
 
 jobs:
-  base:
-    strategy:
-      fail-fast: false
-      matrix:
-        gem:
-          - opentelemetry-resource_detectors
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    name: ${{ matrix.gem }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: "Test Ruby 3.1"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.1"
-      - name: "Test Ruby 3.0"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
-          yard: true
-          rubocop: true
-          build: true
-      - name: "Test JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "jruby"
-      - name: "Test truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "truffleruby"
+  # base:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       gem:
+  #         - opentelemetry-resource_detectors
+  #       os:
+  #         - ubuntu-latest
+  #         - macos-latest
+  #         - windows-latest
+  #   name: ${{ matrix.gem }} / ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: "Test Ruby 3.1"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.1"
+  #     - name: "Test Ruby 3.0"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.0"
+  #     - name: "Test Ruby 2.7"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "2.7"
+  #         yard: true
+  #         rubocop: true
+  #         build: true
+  #     - name: "Test JRuby"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "jruby"
+  #     - name: "Test truffleruby"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "truffleruby"
 
-  propagators:
-    strategy:
-      fail-fast: false
-      matrix:
-        gem:
-          - opentelemetry-propagator-ottrace
-          - opentelemetry-propagator-xray
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    name: ${{ matrix.gem }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: "Test Ruby 3.1"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.1"
-      - name: "Test Ruby 3.0"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
-          yard: true
-          rubocop: true
-          build: true
-      - name: "Test JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "jruby"
-      - name: "Test truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "truffleruby"
+  # propagators:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       gem:
+  #         - opentelemetry-propagator-ottrace
+  #         - opentelemetry-propagator-xray
+  #       os:
+  #         - ubuntu-latest
+  #         - macos-latest
+  #         - windows-latest
+  #   name: ${{ matrix.gem }} / ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: "Test Ruby 3.1"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.1"
+  #     - name: "Test Ruby 3.0"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.0"
+  #     - name: "Test Ruby 2.7"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "2.7"
+  #         yard: true
+  #         rubocop: true
+  #         build: true
+  #     - name: "Test JRuby"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "jruby"
+  #     - name: "Test truffleruby"
+  #       if: "${{ matrix.os == 'ubuntu-latest' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "truffleruby"
 
   instrumentation:
     strategy:
@@ -137,8 +137,8 @@ jobs:
           # - opentelemetry-instrumentation-rspec
           # - opentelemetry-instrumentation-sinatra
         os:
-          - ubuntu-latest
-          - macos-latest
+          # - ubuntu-latest
+          # - macos-latest
           - windows-latest
         exclude:
           - os: windows-latest
@@ -176,192 +176,192 @@ jobs:
           yard: true
           rubocop: true
           build: true
-      - name: "JRuby Filter"
-        id: jruby_skip
-        shell: bash
-        run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_model_serializers" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"            ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-aws_sdk"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-graphql"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http_client"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-koala"                    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rack"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"                    ]] && echo "::set-output name=skip::true"
-          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-          true
-      - name: "Test JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' && steps.jruby_skip.outputs.skip == 'false' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "jruby"
-      - name: "Truffleruby Filter"
-        id: truffleruby_skip
-        shell: bash
-        run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_job"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"          ]] && echo "::set-output name=skip::true"
-          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-          true
-      - name: "Test Truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' && steps.truffleruby_skip.outputs.skip == 'false' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "truffleruby"
+      # - name: "JRuby Filter"
+      #   id: jruby_skip
+      #   shell: bash
+      #   run: |
+      #     echo "::set-output name=skip::false"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"              ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"              ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_model_serializers" ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"            ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support"           ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-aws_sdk"                  ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"              ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-graphql"                  ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http"                     ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http_client"              ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-koala"                    ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"                     ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rack"                     ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"                    ]] && echo "::set-output name=skip::true"
+      #     # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
+      #     true
+      # - name: "Test JRuby"
+      #   if: "${{ matrix.os == 'ubuntu-latest' && steps.jruby_skip.outputs.skip == 'false' }}"
+      #   uses: ./.github/actions/test_gem
+      #   with:
+      #     gem: "${{ matrix.gem }}"
+      #     ruby: "jruby"
+      # - name: "Truffleruby Filter"
+      #   id: truffleruby_skip
+      #   shell: bash
+      #   run: |
+      #     echo "::set-output name=skip::false"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"    ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"    ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_job"     ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"  ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support" ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"    ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"           ]] && echo "::set-output name=skip::true"
+      #     [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"          ]] && echo "::set-output name=skip::true"
+      #     # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
+      #     true
+      # - name: "Test Truffleruby"
+      #   if: "${{ matrix.os == 'ubuntu-latest' && steps.truffleruby_skip.outputs.skip == 'false' }}"
+      #   uses: ./.github/actions/test_gem
+      #   with:
+      #     gem: "${{ matrix.gem }}"
+      #     ruby: "truffleruby"
 
-  # These builds require sidecar services (postgres, redis, etc) in order to run their test suites.
-  instrumentation_with_services:
-    strategy:
-      fail-fast: false
-      # We don't run on macos and windows since service containers aren't supported there.
-      matrix:
-        gem:
-          - opentelemetry-instrumentation-bunny
-          - opentelemetry-instrumentation-dalli
-          - opentelemetry-instrumentation-mongo
-          - opentelemetry-instrumentation-mysql2
-          - opentelemetry-instrumentation-pg
-          - opentelemetry-instrumentation-que
-          - opentelemetry-instrumentation-rdkafka
-          - opentelemetry-instrumentation-redis
-          - opentelemetry-instrumentation-resque
-          - opentelemetry-instrumentation-ruby_kafka
-          - opentelemetry-instrumentation-sidekiq
-          - opentelemetry-instrumentation-trilogy
-    name: ${{ matrix.gem }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: "Test Ruby 3.1"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.1"
-      - name: "Test Ruby 3.0"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
-          yard: true
-          rubocop: true
-          build: true
-      - name: "JRuby Filter"
-        id: jruby_skip
-        shell: bash
-        run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-bunny"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-mysql2"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-pg"         ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-redis"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-resque"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-sidekiq"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-trilogy"    ]] && echo "::set-output name=skip::true"
-          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-          true
-      - name: "Test JRuby"
-        if: "${{ steps.jruby_skip.outputs.skip == 'false' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "jruby"
-      - name: "Truffleruby Filter"
-        id: truffleruby_skip
-        shell: bash
-        run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
-          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-          true
-      - name: "Test Truffleruby"
-        if: "${{ steps.truffleruby_skip.outputs.skip == 'false' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "truffleruby"
-    services:
-      zookeeper:
-        image: confluentinc/cp-zookeeper:latest
-        ports:
-          - 2181:2181
-        env:
-          ZOOKEEPER_CLIENT_PORT: 2181
-          ZOOKEEPER_TICK_TIME: 2000
-      kafka:
-        image: confluentinc/cp-kafka:latest
-        ports:
-          - 9092:9092
-          - 29092:29092
-        env:
-          KAFKA_BROKER_ID: 1
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      memcached:
-        image: memcached:alpine
-        ports:
-          - 11211:11211
-      mongodb:
-        image: mongo:4.4
-        ports:
-          - 27017:27017
-      redis:
-        image: bitnami/redis:6.2
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          REDIS_PASSWORD: "passw0rd"
-      mysql:
-        image: mysql:5.6
-        env:
-          MYSQL_DATABASE: mysql
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_PASSWORD: mysql
-          MYSQL_USER: mysql
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
-      rabbitmq:
-        image: rabbitmq:3.8-alpine
-        ports:
-          - "5672:5672"
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=5s --health-timeout=2s --health-retries=3
+  # # These builds require sidecar services (postgres, redis, etc) in order to run their test suites.
+  # instrumentation_with_services:
+  #   strategy:
+  #     fail-fast: false
+  #     # We don't run on macos and windows since service containers aren't supported there.
+  #     matrix:
+  #       gem:
+  #         - opentelemetry-instrumentation-bunny
+  #         - opentelemetry-instrumentation-dalli
+  #         - opentelemetry-instrumentation-mongo
+  #         - opentelemetry-instrumentation-mysql2
+  #         - opentelemetry-instrumentation-pg
+  #         - opentelemetry-instrumentation-que
+  #         - opentelemetry-instrumentation-rdkafka
+  #         - opentelemetry-instrumentation-redis
+  #         - opentelemetry-instrumentation-resque
+  #         - opentelemetry-instrumentation-ruby_kafka
+  #         - opentelemetry-instrumentation-sidekiq
+  #         - opentelemetry-instrumentation-trilogy
+  #   name: ${{ matrix.gem }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: "Test Ruby 3.1"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.1"
+  #     - name: "Test Ruby 3.0"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "3.0"
+  #     - name: "Test Ruby 2.7"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "2.7"
+  #         yard: true
+  #         rubocop: true
+  #         build: true
+  #     - name: "JRuby Filter"
+  #       id: jruby_skip
+  #       shell: bash
+  #       run: |
+  #         echo "::set-output name=skip::false"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-bunny"      ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-mysql2"     ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-pg"         ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-redis"      ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-resque"     ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-sidekiq"    ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-trilogy"    ]] && echo "::set-output name=skip::true"
+  #         # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
+  #         true
+  #     - name: "Test JRuby"
+  #       if: "${{ steps.jruby_skip.outputs.skip == 'false' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "jruby"
+  #     - name: "Truffleruby Filter"
+  #       id: truffleruby_skip
+  #       shell: bash
+  #       run: |
+  #         echo "::set-output name=skip::false"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
+  #         [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
+  #         # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
+  #         true
+  #     - name: "Test Truffleruby"
+  #       if: "${{ steps.truffleruby_skip.outputs.skip == 'false' }}"
+  #       uses: ./.github/actions/test_gem
+  #       with:
+  #         gem: "${{ matrix.gem }}"
+  #         ruby: "truffleruby"
+  #   services:
+  #     zookeeper:
+  #       image: confluentinc/cp-zookeeper:latest
+  #       ports:
+  #         - 2181:2181
+  #       env:
+  #         ZOOKEEPER_CLIENT_PORT: 2181
+  #         ZOOKEEPER_TICK_TIME: 2000
+  #     kafka:
+  #       image: confluentinc/cp-kafka:latest
+  #       ports:
+  #         - 9092:9092
+  #         - 29092:29092
+  #       env:
+  #         KAFKA_BROKER_ID: 1
+  #         KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+  #         KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
+  #         KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+  #         KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+  #         KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  #     memcached:
+  #       image: memcached:alpine
+  #       ports:
+  #         - 11211:11211
+  #     mongodb:
+  #       image: mongo:4.4
+  #       ports:
+  #         - 27017:27017
+  #     redis:
+  #       image: bitnami/redis:6.2
+  #       ports:
+  #         - 6379:6379
+  #       options: >-
+  #         --health-cmd "redis-cli ping"
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #       env:
+  #         REDIS_PASSWORD: "passw0rd"
+  #     mysql:
+  #       image: mysql:5.6
+  #       env:
+  #         MYSQL_DATABASE: mysql
+  #         MYSQL_ROOT_PASSWORD: root
+  #         MYSQL_PASSWORD: mysql
+  #         MYSQL_USER: mysql
+  #       ports:
+  #         - 3306:3306
+  #       options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+  #     rabbitmq:
+  #       image: rabbitmq:3.8-alpine
+  #       ports:
+  #         - "5672:5672"
+  #     postgres:
+  #       image: postgres:13
+  #       env:
+  #         POSTGRES_PASSWORD: postgres
+  #       ports:
+  #         - 5432:5432
+  #       options: --health-cmd="pg_isready" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,31 +111,31 @@ jobs:
       fail-fast: false
       matrix:
         gem:
-          - opentelemetry-instrumentation-action_pack
+          # - opentelemetry-instrumentation-action_pack
           - opentelemetry-instrumentation-action_view
           - opentelemetry-instrumentation-active_job
           - opentelemetry-instrumentation-active_model_serializers
           - opentelemetry-instrumentation-active_record
           - opentelemetry-instrumentation-active_support
           - opentelemetry-instrumentation-all
-          - opentelemetry-instrumentation-aws_sdk
-          - opentelemetry-instrumentation-base
-          - opentelemetry-instrumentation-concurrent_ruby
+          # - opentelemetry-instrumentation-aws_sdk
+          # - opentelemetry-instrumentation-base
+          # - opentelemetry-instrumentation-concurrent_ruby
           - opentelemetry-instrumentation-delayed_job
-          - opentelemetry-instrumentation-ethon
-          - opentelemetry-instrumentation-excon
-          - opentelemetry-instrumentation-faraday
-          - opentelemetry-instrumentation-graphql
-          - opentelemetry-instrumentation-http
-          - opentelemetry-instrumentation-http_client
-          - opentelemetry-instrumentation-koala
-          - opentelemetry-instrumentation-lmdb
-          - opentelemetry-instrumentation-net_http
-          - opentelemetry-instrumentation-rack
-          - opentelemetry-instrumentation-rails
-          - opentelemetry-instrumentation-restclient
-          - opentelemetry-instrumentation-rspec
-          - opentelemetry-instrumentation-sinatra
+          # - opentelemetry-instrumentation-ethon
+          # - opentelemetry-instrumentation-excon
+          # - opentelemetry-instrumentation-faraday
+          # - opentelemetry-instrumentation-graphql
+          # - opentelemetry-instrumentation-http
+          # - opentelemetry-instrumentation-http_client
+          # - opentelemetry-instrumentation-koala
+          # - opentelemetry-instrumentation-lmdb
+          # - opentelemetry-instrumentation-net_http
+          # - opentelemetry-instrumentation-rack
+          # - opentelemetry-instrumentation-rails
+          # - opentelemetry-instrumentation-restclient
+          # - opentelemetry-instrumentation-rspec
+          # - opentelemetry-instrumentation-sinatra
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,21 +161,21 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.1"
-      - name: "Test Ruby 3.0"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
-          yard: true
-          rubocop: true
-          build: true
+      # - name: "Test Ruby 3.0"
+      #   if: "${{ matrix.os == 'ubuntu-latest' }}"
+      #   uses: ./.github/actions/test_gem
+      #   with:
+      #     gem: "${{ matrix.gem }}"
+      #     ruby: "3.0"
+      # - name: "Test Ruby 2.7"
+      #   if: "${{ matrix.os == 'ubuntu-latest' }}"
+      #   uses: ./.github/actions/test_gem
+      #   with:
+      #     gem: "${{ matrix.gem }}"
+      #     ruby: "2.7"
+      #     yard: true
+      #     rubocop: true
+      #     build: true
       # - name: "JRuby Filter"
       #   id: jruby_skip
       #   shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,15 +113,15 @@ jobs:
         gem:
           # - opentelemetry-instrumentation-action_pack
           - opentelemetry-instrumentation-action_view
-          - opentelemetry-instrumentation-active_job
-          - opentelemetry-instrumentation-active_model_serializers
-          - opentelemetry-instrumentation-active_record
-          - opentelemetry-instrumentation-active_support
-          - opentelemetry-instrumentation-all
+          # - opentelemetry-instrumentation-active_job
+          # - opentelemetry-instrumentation-active_model_serializers
+          # - opentelemetry-instrumentation-active_record
+          # - opentelemetry-instrumentation-active_support
+          # - opentelemetry-instrumentation-all
           # - opentelemetry-instrumentation-aws_sdk
           # - opentelemetry-instrumentation-base
           # - opentelemetry-instrumentation-concurrent_ruby
-          - opentelemetry-instrumentation-delayed_job
+          # - opentelemetry-instrumentation-delayed_job
           # - opentelemetry-instrumentation-ethon
           # - opentelemetry-instrumentation-excon
           # - opentelemetry-instrumentation-faraday

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,10 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Exclude:
     - "**/gemfiles/*"
+Style/SymbolArray:
+  Exclude:
+    - "**/gemfiles/*"
+    - "**/Gemfile"
 Style/ModuleFunction:
   Enabled: false
 Style/MultilineIfModifier:
@@ -49,4 +53,3 @@ Style/SlicingWithRange:
   Enabled: false
 Style/CaseLikeIf:
   Enabled: false
-

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -11,5 +11,7 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'nokogiri', force_ruby_platform: true
   gem 'pry-byebug'
+  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'nokogiri', platforms: [:ruby, :x64_mingw_ucrt]
+  gem 'nokogiri', platforms: [:ruby, :x64_mingw]
   gem 'pry-byebug'
   gem 'sqlite3', platforms: [:ruby, :x64_mingw]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -13,5 +13,5 @@ group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'nokogiri', platforms: [:ruby, :x64_mingw_ucrt]
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :x64_mingw_32]
+  gem 'sqlite3', platforms: [:ruby, :x64_mingw]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -6,12 +6,13 @@
 
 source 'https://rubygems.org'
 
+gem 'nokogiri' #, platforms: [:ruby, :windows]
+
 gemspec
 
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'pry-byebug'
   gem 'sqlite3', platforms: [:ruby, :x64_mingw]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -13,5 +13,5 @@ group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'nokogiri', platforms: [:ruby, :x64_mingw_ucrt]
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :x64_mingw_ucrt]
+  gem 'sqlite3', platforms: [:ruby, :x64_mingw_32]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'nokogiri', platforms: [:ruby, :x64_mingw]
+  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'pry-byebug'
   gem 'sqlite3', platforms: [:ruby, :x64_mingw]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -14,5 +14,5 @@ group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :x64_mingw]
+  gem 'sqlite3'
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'nokogiri', force_ruby_platform: true
+  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
+  gem 'sqlite3', platforms: [:ruby, :windows]
 end

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'nokogiri', platforms: [:ruby, :windows]
+  gem 'nokogiri', platforms: [:ruby, :x64_mingw_ucrt]
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :windows]
+  gem 'sqlite3', platforms: [:ruby, :x64_mingw_ucrt]
 end

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -6,10 +6,9 @@
 
 source 'https://rubygems.org'
 
-gem 'nokogiri', force_ruby_platform: true
-
 gemspec
 
 group :test do
+  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -9,5 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'nokogiri', force_ruby_platform: true
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -6,9 +6,10 @@
 
 source 'https://rubygems.org'
 
+gem 'nokogiri', force_ruby_platform: true
+
 gemspec
 
 group :test do
-  gem 'nokogiri', force_ruby_platform: true
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -9,6 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'nokogiri', force_ruby_platform: true
+  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -9,5 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'nokogiri', force_ruby_platform: true
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -6,11 +6,12 @@
 
 source 'https://rubygems.org'
 
+gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
+
 gemspec
 
 group :test do
   gem 'byebug'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
-  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
 end

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -12,5 +12,5 @@ group :test do
   gem 'byebug'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
-  gem 'sqlite3-ruby'
+  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
 end

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -6,12 +6,11 @@
 
 source 'https://rubygems.org'
 
-gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
-
 gemspec
 
 group :test do
   gem 'byebug'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
+  gem 'sqlite3', platforms: [:ruby, :windows]
 end

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -9,6 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'nokogiri', force_ruby_platform: true
+  gem 'nokogiri', platforms: [:ruby, :windows]
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -9,5 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'nokogiri', force_ruby_platform: true
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -7,3 +7,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'nokogiri', force_ruby_platform: true
+end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -6,6 +6,6 @@
 
 source 'https://rubygems.org'
 
-gem 'nokogiri', force_ruby_platform: true
+gem 'nokogiri', platforms: [:ruby, :windows]
 
 gemspec

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -6,8 +6,6 @@
 
 source 'https://rubygems.org'
 
-gemspec
+gem 'nokogiri', force_ruby_platform: true
 
-group :test do
-  gem 'nokogiri', force_ruby_platform: true
-end
+gemspec

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -10,4 +10,5 @@ gemspec
 
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
 end

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -6,10 +6,9 @@
 
 source 'https://rubygems.org'
 
-gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
-
 gemspec
 
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'sqlite3', platforms: [:ruby, :windows]
 end

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -6,9 +6,10 @@
 
 source 'https://rubygems.org'
 
+gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
+
 gemspec
 
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'sqlite3', platforms: [:ruby, :jruby, :x64_mingw]
 end


### PR DESCRIPTION
Newer versions of gems were released for sqlite3 that have precompiled native dependenices included in the gem.

This change makes having to compile native extensions at install time unnecessary.

<https://github.com/ruby/setup-ruby#bundle-config> <https://github.com/sparklemotion/sqlite3-ruby#avoiding-the-precompiled-native-gem>