### PR TITLE
fix: Windows Ruby 3.1 Native Extensions Installs

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -61,6 +61,7 @@ runs:
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.dir }}"
+        bundler:  "2.3.22"
         bundler-cache: true
         cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
@@ -70,6 +71,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
+        bundler:  "2.3.22"
     - name: Install dependencies and appraisals
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash


### PR DESCRIPTION
A change in `ruby@3.1`, `rubygems`, and/or `bundler@2.3.23` is preventing native extensions both `sqlite3` and `nokogiri` on Windows.

I tried a few different incantations to force bundler to load platform specific versions of [`x64-mingw-ucrt`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/138), however all attempts fell short in some way.

Locking the bundler version to 2.3.22 was the only way I could get the native extensions to install.

This is a temporary fix until we can figure out what changed in the bundler ecosystem to cause this issue.

cc: @johnnyshields 