### PR TITLE
chore: Shorten GH Action Build Names

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -61,6 +61,7 @@ runs:
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.dir }}"
+        bundler:  "2.3.22"
         bundler-cache: true
         cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
@@ -70,6 +71,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
+        bundler:  "2.3.22"
     - name: Install dependencies and appraisals
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           - ruby_kafka
           - sidekiq
           - trilogy
-    name: ${{ matrix.gem }}
+    name: ${{ matrix.gem }} / ubuntu-latest / services
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         gem:
           - ottrace
-          - propagator-xray
+          - xray
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,46 +111,46 @@ jobs:
       fail-fast: false
       matrix:
         gem:
-          - opentelemetry-instrumentation-action_pack
-          - opentelemetry-instrumentation-action_view
-          - opentelemetry-instrumentation-active_job
-          - opentelemetry-instrumentation-active_model_serializers
-          - opentelemetry-instrumentation-active_record
-          - opentelemetry-instrumentation-active_support
-          - opentelemetry-instrumentation-all
-          - opentelemetry-instrumentation-aws_sdk
-          - opentelemetry-instrumentation-base
-          - opentelemetry-instrumentation-concurrent_ruby
-          - opentelemetry-instrumentation-delayed_job
-          - opentelemetry-instrumentation-ethon
-          - opentelemetry-instrumentation-excon
-          - opentelemetry-instrumentation-faraday
-          - opentelemetry-instrumentation-graphql
-          - opentelemetry-instrumentation-http
-          - opentelemetry-instrumentation-http_client
-          - opentelemetry-instrumentation-koala
-          - opentelemetry-instrumentation-lmdb
-          - opentelemetry-instrumentation-net_http
-          - opentelemetry-instrumentation-rack
-          - opentelemetry-instrumentation-rails
-          - opentelemetry-instrumentation-restclient
-          - opentelemetry-instrumentation-rspec
-          - opentelemetry-instrumentation-sinatra
+          - action_pack
+          - action_view
+          - active_job
+          - active_model_serializers
+          - active_record
+          - active_support
+          - all
+          - aws_sdk
+          - base
+          - concurrent_ruby
+          - delayed_job
+          - ethon
+          - excon
+          - faraday
+          - graphql
+          - http
+          - http_client
+          - koala
+          - lmdb
+          - net_http
+          - rack
+          - rails
+          - restclient
+          - rspec
+          - sinatra
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
         exclude:
           - os: windows-latest
-            gem: opentelemetry-instrumentation-ethon
+            gem: ethon
           - os: windows-latest
-            gem: opentelemetry-instrumentation-action_pack
+            gem: action_pack
           - os: windows-latest
-            gem: opentelemetry-instrumentation-restclient
+            gem: restclient
           - os: windows-latest
-            gem: opentelemetry-instrumentation-rails
+            gem: rails
           - os: macos-latest
-            gem: opentelemetry-instrumentation-lmdb
+            gem: lmdb
 
     name: ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -159,19 +159,19 @@ jobs:
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.1"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
       - name: "Test Ruby 2.7"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
           rubocop: true
@@ -181,48 +181,48 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_model_serializers" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"            ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-aws_sdk"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-graphql"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-http_client"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-koala"                    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rack"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"                    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "action_pack"              ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "action_view"              ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_model_serializers" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_record"            ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_support"           ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "aws_sdk"                  ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "delayed_job"              ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "graphql"                  ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "http"                     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "http_client"              ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "koala"                    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "lmdb"                     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "rack"                     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "rails"                    ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test JRuby"
         if: "${{ matrix.os == 'ubuntu-latest' && steps.jruby_skip.outputs.skip == 'false' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash
         run: |
           echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_pack"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-action_view"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_job"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_record"  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-active_support" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-delayed_job"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-lmdb"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rails"          ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "action_pack"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "action_view"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_job"     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_record"  ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "active_support" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "delayed_job"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "lmdb"           ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "rails"          ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test Truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' && steps.truffleruby_skip.outputs.skip == 'false' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "truffleruby"
 
   # These builds require sidecar services (postgres, redis, etc) in order to run their test suites.
@@ -232,18 +232,18 @@ jobs:
       # We don't run on macos and windows since service containers aren't supported there.
       matrix:
         gem:
-          - opentelemetry-instrumentation-bunny
-          - opentelemetry-instrumentation-dalli
-          - opentelemetry-instrumentation-mongo
-          - opentelemetry-instrumentation-mysql2
-          - opentelemetry-instrumentation-pg
-          - opentelemetry-instrumentation-que
-          - opentelemetry-instrumentation-rdkafka
-          - opentelemetry-instrumentation-redis
-          - opentelemetry-instrumentation-resque
-          - opentelemetry-instrumentation-ruby_kafka
-          - opentelemetry-instrumentation-sidekiq
-          - opentelemetry-instrumentation-trilogy
+          - bunny
+          - dalli
+          - mongo
+          - mysql2
+          - pg
+          - que
+          - rdkafka
+          - redis
+          - resque
+          - ruby_kafka
+          - sidekiq
+          - trilogy
     name: ${{ matrix.gem }}
     runs-on: ubuntu-latest
     steps:
@@ -251,17 +251,17 @@ jobs:
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.1"
       - name: "Test Ruby 3.0"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
       - name: "Test Ruby 2.7"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
           rubocop: true
@@ -271,39 +271,39 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-bunny"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-mysql2"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-pg"         ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-redis"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-resque"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-sidekiq"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-trilogy"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "bunny"      ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "mysql2"     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "pg"         ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "que"        ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "redis"      ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "resque"     ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "sidekiq"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "trilogy"    ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test JRuby"
         if: "${{ steps.jruby_skip.outputs.skip == 'false' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash
         run: |
           echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-instrumentation-ruby_kafka" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "que"        ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test Truffleruby"
         if: "${{ steps.truffleruby_skip.outputs.skip == 'false' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "truffleruby"
     services:
       zookeeper:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,31 @@ jobs:
       fail-fast: false
       matrix:
         gem:
-          - opentelemetry-resource_detectors
+          - resource_detectors
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    name: ${{ matrix.gem }} / ${{ matrix.os }}
+    name: "opentelemetry-${{ matrix.gem }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.1"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.0"
       - name: "Test Ruby 2.7"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
           rubocop: true
@@ -49,13 +49,13 @@ jobs:
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "truffleruby"
 
   propagators:
@@ -63,32 +63,32 @@ jobs:
       fail-fast: false
       matrix:
         gem:
-          - opentelemetry-propagator-ottrace
-          - opentelemetry-propagator-xray
+          - ottrace
+          - propagator-xray
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    name: ${{ matrix.gem }} / ${{ matrix.os }}
+    name: "propagator-${{ matrix.gem }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.1"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.0"
       - name: "Test Ruby 2.7"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "2.7"
           yard: true
           rubocop: true
@@ -97,13 +97,13 @@ jobs:
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
-          gem: "${{ matrix.gem }}"
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "truffleruby"
 
   instrumentation:


### PR DESCRIPTION
Shortening the names makes them easier to read: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/140/checks

<img width="649" alt="image" src="https://user-images.githubusercontent.com/82798/194981549-ed1f1cc7-7fbc-46fd-8e35-ccdacdf2f616.png">
