### PR TITLE
ci: replace newly-deprecated commands in actions

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         dir=$(find . -iname '${{ inputs.gem }}.gemspec' -exec dirname {} \;)
-        echo "::set-output name=dir::${dir}"
+        echo "gem_dir=${dir}" >> $GITHUB_OUTPUT
 
         # We install multiple ruby versions here, and that makes for some
         # annoying bundler conflicts when we get to the JRuby step. Removing
@@ -41,16 +41,16 @@ runs:
         # of the benefits of bundler caching.
         rm -f "${dir}/Gemfile.lock"
 
-        echo "::set-output name=cache_key::mri"
+        echo "cache_key=mri" >> $GITHUB_OUTPUT
         if [[ "${{ inputs.ruby }}" == "jruby" ]]; then
-          echo "::set-output name=cache_key::jruby"
+          echo "cache_key=jruby" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.ruby }}" == "truffleruby" ]]; then
-          echo "::set-output name=cache_key::truffleruby"
+          echo "cache_key=truffleruby" >> $GITHUB_OUTPUT
         fi
 
-        echo "::set-output name=appraisals::false"
+        echo "appraisals=false" >> $GITHUB_OUTPUT
         if [[ -f "${dir}/Appraisals" ]]; then
-          echo "::set-output name=appraisals::true"
+          echo "appraisals=true" >> $GITHUB_OUTPUT
         fi
 
     # Install ruby and bundle dependencies and cache!
@@ -60,7 +60,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
-        working-directory: "${{ steps.setup.outputs.dir }}"
+        working-directory: "${{ steps.setup.outputs.gem_dir }}"
         bundler:  "2.3.22"
         bundler-cache: true
         cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
@@ -76,14 +76,14 @@ runs:
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle install
         bundle exec appraisal install
 
     - name: Test Gem
       shell: bash
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
 
         if [[ -f "Appraisals" ]]; then
           bundle exec appraisal rake test
@@ -116,19 +116,19 @@ runs:
       shell: bash
       if: "${{ inputs.yard == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle exec rake yard
 
     - name: Rubocop
       shell: bash
       if: "${{ inputs.rubocop == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle exec rake rubocop
 
     - name: Build Gem
       shell: bash
       if: "${{ inputs.build == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         gem build ${{ inputs.gem }}.gemspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,21 +180,21 @@ jobs:
         id: jruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "action_pack"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "action_view"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_model_serializers" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_record"            ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_support"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "aws_sdk"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "delayed_job"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "graphql"                  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "http"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "http_client"              ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "koala"                    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "lmdb"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "rack"                     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "rails"                    ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "action_pack"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "action_view"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_model_serializers" ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_record"            ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_support"           ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "aws_sdk"                  ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "delayed_job"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "graphql"                  ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "http"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "http_client"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "koala"                    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "lmdb"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "rack"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "rails"                    ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test JRuby"
@@ -207,15 +207,15 @@ jobs:
         id: truffleruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "action_pack"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "action_view"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_job"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_record"  ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "active_support" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "delayed_job"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "lmdb"           ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "rails"          ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "action_pack"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "action_view"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_job"     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_record"  ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "active_support" ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "delayed_job"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "lmdb"           ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "rails"          ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test Truffleruby"
@@ -270,17 +270,17 @@ jobs:
         id: jruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "bunny"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "mysql2"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "pg"         ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "redis"      ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "resque"     ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "sidekiq"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "trilogy"    ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "bunny"      ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "mysql2"     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "pg"         ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "que"        ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "redis"      ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "resque"     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "sidekiq"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "trilogy"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test JRuby"
@@ -293,10 +293,10 @@ jobs:
         id: truffleruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "que"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "que"        ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "rdkafka"    ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "ruby_kafka" ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test Truffleruby"


### PR DESCRIPTION
The `set-output` command is being deprecated, and so we need to migrate.
Per the guides, this looks like the easiest replacement.

Fixes #144
