### PR TITLE
fix: declare span_naming option in action_pack instrumentation

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
@@ -26,6 +26,7 @@ module OpenTelemetry
         end
 
         option :enable_recognize_route, default: false, validate: :boolean
+        option :span_naming, default: :rails_route, validate: %i[controller_action rails_route]
 
         private
 


### PR DESCRIPTION
The `span_naming` option is not declared in `OpenTelemetry::Instrumentation::ActionPack::Instrumentation`, so this option is ignored if the class is configured using `OpenTelemetry::SDK.configure` method.

The `span_naming` is validated against 2 values: `:controller_action` and `:rails_route` and the default value is `:rails_route`.
