### PR TITLE
docs: Add information about ActionPack instrumentation span naming

### DIFF
--- a/instrumentation/action_pack/README.md
+++ b/instrumentation/action_pack/README.md
@@ -32,7 +32,26 @@ end
 
 ### Configuration options
 
-The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/journey/router.rb#L65)
+**`:span_naming`**
+
+The ActionPack span name may be configured with the `:span_naming` option.
+
+The default behaviour is in the form of `<request method> <rails route>`, for example `'GET /ok(.:format)'`. This is in adherence with the [HTTP Server Semantic Conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-server-semantic-conventions).
+
+Alternatively you can configure `span_naming: :controller_action` to receive the format of `ExampleController#ok`.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::ActionPack', {
+    span_naming: :controller_action
+  }
+end
+```
+
+**`:enable_recognize_route`**
+
+The `http.route` when enabled includes the Rails route, for example `/ok(.:format)'`. This attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/journey/router.rb#L65)
+
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::ActionPack', {


### PR DESCRIPTION
Since https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/123 has been merged I think the ActionPack README should be updated to reflect this new option and default behaviour.

This pull requests adds some documentation to satisfy this.

I have left the somewhat ominous, but not explained, line:

>This attribute is disabled by default because we use .recognize

I will create an issue for proposing some changes to the instrumentation and will address it there, as I would like to change the default setting for this attribute from `false` to `true`.