### PR TITLE
test: Fix Rails tests for new ActionPack instrumentation default behaviour

### DIFF
--- a/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -17,7 +17,7 @@ describe OpenTelemetry::Instrumentation::Rails do
   # Clear captured spans
   before { exporter.reset }
 
-  it 'sets the span name to ControllerName#action' do
+  it 'sets the span name to the format: HTTP_METHOD /rails/route(.:format)' do
     get '/ok'
 
     _(last_response.body).must_equal 'actually ok'
@@ -35,7 +35,9 @@ describe OpenTelemetry::Instrumentation::Rails do
     _(span.attributes['http.target']).must_equal '/ok'
     _(span.attributes['http.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
-    _(span.attributes['http.route']).must_be_nil
+    _(span.attributes['http.route']).must_equal '/ok(.:format)'
+    _(span.attributes['code.namespace']).must_equal 'ExampleController'
+    _(span.attributes['code.function']).must_equal 'ok'
   end
 
   def app


### PR DESCRIPTION
* ActionPack instrumentation now defaults enabled_recognize_route to true, and this means the http.route is added by default.

* This also corrects the tests description and adds the code.namspace and code.function attributes

--- 

https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/170 was merged while tests were failing and this addresses the failures on `main`

Sorry about that, it wasn't clear to me that the tests were failing in a different gem than I made the changes in. I missed that totally.

---
The rails tests in the rails gem are very minimal, is this expected? https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb

The ActionPack tests have much more to them https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb

Should all the tests that exist in the ActionPack gem, exist in the Rails tests as well? I also notice that other Rails instrumentation features, like ActiveSupport, aren't tested in the rails gem.