### PR TITLE
fix: Use attributes from the active PG connection

### DIFF
--- a/instrumentation/pg/Appraisals
+++ b/instrumentation/pg/Appraisals
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
-appraise 'pg-1.2.3' do
+# 1.2.3 appears to be the most popular version at RubyGems.org
+appraise 'pg-1.2' do
+  gem 'pg', '~> 1.2.3'
+end
+
+# 1.3.0 significantly changed connecting and the handling of connection strings
+appraise 'pg-1.3' do
+  gem 'pg', '~> 1.3.5'
+end
+
+appraise 'pg-latest' do
   gem 'pg'
 end

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -166,12 +166,12 @@ module OpenTelemetry
           def transport_port
             # The port method can fail in older versions of the gem. It is
             # accurate and safe to use when the DEF_PGPORT constant is defined.
-            return port.to_s if defined?(::PG::DEF_PGPORT)
+            return port if defined?(::PG::DEF_PGPORT)
 
             # As a fallback, we can use the port of the parsed connection
             # string when there is exactly one.
             p = conninfo_hash[:port]
-            return p unless p.nil? || p.empty? || p.include?(',')
+            return p.to_i unless p.nil? || p.empty? || p.include?(',')
           end
         end
       end

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -97,7 +97,7 @@ module OpenTelemetry
           end
 
           def span_name(operation)
-            [validated_operation(operation), database_name].compact.join(' ')
+            [validated_operation(operation), db].compact.join(' ')
           end
 
           def validated_operation(operation)
@@ -123,42 +123,55 @@ module OpenTelemetry
             @generated_postgres_regex ||= Regexp.union(PG::Constants::POSTGRES_COMPONENTS.map { |component| PG::Constants::COMPONENTS_REGEX_MAP[component] })
           end
 
-          def database_name
-            conninfo_hash[:dbname]&.to_s
-          end
-
-          def first_in_list(item)
-            return unless item
-
-            if (idx = item.index(','))
-              item[0...idx]
-            else
-              item
-            end
-          end
-
           def client_attributes
             attributes = {
               'db.system' => 'postgresql',
-              'db.user' => conninfo_hash[:user]&.to_s,
-              'db.name' => database_name,
-              'net.peer.name' => first_in_list(conninfo_hash[:host]&.to_s)
+              'db.user' => user,
+              'db.name' => db
             }
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             attributes.merge(transport_attrs).reject { |_, v| v.nil? }
           end
 
+          def transport_addr
+            # The hostaddr method is available when the gem is built against
+            # a recent version of libpq.
+            return hostaddr if defined?(hostaddr)
+
+            # As a fallback, we can use the hostaddr of the parsed connection
+            # string when there is only one. Some older versions of libpq allow
+            # multiple without any way to discern which is presently connected.
+            addr = conninfo_hash[:hostaddr]
+            return addr unless addr&.include?(',')
+          end
+
           def transport_attrs
-            if conninfo_hash[:host]&.start_with?('/')
-              { 'net.transport' => 'Unix' }
+            h = host
+            if h&.start_with?('/')
+              {
+                'net.sock.family' => 'unix',
+                'net.peer.name' => h
+              }
             else
               {
-                'net.transport' => 'IP.TCP',
-                'net.peer.ip' => conninfo_hash[:hostaddr]&.to_s,
-                'net.peer.port' => first_in_list(conninfo_hash[:port]&.to_s)
+                'net.transport' => 'ip_tcp',
+                'net.peer.name' => h,
+                'net.peer.ip' => transport_addr,
+                'net.peer.port' => transport_port
               }
             end
+          end
+
+          def transport_port
+            # The port method can fail in older versions of the gem. It is
+            # accurate and safe to use when the DEF_PGPORT constant is defined.
+            return port.to_s if defined?(::PG::DEF_PGPORT)
+
+            # As a fallback, we can use the port of the parsed connection
+            # string when there is exactly one.
+            p = conninfo_hash[:port]
+            return p unless p.nil? || p.empty? || p.include?(',')
           end
         end
       end

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -114,7 +114,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.statement']).must_equal 'SELECT 1'
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -128,7 +128,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.statement']).must_equal 'SELECT $1 AS a'
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.operation']).must_equal 'PREPARE'
         _(span.attributes['db.postgresql.prepared_statement_name']).must_equal 'foo'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -159,7 +159,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(last_span.attributes['db.statement']).must_equal 'SELECT $1 AS a'
         _(last_span.attributes['db.postgresql.prepared_statement_name']).must_equal 'foo'
         _(last_span.attributes['net.peer.name']).must_equal host.to_s
-        _(last_span.attributes['net.peer.port']).must_equal port.to_s
+        _(last_span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -173,7 +173,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.statement']).must_equal 'SELECT 1'
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -189,7 +189,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(last_span.attributes['db.statement']).must_be_nil
       _(last_span.attributes['db.postgresql.prepared_statement_name']).must_equal 'foo0'
       _(last_span.attributes['net.peer.name']).must_equal host.to_s
-      _(last_span.attributes['net.peer.port']).must_equal port.to_s
+      _(last_span.attributes['net.peer.port']).must_equal port.to_i
     end
 
     it 'after error' do
@@ -203,7 +203,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(span.attributes['db.statement']).must_equal 'SELECT INVALID'
       _(span.attributes['db.operation']).must_equal 'SELECT'
       _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['net.peer.port']).must_equal port.to_i
 
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
@@ -226,7 +226,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(span.attributes['db.statement']).must_equal explain_sql
       _(span.attributes['db.operation']).must_equal 'EXPLAIN'
       _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['net.peer.port']).must_equal port.to_i
     end
 
     it 'uses database name as span.name fallback with invalid sql' do
@@ -240,7 +240,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(span.attributes['db.statement']).must_equal 'DESELECT 1'
       _(span.attributes['db.operation']).must_be_nil
       _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['net.peer.port']).must_equal port.to_i
 
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
@@ -267,7 +267,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.statement']).must_equal obfuscated_sql
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
       end
     end
 
@@ -285,7 +285,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.name).must_equal 'SELECT postgres'
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
 
         _(span.attributes['db.statement']).must_be_nil
       end
@@ -305,7 +305,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.name).must_equal 'SELECT postgres'
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
-        _(span.attributes['net.peer.port']).must_equal port.to_s
+        _(span.attributes['net.peer.port']).must_equal port.to_i
 
         _(span.attributes['db.statement']).must_be_nil
       end
@@ -341,7 +341,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         client.query('SELECT 1')
 
         _(span.attributes['net.peer.name']).must_equal host
-        _(span.attributes['net.peer.port']).must_equal port if ::PG.const_defined?('DEF_PORT')
+        _(span.attributes['net.peer.port']).must_equal port.to_i if ::PG.const_defined?('DEF_PORT')
       end
     end
   end unless ENV['OMIT_SERVICES']


### PR DESCRIPTION
As discovered and addressed in #142, the `pg` gem and its underlying `libpq` library allow multiple hosts and network addresses in the connection string. The solution applied there, however, does not always return accurate information about the connected peer.

When there are multiple hosts or addresses, the library [tries each in order until one succeeds](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS). The [`target_session_attrs`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-TARGET-SESSION-ATTRS) setting allows both primary and replica servers to be specified in the connection string, and the library will figure which is which. Always using the first value in the connection string ignores this stuff.

I don't see an explanation for why `conninfo_hash` was used in 463c14c3581641ce57270c1c7cfb91715cfd2c3e, so perhaps I'm missing some benefit to it.

The separate methods (`host`, `hostaddr`, `port`, `user`, and `db`) describe the singular active connection from the resolved connection string (IPv4, IPv6, primary, replica, etc). I'm pretty sure we should use these when they're available.

There are a couple of older versions of `libpq` that allow multiple hosts/addresses but lack a `hostaddr` method. For those, `conninfo_hash` is accurate when it returns a single address. When it returns multiple addresses, we can use the first like #142 or omit `net.peer.ip`. The latter seems better to me, so that's what I've done in this PR.

~TODO:~
- [x] I would like to rebase this after #178 lands for the UNIX socket test there.