### PR TITLE
Loosen actionpack dep on rack instrumentation

### DIFF
--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
-  spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21.0'
+  spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'


### PR DESCRIPTION
Right now, actionpack instrumentation accepts any rack instrumentation release in the 0.21.x series. I think we should allow it to accept anything in the 0.x series. Per Semver.org, this will allow us to add backwards-compatible functionality to rack instrumentation (as in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/197) without explicitly bumping actionpack's dep:

> Given a version number MAJOR.MINOR.PATCH, increment the:
> MAJOR version when you make incompatible API changes
> MINOR version when you add functionality in a backwards compatible manner
> PATCH version when you make backwards compatible bug fixes

(companion to https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/198)