### PR TITLE
feat: Add db,view,cpu time & allocation count to ActionPack span

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/action_controller_subscriber.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/action_controller_subscriber.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module ActionPack
+      # ActiveSupport::Notification handlers for ActionController published events
+      # https://guides.rubyonrails.org/active_support_instrumentation.html#action-controller
+      class ActionControllerSubscriber < ::ActiveSupport::Subscriber
+        # @private
+        GTE_TO_RAILS_SIX = Gem::Version.new(::Rails.version) >= Gem::Version.new('6')
+
+        def process_action(event)
+          current_span = OpenTelemetry::Trace.current_span
+          return unless current_span.recording?
+
+          attributes = {}
+          add_common_attributes(attributes, event)
+          add_process_action_attributes(attributes, event.payload)
+
+          current_span.add_attributes(attributes) unless attributes.empty?
+        end
+
+        protected
+
+        def add_common_attributes(attributes, event)
+          return unless GTE_TO_RAILS_SIX
+
+          attach('process.runtime.ruby.allocations.count', event.try(:allocations), attributes)
+          attach('rails.cpu.duration', event.try(:cpu_time).round(2), attributes)
+        end
+
+        def add_process_action_attributes(attributes, payload)
+          attach('rails.view.duration', payload[:view_runtime]&.round(2), attributes)
+          attach('rails.db.duration', payload[:db_runtime]&.round(2), attributes)
+        end
+
+        def attach(name, value, attributes)
+          attributes[name] = value if value
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
@@ -15,6 +15,7 @@ module OpenTelemetry
           require_railtie
           require_dependencies
           patch
+          register_event_handler
         end
 
         present do
@@ -38,8 +39,13 @@ module OpenTelemetry
           ::ActionController::Metal.prepend(Patches::ActionController::Metal)
         end
 
+        def register_event_handler
+          ActionControllerSubscriber.attach_to(:action_controller)
+        end
+
         def require_dependencies
           require_relative 'patches/action_controller/metal'
+          require_relative 'action_controller_subscriber'
         end
 
         def require_railtie

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rubocop', '~> 1.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/action_controller_subscriber_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/action_controller_subscriber_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/action_pack'
+require_relative '../../../../lib/opentelemetry/instrumentation/action_pack/action_controller_subscriber'
+
+describe OpenTelemetry::Instrumentation::ActionPack::ActionControllerSubscriber do
+  include Rack::Test::Methods
+
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+  let(:span) { exporter.finished_spans.last }
+  let(:rails_app) { DEFAULT_RAILS_APP }
+
+  # Clear captured spans
+  before { exporter.reset }
+
+  it 'sets the view runtime' do
+    get '/ok'
+
+    _(last_response.body).must_equal 'actually ok'
+    _(last_response.ok?).must_equal true
+
+    _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
+    _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
+
+    _(span.attributes['rails.view.duration']).must_be :>=, 0
+  end
+
+  it 'sets the db runtime' do
+    get '/query'
+
+    _(last_response.body).must_equal 'make query'
+    _(last_response.ok?).must_equal true
+
+    _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
+    _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
+
+    _(span.attributes['rails.db.duration']).must_be :>=, 0
+  end
+
+  it 'sets common active support notification attributes' do
+    get '/ok'
+
+    _(last_response.body).must_equal 'actually ok'
+    _(last_response.ok?).must_equal true
+
+    _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
+    _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
+
+    below_rails('6') do
+      _(span.attributes['process.runtime.ruby.allocations.count']).must_be_nil
+      _(span.attributes['rails.cpu.duration']).must_be_nil
+    end
+
+    equal_or_above_rails('6') do
+      _(span.attributes['process.runtime.ruby.allocations.count']).must_be :>=, 0
+      _(span.attributes['rails.cpu.duration']).must_be :>=, 0
+    end
+  end
+
+  def app
+    rails_app
+  end
+end

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -30,3 +30,11 @@ end
 # specifically testing behaviour with different initialization configs.
 DEFAULT_RAILS_APP = AppConfig.initialize_app
 ::Rails.application = DEFAULT_RAILS_APP
+
+def below_rails(version, &block)
+  block.call if Gem::Version.new(::Rails.version) < Gem::Version.new(version)
+end
+
+def equal_or_above_rails(version, &block)
+  block.call if Gem::Version.new(::Rails.version) >= Gem::Version.new(version)
+end

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -6,9 +6,21 @@
 
 class Application < Rails::Application; end
 require 'action_controller/railtie'
+require 'active_record'
+
+require 'active_record/railties/controller_runtime'
+ActiveSupport.on_load(:action_controller) do
+  include ActiveRecord::Railties::ControllerRuntime
+end
+
 require_relative 'middlewares'
 require_relative 'controllers'
 require_relative 'routes'
+
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: 'db/development.sqlite3'
+)
 
 module AppConfig
   extend self

--- a/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
+++ b/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
@@ -19,6 +19,11 @@ class ExampleController < ActionController::Base
     render plain: 'created new item'
   end
 
+  def query
+    ActiveRecord::Base.connection.execute('select 1')
+    render plain: 'make query'
+  end
+
   def internal_server_error
     raise :internal_server_error
   end

--- a/instrumentation/action_pack/test/test_helpers/routes.rb
+++ b/instrumentation/action_pack/test/test_helpers/routes.rb
@@ -9,6 +9,7 @@ def draw_routes(rails_app)
     get '/ok', to: 'example#ok'
     get '/items/new', to: 'example#new_item'
     get '/items/:id', to: 'example#item'
+    get '/query', to: 'example#query'
     get '/internal_server_error', to: 'example#internal_server_error'
   end
 end


### PR DESCRIPTION
The standard ruby on rails logs include some nice stats like time spent in views, time spent in DB, and allocation count. This information is all available when subscribing to the `process_action.action_controller`

Note: It is possible to subscribe to ActiveSupport notifications in a few different ways. However, it appears that using a ActiveSupport::Subscriber is the only way that gets you access the performance stats like cpu time and allocations counts. Subscribing directly using ActiveSupport::Notifications.subscribe will not provide these.

You can play around with that in the following file:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'activesupport', '7.0.4'
end

require 'active_support'
require "active_support/notifications"
require "active_support/subscriber"

puts 'running...'

ActiveSupport::Notifications.subscribe('work.acme') do |name, _start, _finish, id, payload|
  puts "ActiveSupport::Notifications -- name:#{name}, id:#{id}, payload:#{payload}"
end

module Acme
  class Subscriber < ActiveSupport::Subscriber
    def work(event)
      puts "ActiveSupport::Subscriber -- #{event.inspect}"
    end
  end
end

Acme::Subscriber.attach_to(:acme)

ActiveSupport::Notifications.instrument('work.acme', {some: :metadata}) do
  puts "  WORKING"
end
```

Outputs:

```
running...
  WORKING
ActiveSupport::Notifications -- name:work.acme, id:45173c87df4b07c736fc, payload:{:some=>:metadata}
ActiveSupport::Subscriber -- #<ActiveSupport::Notifications::Event:0x00007f9c9d1ecc38 @name="work.acme", @payload={:some=>:metadata}, @time=662445703.679, @transaction_id="45173c87df4b07c736fc", @end=662445703.73, @children=[], @cpu_time_start=650.954916, @cpu_time_finish=651.003522, @allocation_count_start=255318, @allocation_count_finish=255326>
```

In doing this noticed that the current [Metal instrumentation](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb#L14) could be refactored to use the subscription method rather than patching with module prepend. Is this something that would be preferred?

I'll leave some inline comments for other things I'd like to point out.