### PR TITLE
Fix `format_command`'s terrible performance

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
@@ -53,7 +53,17 @@ module OpenTelemetry
 
       def format_command(operation, args)
         placeholder = "#{operation} BLOB (OMITTED)"
-        command = [operation, *args].join(' ').strip
+
+        command = +operation.to_s
+        args.flatten.each do |arg|
+          str = arg.to_s
+          if str.bytesize >= CMD_MAX_LEN
+            command << ' BLOB (OMITTED)'
+          elsif !str.empty?
+            command << ' ' << str
+          end
+        end
+
         command = OpenTelemetry::Common::Utilities.utf8_encode(command, binary: true, placeholder: placeholder)
         OpenTelemetry::Common::Utilities.truncate(command, CMD_MAX_LEN)
       rescue StandardError => e


### PR DESCRIPTION
I recently got pulled on a memcached performance issue, we were seeing horribly slow memcached operations.

After profiling it turns out that 99% of the time was spent in opentelemetry.

This was particularly bad when the payload we were writing in memcache was a large (1MB) binary blob.

benchmark:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'opentelemetry-instrumentation-dalli'
  gem 'benchmark-ips'
end

require 'benchmark/ips'
require 'opentelemetry-instrumentation-dalli'
require 'opentelemetry/instrumentation/dalli/utils'

operation = :set
args = ["foo", Random.bytes(1_000_000), 0, 0, nil].freeze

ORIG = OpenTelemetry::Instrumentation::Utils

module Opt
  extend self

  CMD_MAX_LEN = 500

  def format_command(operation, args)
    placeholder = "#{operation} BLOB (OMITTED)"

    command = operation.to_s
    args.each do |arg|
      str = arg.to_s
      if str.bytesize >= CMD_MAX_LEN
        break
      else
        command << " " << str
      end
    end

    command = OpenTelemetry::Common::Utilities.utf8_encode(command, binary: true, placeholder: placeholder)
    OpenTelemetry::Common::Utilities.truncate(command, CMD_MAX_LEN)
  rescue StandardError => e
    OpenTelemetry.logger.debug("Error sanitizing Dalli operation: #{e}")
    placeholder
  end
end

Benchmark.ips do |x|
  x.report("original") { ORIG.format_command(operation, args) }
  x.report("opt") { Opt.format_command(operation, args) }
  x.compare!(order: :baseline)
end
```

Results:

```
Warming up --------------------------------------
            original     4.000  i/100ms
                 opt    99.088k i/100ms
Calculating -------------------------------------
            original     42.831  (± 2.3%) i/s -    216.000  in   5.044141s
                 opt    990.037k (± 0.4%) i/s -      4.954M in   5.004339s

Comparison:
            original:       42.8 i/s
                 opt:   990037.0 i/s - 23114.82x  (± 0.00) faster
```

cc @robertlaurin 