### PR TITLE
ci: pin to last known good jruby release

### DIFF
--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
@@ -93,7 +93,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem

--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
 
   resource-detectors:
     strategy:
@@ -88,4 +88,4 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"

--- a/.github/workflows/ci-instrumentation-canary.yml
+++ b/.github/workflows/ci-instrumentation-canary.yml
@@ -102,7 +102,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash

--- a/.github/workflows/ci-instrumentation-with-services-canary.yml
+++ b/.github/workflows/ci-instrumentation-with-services-canary.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"
     services:
       zookeeper:
         image: confluentinc/cp-zookeeper:latest

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -94,4 +94,4 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby"
+          ruby: "jruby-9.3.9.0"


### PR DESCRIPTION
JRuby 9.4.0.0 - along with amazing new MRI 3.1 compatibility - seems to
be shipping also with exotic new bugs. We're going to temporarily pin to
an older version until we have time to understand those bugs and/or help
fix them upstream (and/or help upstream fix them!).
