### PR TITLE
fix: add untraced check to the Net::HTTP connect instrumentation

### DIFF
--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -45,6 +45,8 @@ module OpenTelemetry
 
             # rubocop:disable Metrics/MethodLength
             def connect
+              return super if untraced?
+
               if proxy?
                 conn_address = proxy_address
                 conn_port    = proxy_port

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -150,6 +150,18 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         _(exporter.finished_spans.size).must_equal 0
       end
 
+      it 'does not create a span on connect when request ignored using a regexp' do
+        WebMock.allow_net_connect!
+
+        uri = URI.parse('http://bazqux.com')
+        Net::HTTP.start(uri.host, uri.port) do |http|
+          http.get('/')
+        end
+        _(exporter.finished_spans.size).must_equal 0
+      ensure
+        WebMock.disable_net_connect!
+      end
+
       it 'creates a span for a non-ignored request' do
         ::Net::HTTP.get('example.com', '/body')
         _(exporter.finished_spans.size).must_equal 1

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -151,15 +151,11 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       end
 
       it 'does not create a span on connect when request ignored using a regexp' do
-        WebMock.allow_net_connect!
-
         uri = URI.parse('http://bazqux.com')
-        Net::HTTP.start(uri.host, uri.port) do |http|
-          http.get('/')
-        end
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.send(:connect)
+        http.send(:do_finish)
         _(exporter.finished_spans.size).must_equal 0
-      ensure
-        WebMock.disable_net_connect!
       end
 
       it 'creates a span for a non-ignored request' do
@@ -168,6 +164,18 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
+      end
+
+      it 'creates a span on connect for a non-ignored request' do
+        uri = URI.parse('http://example.com')
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.send(:connect)
+        http.send(:do_finish)
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal('connect')
+        _(span.kind).must_equal(:internal)
+        _(span.attributes['net.peer.name']).must_equal('example.com')
+        _(span.attributes['net.peer.port']).must_equal(80)
       end
     end
   end


### PR DESCRIPTION
We are observing that the Net::HTTP connect instrumentation does not respect untraced hosts.

I think this check should have been included in #108 but let me know if not having the check is intentional