### PR TITLE
String-ify the code.function Span attribute

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
                 attributes_to_append = {
                   OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE => self.class.name,
-                  OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => name
+                  OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => String(name)
                 }
                 attributes_to_append[OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET] = request.filtered_path if request.filtered_path != request.fullpath
                 rack_span.add_attributes(attributes_to_append)

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
@@ -42,6 +42,12 @@ describe OpenTelemetry::Instrumentation::ActionPack::Patches::ActionController::
     _(span.attributes['code.function']).must_equal 'ok'
   end
 
+  it 'handles action name as a symbol when setting code.function' do
+    get 'ok-symbol'
+
+    _(span.attributes['code.function']).must_equal 'ok'
+  end
+
   it 'does not memoize data across requests' do
     get '/ok'
     get '/items/new'

--- a/instrumentation/action_pack/test/test_helpers/routes.rb
+++ b/instrumentation/action_pack/test/test_helpers/routes.rb
@@ -7,6 +7,7 @@
 def draw_routes(rails_app)
   rails_app.routes.draw do
     get '/ok', to: 'example#ok'
+    get '/ok-symbol', to: ExampleController.action(:ok)
     get '/items/new', to: 'example#new_item'
     get '/items/:id', to: 'example#item'
     get '/internal_server_error', to: 'example#internal_server_error'


### PR DESCRIPTION
Some times these come through as symbols, for example when using Devise's `FailureApp`, the name will be `:respond`. So we'll String-ify the value before sending it on.