### PR TITLE
feat: add option to configure span name

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
@@ -30,6 +30,7 @@ module OpenTelemetry
         option :peer_service, default: nil, validate: :string
         option :enable_sql_obfuscation, default: false, validate: :boolean
         option :db_statement, default: :include, validate: %I[omit include obfuscate]
+        option :span_name, default: :statement_type, validate: %I[statement_type db_name db_operation_and_name]
 
         private
 

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -95,7 +95,7 @@ module OpenTelemetry
             %r{'|"|\/\*|\*\/}.match(obfuscated)
           end
 
-          def database_span_name(sql)
+          def database_span_name(sql) # rubocop:disable Metrics/CyclomaticComplexity
             case config[:span_name]
             when :statement_type
               extract_statement_type(sql)

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -96,19 +96,22 @@ module OpenTelemetry
           end
 
           def database_span_name(sql)
-            # Setting span name to the SQL query without obfuscation would
-            # result in PII + cardinality issues.
-            # First attempt to infer the statement type then fallback to
-            # current Otel approach {database.component_name}.{database_instance_name}
-            # https://github.com/open-telemetry/opentelemetry-python/blob/39fa078312e6f41c403aa8cad1868264011f7546/ext/opentelemetry-ext-dbapi/tests/test_dbapi_integration.py#L53
-            # This creates span names like mysql.default, mysql.replica, postgresql.staging etc.
-
-            statement_type = extract_statement_type(sql)
-
-            return statement_type unless statement_type.nil?
-
-            # fallback
-            database_name ? "mysql.#{database_name}" : 'mysql'
+            case config[:span_name]
+            when :statement_type
+              extract_statement_type(sql)
+            when :db_name
+              database_name
+            when :db_operation_and_name
+              op = OpenTelemetry::Instrumentation::Mysql2.attributes['db.operation']
+              name = database_name
+              if op && name
+                "#{op} #{name}"
+              elsif op
+                op
+              elsif name
+                name
+              end
+            end || 'mysql'
           end
 
           def database_name

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -139,7 +139,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         client.query('DESELECT 1')
       end.must_raise Mysql2::Error
 
-      _(span.name).must_equal 'mysql.mysql'
+      _(span.name).must_equal 'mysql'
       _(span.attributes['db.system']).must_equal 'mysql'
       _(span.attributes['db.name']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'DESELECT 1'
@@ -219,7 +219,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
           client.query(sql)
         end.must_raise Mysql2::Error
 
-        _(span.name).must_equal 'mysql.mysql'
+        _(span.name).must_equal 'mysql'
         _(span.attributes['db.statement']).must_equal obfuscated_sql
       end
     end

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -412,14 +412,14 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
             OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_MYSQL2_CONFIG_OPTS' => 'span_name=db_operation_and_name') do
               instrumentation.instance_variable_set(:@installed, false)
               instrumentation.install
-  
+
               sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
               OpenTelemetry::Instrumentation::Mysql2.with_attributes('db.operation' => 'foo') do
                 expect do
                   client.query(sql)
                 end.must_raise Mysql2::Error
               end
-  
+
               _(span.name).must_equal 'foo'
             end
           end


### PR DESCRIPTION
This adds a configuration option for MySQL instrumentation to control the span name. At present, we default to expensive client-side parsing of the expression to determine the statement type, however this is contrary to recommendations in the Semantic Conventions.

This adds 3 options, defaulting to the current behaviour: `statement_type`, `db_name` and `db_operation_and_name`. The `db_name` option extracts the database name from the `query_options`, if available. The `db_operation_and_name` option additionally looks for `db.operation` in the `OpenTelemetry::Instrumentation::Mysql2.attributes` (from the current context). This allows callers to add `db.operation` to the context, if they know it.

In all cases, if no useful span name can be determined, we default to `mysql`.

### TODO
- [x] Add tests for new config option