### PR TITLE
feat: add config[:obfuscation_limit] to pg and mysql2

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
@@ -31,6 +31,7 @@ module OpenTelemetry
         option :enable_sql_obfuscation, default: false, validate: :boolean
         option :db_statement, default: :include, validate: %I[omit include obfuscate]
         option :span_name, default: :statement_type, validate: %I[statement_type db_name db_operation_and_name]
+        option :obfuscation_limit, default: 2000, validate: :integer
 
         private
 

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -73,7 +73,7 @@ module OpenTelemetry
           def obfuscate_sql(sql)
             if sql.size > config[:obfuscation_limit]
               truncated_sql = sql[..sql.index(generated_mysql_regex) - 1]
-              truncated_sql + "\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+              truncated_sql + "...\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
             else
               obfuscated = OpenTelemetry::Common::Utilities.utf8_encode(sql, binary: true)
               obfuscated = obfuscated.gsub(generated_mysql_regex, '?')

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -30,6 +30,7 @@ module OpenTelemetry
 
           QUERY_NAME_RE = Regexp.new("^(#{QUERY_NAMES.join('|')})", Regexp::IGNORECASE)
 
+          # From: https://github.com/newrelic/newrelic-ruby-agent/blob/0235b288d85b8bc795bdc1a24621dd9f84cfef45/lib/new_relic/agent/database/obfuscation_helpers.rb#L9-L34
           COMPONENTS_REGEX_MAP = {
             single_quotes: /'(?:[^']|'')*?(?:\\'.*|'(?!'))/,
             double_quotes: /"(?:[^"]|"")*?(?:\\".*|"(?!"))/,
@@ -70,8 +71,9 @@ module OpenTelemetry
           private
 
           def obfuscate_sql(sql)
-            if sql.size > 2000
-              'SQL query too large to remove sensitive data ...'
+            if sql.size > config[:obfuscation_limit]
+              truncated_sql = sql[..sql.index(generated_mysql_regex) - 1]
+              truncated_sql + "\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
             else
               obfuscated = OpenTelemetry::Common::Utilities.utf8_encode(sql, binary: true)
               obfuscated = obfuscated.gsub(generated_mysql_regex, '?')

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -172,6 +172,20 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_s
       end
+
+      describe 'with obfuscation_limit' do
+        let(:config) { { db_statement: :obfuscate, obfuscation_limit: 10 } }
+
+        it 'truncates SQL using config limit' do
+          sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+          obfuscated_sql = "SELECT * from users where users.id = \nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+          expect do
+            client.query(sql)
+          end.must_raise Mysql2::Error
+
+          _(span.attributes['db.statement']).must_equal obfuscated_sql
+        end
+      end
     end
 
     describe 'when db_statement set as omit' do

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -178,7 +178,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
         it 'truncates SQL using config limit' do
           sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
-          obfuscated_sql = "SELECT * from users where users.id = \nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+          obfuscated_sql = "SELECT * from users where users.id = ...\nSQL truncated (> 10 characters)"
           expect do
             client.query(sql)
           end.must_raise Mysql2::Error

--- a/instrumentation/pg/example/pg.rb
+++ b/instrumentation/pg/example/pg.rb
@@ -7,7 +7,7 @@ Bundler.require
 
 ENV['OTEL_TRACES_EXPORTER'] = 'console'
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::PG', enable_sql_obfuscation: true
+  c.use 'OpenTelemetry::Instrumentation::PG', db_statement: :obfuscate
 end
 
 conn = PG::Connection.open(

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -44,6 +44,7 @@ module OpenTelemetry
         option :enable_sql_obfuscation, default: false, validate: :boolean
         option :enable_statement_attribute, default: true, validate: :boolean
         option :db_statement, default: :include, validate: %I[omit include obfuscate]
+        option :obfuscation_limit, default: 2000, validate: :integer
 
         private
 

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -107,8 +107,10 @@ module OpenTelemetry
           def obfuscate_sql(sql)
             return sql unless config[:db_statement] == :obfuscate
 
-            # Borrowed from opentelemetry-instrumentation-mysql2
-            return 'SQL query too large to remove sensitive data ...' if sql.size > 2000
+            if sql.size > config[:obfuscation_limit]
+              truncated_sql = sql[..sql.index(generated_postgres_regex) - 1]
+              return truncated_sql + "\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+            end
 
             # From:
             # https://github.com/newrelic/newrelic-ruby-agent/blob/9787095d4b5b2d8fcaf2fdbd964ed07c731a8b6b/lib/new_relic/agent/database/obfuscator.rb

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -109,7 +109,7 @@ module OpenTelemetry
 
             if sql.size > config[:obfuscation_limit]
               truncated_sql = sql[..sql.index(generated_postgres_regex) - 1]
-              return truncated_sql + "\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+              return truncated_sql + "...\nSQL truncated (> #{config[:obfuscation_limit]} characters)"
             end
 
             # From:

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -275,7 +275,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
 
         it 'truncates SQL using config limit' do
           sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
-          obfuscated_sql = "SELECT * from users where users.id = \nSQL truncated (> #{config[:obfuscation_limit]} characters)"
+          obfuscated_sql = "SELECT * from users where users.id = ...\nSQL truncated (> 10 characters)"
           expect do
             client.exec(sql)
           end.must_raise PG::UndefinedTable


### PR DESCRIPTION
Enable the following:

```ruby
c.use 'OpenTelemetry::Instrumentation::PG', db_statement: :obfuscate, obfuscation_limit: 1000
```
to allow users to control obfuscation performance via a configurable limit.

Additionally, when SQL is over the limit, truncate it to the first regex match to make output more useful for analysis:
```
SELECT * from users where users.id =... 
SQL truncated (> 1000 characters)
```