### PR TITLE
chore: Use Bundler bootstrap dependencies

### DIFF
--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -4,7 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -4,17 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'rails'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
+require 'opentelemetry-instrumentation-action_pack'
 require 'minitest/autorun'
 require 'rack/test'
-
 require 'test_helpers/app_config'
-require_relative '../lib/opentelemetry/instrumentation'
 
 # Global opentelemetry-sdk setup
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -9,7 +9,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
 end

--- a/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/instrumentation_test.rb
+++ b/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/instrumentation_test.rb
@@ -6,8 +6,6 @@
 
 require 'test_helper'
 
-require_relative '../../../../lib/opentelemetry/instrumentation/action_view'
-
 describe OpenTelemetry::Instrumentation::ActionView do
   let(:instrumentation) { OpenTelemetry::Instrumentation::ActionView::Instrumentation.instance }
 

--- a/instrumentation/action_view/test/test_helper.rb
+++ b/instrumentation/action_view/test/test_helper.rb
@@ -4,16 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'pry'
-require 'minitest/autorun'
-require 'webmock/minitest'
-
-require 'rails'
 require 'action_view'
 require 'opentelemetry-instrumentation-action_view'
+require 'minitest/autorun'
+require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -5,15 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'active_job'
 require 'opentelemetry-instrumentation-active_job'
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
 require 'minitest/autorun'
 require 'webmock/minitest'
-
-require 'pry'
 
 class TestJob < ::ActiveJob::Base
   def perform; end

--- a/instrumentation/active_model_serializers/test/test_helper.rb
+++ b/instrumentation/active_model_serializers/test/test_helper.rb
@@ -4,17 +4,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'active_support/all'
-require 'active_model_serializers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'active_support/all'
+require 'opentelemetry-instrumentation-active_model_serializers'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
-
-require_relative '../lib/opentelemetry-instrumentation-active_model_serializers'
 
 # disable logging
 ActiveModelSerializers.logger.level = Logger::Severity::UNKNOWN

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -3,14 +3,15 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'active_record'
 require 'opentelemetry-instrumentation-active_record'
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'pry'
 
 # Global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/active_support/test/test_helper.rb
+++ b/instrumentation/active_support/test/test_helper.rb
@@ -4,16 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'opentelemetry-instrumentation-active_support'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'pry'
-
-require 'rails'
-
-require 'opentelemetry-instrumentation-active_support'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/all/test/test_helper.rb
+++ b/instrumentation/all/test/test_helper.rb
@@ -4,4 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'minitest/autorun'

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'aws-sdk'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'opentelemetry-instrumentation-aws_sdk'
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/base/test/test_helper.rb
+++ b/instrumentation/base/test/test_helper.rb
@@ -4,12 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'simplecov'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 SimpleCov.start
 SimpleCov.minimum_coverage 85
 
-require 'opentelemetry/instrumentation'
-require 'opentelemetry-test-helpers'
+require 'opentelemetry-instrumentation-base'
 require 'minitest/autorun'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/instrumentation/bunny/test/test_helper.rb
+++ b/instrumentation/bunny/test/test_helper.rb
@@ -4,13 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'securerandom'
-require 'bunny'
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
 require 'minitest/autorun'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/concurrent_ruby/test/test_helper.rb
+++ b/instrumentation/concurrent_ruby/test/test_helper.rb
@@ -7,6 +7,8 @@
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
+require 'concurrent'
+
 require 'minitest/autorun'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/concurrent_ruby/test/test_helper.rb
+++ b/instrumentation/concurrent_ruby/test/test_helper.rb
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'concurrent'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/dalli/test/test_helper.rb
+++ b/instrumentation/dalli/test/test_helper.rb
@@ -4,13 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'dalli'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'pry'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -4,18 +4,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'active_support/core_ext/kernel/reporting'
-require 'delayed_job'
-require 'delayed_job_active_record'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'opentelemetry-instrumentation-delayed_job'
+require 'active_support/core_ext/kernel/reporting'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
-
-require_relative '../lib/opentelemetry-instrumentation-delayed_job'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/ethon/test/test_helper.rb
+++ b/instrumentation/ethon/test/test_helper.rb
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'ethon'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'excon'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -4,15 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'faraday'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-require_relative '../lib/opentelemetry-instrumentation-faraday'
+require 'opentelemetry-instrumentation-faraday'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -4,12 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'graphql'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'
 

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -3,15 +3,13 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-require 'http'
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
-require 'pry'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/http_client/test/test_helper.rb
+++ b/instrumentation/http_client/test/test_helper.rb
@@ -3,12 +3,10 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-require 'httpclient'
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'
 

--- a/instrumentation/koala/test/test_helper.rb
+++ b/instrumentation/koala/test/test_helper.rb
@@ -4,16 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'koala'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
 
-require_relative '../lib/opentelemetry-instrumentation-koala'
+require 'opentelemetry-instrumentation-koala'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/lmdb/test/test_helper.rb
+++ b/instrumentation/lmdb/test/test_helper.rb
@@ -3,12 +3,10 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-require 'lmdb'
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'
 

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -4,17 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'pry'
-require 'mongo'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
 
-require_relative '../lib/opentelemetry-instrumentation-mongo'
+require 'opentelemetry-instrumentation-mongo'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/mysql2/test/test_helper.rb
+++ b/instrumentation/mysql2/test/test_helper.rb
@@ -4,11 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'mysql2'
-require 'opentelemetry-test-helpers'
-require 'opentelemetry/sdk'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'minitest/autorun'
-require 'pry'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -5,9 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'net/http'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -4,15 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'active_record'
-require 'pg'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'active_record'
 
 require 'minitest/autorun'
-
-require 'pry'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/que/test/test_helper.rb
+++ b/instrumentation/que/test/test_helper.rb
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'opentelemetry-instrumentation-que'
 
 require 'minitest/autorun'
-
-require_relative '../lib/opentelemetry-instrumentation-que'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/racecar/test/test_helper.rb
+++ b/instrumentation/racecar/test/test_helper.rb
@@ -4,7 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'active_support'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
@@ -19,6 +22,3 @@ OpenTelemetry::SDK.configure do |c|
   c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
   c.add_span_processor span_processor
 end
-
-require 'racecar'
-require 'active_support'

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -4,17 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'rack'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-sdk-experimental'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-require_relative '../lib/opentelemetry-instrumentation-rack'
+require 'opentelemetry-instrumentation-rack'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -4,17 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'rails'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
 require 'minitest/autorun'
 require 'rack/test'
 require 'test_helpers/app_config'
 
-require_relative '../../lib/opentelemetry/instrumentation'
+require 'opentelemetry-instrumentation-rails'
 
 # Global opentelemetry-sdk setup
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/rails/test/railtie/test_helper.rb
+++ b/instrumentation/rails/test/railtie/test_helper.rb
@@ -8,10 +8,10 @@
 ENV['RACK_ENV'] = 'test'
 ENV['RAILS_ENV'] = 'test'
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require_relative '../../test/railtie/dummy/config/environment'
 require 'rails/test_help'
 
-require 'simplecov'
 SimpleCov.start

--- a/instrumentation/rake/test/test_helper.rb
+++ b/instrumentation/rake/test/test_helper.rb
@@ -4,7 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/rdkafka/test/test_helper.rb
+++ b/instrumentation/rdkafka/test/test_helper.rb
@@ -4,13 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-
-require 'rdkafka'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/redis/test/test_helper.rb
+++ b/instrumentation/redis/test/test_helper.rb
@@ -4,11 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'redis'
-require 'redis-client'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/resque/test/test_helper.rb
+++ b/instrumentation/resque/test/test_helper.rb
@@ -4,14 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'resque'
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'pry'
+require 'active_job'
+
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'active_job'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/restclient/test/test_helper.rb
+++ b/instrumentation/restclient/test/test_helper.rb
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'rest-client'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -3,6 +3,8 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# This gem does not use Bundler to require gems because it is testing confilicting features between rspec and minitest.
 require 'opentelemetry/sdk'
 require 'opentelemetry-test-helpers'
 

--- a/instrumentation/ruby_kafka/test/test_helper.rb
+++ b/instrumentation/ruby_kafka/test/test_helper.rb
@@ -4,12 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'kafka'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
-
-require 'pry'
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -4,16 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'sidekiq'
-require 'sidekiq/testing'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'active_job'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
-require 'active_job'
-require 'pry'
+require 'sidekiq/testing'
 
 # Sidekiq changed its loading mechanism in 6.5.0, but we still want to test the
 # older versions. We can eliminate the first part of this conditional when we no

--- a/instrumentation/sinatra/test/test_helper.rb
+++ b/instrumentation/sinatra/test/test_helper.rb
@@ -4,15 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'sinatra'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'rack/test'
 
-require_relative '../lib/opentelemetry-instrumentation-sinatra'
+require 'opentelemetry-instrumentation-sinatra'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -6,14 +6,11 @@
 
 ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 
-require 'trilogy'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
-require 'pry'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/propagator/ottrace/test/test_helper.rb
+++ b/propagator/ottrace/test/test_helper.rb
@@ -4,15 +4,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'opentelemetry-propagator-ottrace'
+require 'minitest/autorun'
+
 if ENV['ENABLE_COVERAGE'].to_i.positive?
   require 'simplecov'
   SimpleCov.start
   SimpleCov.minimum_coverage 85
 end
-
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
-require 'minitest/autorun'
-require 'opentelemetry-api'
-require 'opentelemetry-propagator-ottrace'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/propagator/xray/test/test_helper.rb
+++ b/propagator/xray/test/test_helper.rb
@@ -4,7 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'minitest/autorun'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 require 'opentelemetry-propagator-xray'
+require 'minitest/autorun'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/resource_detectors/test/test_helper.rb
+++ b/resource_detectors/test/test_helper.rb
@@ -4,12 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'simplecov'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
 SimpleCov.start
 
-require 'opentelemetry/resource/detectors'
+require 'opentelemetry-resource_detectors'
 require 'minitest/autorun'
-require 'pry'
 require 'webmock/minitest'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)


### PR DESCRIPTION
This change leverages bundler to require all of the appropriate dependencies uses in tests instead of requireing them manually.