### PR TITLE
chore: Add Default Noisy Error Handler to tests

### DIFF
--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -14,5 +14,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -22,6 +22,7 @@ span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPO
 
 OpenTelemetry::SDK.configure do |c|
   c.logger = Logger.new('/dev/null')
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::ActionPack'
   c.add_span_processor span_processor
 end

--- a/instrumentation/action_view/test/test_helper.rb
+++ b/instrumentation/action_view/test/test_helper.rb
@@ -20,6 +20,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::ActionView'
   c.add_span_processor span_processor
 end

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -78,6 +78,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::ActiveJob'
   c.add_span_processor span_processor
 end

--- a/instrumentation/active_model_serializers/test/test_helper.rb
+++ b/instrumentation/active_model_serializers/test/test_helper.rb
@@ -24,6 +24,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -17,6 +17,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
   c.add_span_processor span_processor
 end

--- a/instrumentation/active_support/test/test_helper.rb
+++ b/instrumentation/active_support/test/test_helper.rb
@@ -20,6 +20,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
   c.add_span_processor span_processor
 end

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -19,6 +19,7 @@ span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPO
 OpenTelemetry.logger = Logger.new(File::NULL)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.use 'OpenTelemetry::Instrumentation::AwsSdk'
   c.add_span_processor span_processor
 end

--- a/instrumentation/bunny/test/test_helper.rb
+++ b/instrumentation/bunny/test/test_helper.rb
@@ -18,5 +18,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 SPAN_PROCESSOR = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor SPAN_PROCESSOR
 end

--- a/instrumentation/concurrent_ruby/test/test_helper.rb
+++ b/instrumentation/concurrent_ruby/test/test_helper.rb
@@ -16,5 +16,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/dalli/test/test_helper.rb
+++ b/instrumentation/dalli/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
+++ b/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
@@ -18,6 +18,8 @@ module OpenTelemetry
 
               attributes = build_attributes(job)
               attributes['messaging.operation'] = 'send'
+              attributes.compact!
+
               tracer.in_span("#{job_queue(job)} send", attributes: attributes, kind: :producer) do |span|
                 yield job
                 span.set_attribute('messaging.message_id', job.id.to_s)
@@ -33,6 +35,8 @@ module OpenTelemetry
               attributes['messaging.delayed_job.locked_by'] = job.locked_by if job.locked_by
               attributes['messaging.operation'] = 'process'
               attributes['messaging.message_id'] = job.id.to_s
+              attributes.compact!
+
               tracer.in_span("#{job_queue(job)} process", attributes: attributes, kind: :consumer) do |span|
                 add_events(span, job)
                 yield job

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -22,6 +22,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -84,9 +84,12 @@ module OpenTelemetry
 
           def span_creation_attributes(method)
             instrumentation_attrs = {
-              'http.method' => method,
-              'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url)
+              'http.method' => method
             }
+
+            http_url = OpenTelemetry::Common::Utilities.cleanse_url(url)
+            instrumentation_attrs['http.url'] = http_url if http_url
+
             config = Ethon::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
             instrumentation_attrs.merge!(

--- a/instrumentation/ethon/test/test_helper.rb
+++ b/instrumentation/ethon/test/test_helper.rb
@@ -16,5 +16,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -19,5 +19,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -18,5 +18,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -18,5 +18,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/http_client/test/test_helper.rb
+++ b/instrumentation/http_client/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/koala/test/test_helper.rb
+++ b/instrumentation/koala/test/test_helper.rb
@@ -20,5 +20,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/lmdb/test/test_helper.rb
+++ b/instrumentation/lmdb/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -21,6 +21,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/mysql2/test/test_helper.rb
+++ b/instrumentation/mysql2/test/test_helper.rb
@@ -15,5 +15,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -19,5 +19,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/que/test/test_helper.rb
+++ b/instrumentation/que/test/test_helper.rb
@@ -31,6 +31,7 @@ class JobThatFails < Que::Job
 end
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/racecar/test/test_helper.rb
+++ b/instrumentation/racecar/test/test_helper.rb
@@ -15,6 +15,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -21,5 +21,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -21,6 +21,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.logger = ::Logger.new(File::NULL)
   c.use_all
   c.add_span_processor span_processor

--- a/instrumentation/rake/test/test_helper.rb
+++ b/instrumentation/rake/test/test_helper.rb
@@ -14,5 +14,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/rdkafka/test/test_helper.rb
+++ b/instrumentation/rdkafka/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/redis/test/test_helper.rb
+++ b/instrumentation/redis/test/test_helper.rb
@@ -20,5 +20,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/resque/test/test_helper.rb
+++ b/instrumentation/resque/test/test_helper.rb
@@ -18,6 +18,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/restclient/test/test_helper.rb
+++ b/instrumentation/restclient/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -17,5 +17,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/ruby_kafka/test/test_helper.rb
+++ b/instrumentation/ruby_kafka/test/test_helper.rb
@@ -18,6 +18,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 SPAN_PROCESSOR = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor SPAN_PROCESSOR
 end
 

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -29,6 +29,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end
 

--- a/instrumentation/sinatra/test/test_helper.rb
+++ b/instrumentation/sinatra/test/test_helper.rb
@@ -19,5 +19,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -20,5 +20,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end


### PR DESCRIPTION
This will help identify issues with instrumentation during testing, e.g. the use of invalid span attriributes.

Related https://github.com/rails/rails/pull/46258