### PR TITLE
chore: Limit GraphQL 1.x support

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -4,16 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'graphql-1.11' do
-  gem 'graphql', '~> 1.11.0'
-end
-
-appraise 'graphql-1.10' do
-  gem 'graphql', '~> 1.10.0'
+appraise 'graphql-1.x' do
+  gem 'graphql', '~> 1.13'
 end
 
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if RUBY_VERSION < '3'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('3.0.0')
   appraise 'graphql-1.9' do
     gem 'graphql', '~> 1.9.0'
   end

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -11,6 +11,12 @@ module OpenTelemetry
     module GraphQL
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
+        MAX_VERSION = '2.0.0'
+
+        compatible do
+          gem_version < Gem::Version.new(MAX_VERSION)
+        end
+
         install do |config|
           require_dependencies
           install_tracer(config)
@@ -40,6 +46,10 @@ module OpenTelemetry
         option :enable_platform_resolve_type, default: false, validate: :boolean
 
         private
+
+        def gem_version
+          Gem::Version.new(::GraphQL::VERSION)
+        end
 
         def require_dependencies
           require_relative 'tracers/graphql_tracer'


### PR DESCRIPTION
We have not tested this instrumentation against the 2.0 versions of the GraphQL gem. 

Adding support for 2.x results in build failures. This change mitigates errors tying to use the instrumentation with an incompatible versions of the gem. 

Related to https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/253