### PR TITLE
chore: Add GraphQL 2.x support

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -8,10 +8,6 @@ appraise 'graphql-1.11' do
   gem 'graphql', '~> 1.11.0'
 end
 
-appraise 'graphql-1.10' do
-  gem 'graphql', '~> 1.10.0'
-end
-
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
 if RUBY_VERSION < '3'
   appraise 'graphql-1.9' do

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -4,13 +4,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'graphql-1.11' do
-  gem 'graphql', '~> 1.11.0'
-end
+current_ruby_version = Gem::Version.new(RUBY_VERSION)
 
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if RUBY_VERSION < '3'
+if current_ruby_version < Gem::Version.new('3.0.0')
   appraise 'graphql-1.9' do
     gem 'graphql', '~> 1.9.0'
+  end
+else
+  appraise 'graphql-1.13' do
+    gem 'graphql', '~> 1.13'
+  end
+
+  appraise 'graphql-2.0.x' do
+    gem 'graphql', '~> 2.0.16'
   end
 end

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -11,6 +11,10 @@ module OpenTelemetry
     module GraphQL
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
+        compatible do
+          gem_version < Gem::Version.new('3.0.0')
+        end
+
         install do |config|
           require_dependencies
           install_tracer(config)
@@ -40,6 +44,10 @@ module OpenTelemetry
         option :enable_platform_resolve_type, default: false, validate: :boolean
 
         private
+
+        def gem_version
+          Gem::Version.new(::GraphQL::VERSION)
+        end
 
         def require_dependencies
           require_relative 'tracers/graphql_tracer'

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'graphql', '~> 1.11'
+  spec.add_development_dependency 'graphql', '>= 1.9.0', '< 3.0.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -237,14 +237,10 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
 
   class SomeOtherGraphQLAppSchema < ::GraphQL::Schema
     query(::OtherQueryType)
-    use GraphQL::Execution::Interpreter
-    use GraphQL::Analysis::AST
   end
 
   class SomeGraphQLAppSchema < ::GraphQL::Schema
     query(::QueryType)
-    use GraphQL::Execution::Interpreter
-    use GraphQL::Analysis::AST
     orphan_types Car
 
     def self.resolve_type(_type, _obj, _ctx)

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -176,7 +176,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
   # These fields are only supported as of version 1.10.0
   # https://github.com/rmosolgo/graphql-ruby/blob/v1.10.0/CHANGELOG.md#new-features-1
   def supports_authorized_and_resolved_types?
-    Gem.loaded_specs['graphql'].version >= Gem::Version.new('1.10.0')
+    Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.10.0')
   end
 
   module Old
@@ -245,6 +245,15 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
 
     def self.resolve_type(_type, _obj, _ctx)
       Car
+    end
+  end
+
+  if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.10.0')
+    [SomeOtherGraphQLAppSchema, SomeGraphQLAppSchema].each do |schema|
+      schema.class_eval do
+        use GraphQL::Execution::Interpreter
+        use GraphQL::Analysis::AST
+      end
     end
   end
 end


### PR DESCRIPTION
Adds appraisals and constraint checks for versions between 1.9-2.0

Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/253

Removes deprecation warnings:

```console
GraphQL::Execution::Interpreter is now the default; remove `use GraphQL::Execution::Interpreter` from the schema definition (/Users/arielvalentin/github/opentelemetry-ruby-contrib/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb:240:in `<class:SomeOtherGraphQLAppSchema>')
GraphQL::Analysis::AST is now the default; remove `use GraphQL::Analysis::AST` from the schema definition (/Users/arielvalentin/github/opentelemetry-ruby-contrib/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb:241:in `<class:SomeOtherGraphQLAppSchema>')
GraphQL::Execution::Interpreter is now the default; remove `use GraphQL::Execution::Interpreter` from the schema definition (/Users/arielvalentin/github/opentelemetry-ruby-contrib/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb:246:in `<class:SomeGraphQLAppSchema>')
GraphQL::Analysis::AST is now the default; remove `use GraphQL::Analysis::AST` from the schema definition (/Users/arielvalentin/github/opentelemetry-ruby-contrib/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb:247:in `<class:SomeGraphQLAppSchema>')
Run options: --seed 19585
```