### PR TITLE
Check if env['sinatra.error'] exists before recording it

### DIFF
--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
             sinatra_response = ::Sinatra::Response.new([], response.first)
             return unless sinatra_response.server_error?
 
-            span.record_exception(env['sinatra.error'])
+            span.record_exception(env['sinatra.error']) if env['sinatra.error']
             span.status = OpenTelemetry::Trace::Status.error
           end
         end


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby/issues/1420

Needs tests, I would like tips on if that would be required since afaict there aren't tests for this type of guard code. Thanks!