### PR TITLE
chore: fix bad merges

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,9 +57,3 @@ Lint/RedundantRequireStatement:
   Enabled: false
 Style/CollectionCompact:
   Enabled: false
-Style/GlobalStdStream:
-  Enabled: false
-Style/GlobalStdStream:
-  Enabled: false
-Style/QuotedSymbols:
-  Enabled: false


### PR DESCRIPTION
merged Rubocop rules that were already enabled