### PR TITLE
redis: Handle redis with unix socket configuration

### DIFF
--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/middlewares/redis_client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/middlewares/redis_client.rb
@@ -43,9 +43,11 @@ module OpenTelemetry
           def span_attributes(redis_config)
             attributes = {
               'db.system' => 'redis',
-              'net.peer.name' => redis_config.host,
-              'net.peer.port' => redis_config.port
             }
+
+            redis_config.host.tap { attributes['net.peer.name'] = _1 if _1 }
+            redis_config.port.tap { attributes['net.peer.port'] = _1 if _1 }
+            redis_config.path.tap { attributes['net.peer.name'] = "unix://#{_1}" if _1 }
 
             attributes['db.redis.database_index'] = redis_config.db unless redis_config.db.zero?
             attributes['peer.service'] = instrumentation.config[:peer_service] if instrumentation.config[:peer_service]

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/redis_v4_client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/redis_v4_client.rb
@@ -16,14 +16,13 @@ module OpenTelemetry
           def process(commands) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
             return super unless instrumentation_config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
 
-            host = options[:host]
-            port = options[:port]
-
             attributes = {
               'db.system' => 'redis',
-              'net.peer.name' => host,
-              'net.peer.port' => port
             }
+
+            options[:host].tap { attributes['net.peer.name'] = _1 if _1 }
+            options[:port].tap { attributes['net.peer.port'] = _1 if _1 }
+            options[:path].tap { attributes['net.peer.name'] = "unix://#{_1}" if _1 }
 
             attributes['db.redis.database_index'] = options[:db] unless options[:db].zero?
             attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]


### PR DESCRIPTION
The instrumentation package expected to always have host and port configured, which isn't the case in path was set. Only setting the peer name in case it has been configured.