### PR TITLE
chore: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,179 @@
+---
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/propagator/ottrace"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/propagator/xray"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/que"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/http_client"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/mysql2"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/sinatra"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/sidekiq"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/dalli"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/racecar"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/redis"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/ruby_kafka"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/concurrent_ruby"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/active_model_serializers"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/rake"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/action_view"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/bunny"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/all"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/aws_sdk"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/active_record"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/faraday"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/resque"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/rdkafka"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/pg"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/ethon"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/lmdb"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/active_support"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/http"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/graphql"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/trilogy"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/net_http"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/rack"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/action_pack"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/mongo"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/restclient"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/koala"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/active_job"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/excon"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/rspec"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/base"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/delayed_job"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/rails"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/resource_detectors"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Dependabot does not support subdirectories and I did not want to bother with scripting the output:

- https://github.com/dependabot/dependabot-core/issues/2178

Dependabot does not support YAML aliases:

- https://github.com/dependabot/dependabot-core/issues/1582