### PR TITLE
Normalize GraphQL span names for easier aggregation analysis

### DIFF
--- a/instrumentation/graphql/README.md
+++ b/instrumentation/graphql/README.md
@@ -41,6 +41,11 @@ OpenTelemetry::SDK.configure do |c|
     enable_platform_authorized: false,
     # enable_platform_resolve_type maps to the resolve_type and resolve_type_lazy keys
     enable_platform_resolve_type: false
+
+    # Controls if platform tracing (field/authorized/resolve_type)
+    # should use the legacy span names (e.g. "MyType.myField") or the
+    # new normalized span names (e.g. "graphql.execute_field").
+    legacy_platform_span_names: false
   }
 end
 ```

--- a/instrumentation/graphql/README.md
+++ b/instrumentation/graphql/README.md
@@ -40,7 +40,7 @@ OpenTelemetry::SDK.configure do |c|
     # enable_platform_authorized maps to the authorized and authorized_lazy keys
     enable_platform_authorized: false,
     # enable_platform_resolve_type maps to the resolve_type and resolve_type_lazy keys
-    enable_platform_resolve_type: false
+    enable_platform_resolve_type: false,
 
     # Controls if platform tracing (field/authorized/resolve_type)
     # should use the legacy span names (e.g. "MyType.myField") or the

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -47,7 +47,7 @@ module OpenTelemetry
         option :enable_platform_field,        default: false, validate: :boolean
         option :enable_platform_authorized,   default: false, validate: :boolean
         option :enable_platform_resolve_type, default: false, validate: :boolean
-        option :legacy_platform_span_names,   default: true,  validate: :boolean
+        option :legacy_platform_span_names,   default: false, validate: :boolean
 
         private
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -35,6 +35,11 @@ module OpenTelemetry
         # The enable_platform_resolve_type key expects a boolean value,
         # and enables the tracing of "resolve_type" and "resolve_type_lazy".
         #
+        # The legacy_platform_span_names key expects a boolean value,
+        # and controls if platform tracing (field/authorized/resolve_type)
+        # should use the legacy span names (e.g. "MyType.myField") or the
+        # new normalized span names (e.g. "graphql.execute_field").
+        #
         # The schemas key expects an array of Schemas, and is used to specify
         # which schemas are to be instrumented. If this value is not supplied
         # the default behaviour is to instrument all schemas.
@@ -42,6 +47,7 @@ module OpenTelemetry
         option :enable_platform_field,        default: false, validate: :boolean
         option :enable_platform_authorized,   default: false, validate: :boolean
         option :enable_platform_resolve_type, default: false, validate: :boolean
+        option :legacy_platform_span_names,   default: true,  validate: :boolean
 
         private
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -86,14 +86,14 @@ module OpenTelemetry
             attributes = {}
             case key
             when 'execute_field', 'execute_field_lazy'
-              attributes['graphql.field.parent'] = data[:owner].graphql_name # owner is the concrete type, not interface
-              attributes['graphql.field.name'] = data[:field].graphql_name
+              attributes['graphql.field.parent'] = data[:owner]&.graphql_name # owner is the concrete type, not interface
+              attributes['graphql.field.name'] = data[:field]&.graphql_name
               attributes['graphql.lazy'] = key == 'execute_field_lazy'
             when 'authorized', 'authorized_lazy'
-              attributes['graphql.type.name'] = data.fetch(:type).graphql_name
+              attributes['graphql.type.name'] = data[:type]&.graphql_name
               attributes['graphql.lazy'] = key == 'authorized_lazy'
             when 'resolve_type', 'resolve_type_lazy'
-              attributes['graphql.type.name'] = data.fetch(:type).graphql_name
+              attributes['graphql.type.name'] = data[:type]&.graphql_name
               attributes['graphql.lazy'] = key == 'resolve_type_lazy'
             when 'execute_query'
               attributes['graphql.operation.name'] = data[:query].selected_operation_name if data[:query].selected_operation_name

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
             GraphQL::Instrumentation.instance.config
           end
 
-          def attributes_for(key, data)
+          def attributes_for(key, data) # rubocop:disable Metrics/CyclomaticComplexity
             attributes = {}
             case key
             when 'execute_field', 'execute_field_lazy'

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -45,19 +45,31 @@ module OpenTelemetry
           def platform_field_key(type, field)
             return unless config[:enable_platform_field]
 
-            "#{type.graphql_name}.#{field.graphql_name}"
+            if config[:legacy_platform_span_names]
+              "#{type.graphql_name}.#{field.graphql_name}"
+            else
+              'graphql.execute_field'
+            end
           end
 
           def platform_authorized_key(type)
             return unless config[:enable_platform_authorized]
 
-            "#{type.graphql_name}.authorized"
+            if config[:legacy_platform_span_names]
+              "#{type.graphql_name}.authorized"
+            else
+              'graphql.authorized'
+            end
           end
 
           def platform_resolve_type_key(type)
             return unless config[:enable_platform_resolve_type]
 
-            "#{type.graphql_name}.resolve_type"
+            if config[:legacy_platform_span_names]
+              "#{type.graphql_name}.resolve_type"
+            else
+              'graphql.resolve_type'
+            end
           end
 
           private
@@ -73,6 +85,16 @@ module OpenTelemetry
           def attributes_for(key, data)
             attributes = {}
             case key
+            when 'execute_field', 'execute_field_lazy'
+              attributes['graphql.field.parent'] = data[:owner].graphql_name # owner is the concrete type, not interface
+              attributes['graphql.field.name'] = data[:field].graphql_name
+              attributes['graphql.lazy'] = key == 'execute_field_lazy'
+            when 'authorized', 'authorized_lazy'
+              attributes['graphql.type.name'] = data.fetch(:type).graphql_name
+              attributes['graphql.lazy'] = key == 'authorized_lazy'
+            when 'resolve_type', 'resolve_type_lazy'
+              attributes['graphql.type.name'] = data.fetch(:type).graphql_name
+              attributes['graphql.lazy'] = key == 'resolve_type_lazy'
             when 'execute_query'
               attributes['graphql.operation.name'] = data[:query].selected_operation_name if data[:query].selected_operation_name
               attributes['graphql.operation.type'] = data[:query].selected_operation.operation_type

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -128,6 +128,35 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
+    describe 'when platform_field is enabled without legacy naming' do
+      let(:config) { { enable_platform_field: true, legacy_platform_span_names: false } }
+
+      it 'traces execute_field' do
+        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+        span = spans.find do |s|
+          s.name == 'graphql.execute_field' &&
+            s.attributes['graphql.field.parent'] == 'Query' &&
+            s.attributes['graphql.field.name'] == 'resolvedField'
+        end
+        _(span).wont_be_nil
+      end
+
+      it 'includes attributes' do
+        expected_attributes = {
+          'graphql.field.parent' => 'Car', # type name, not interface
+          'graphql.field.name' => 'model',
+          'graphql.lazy' => false
+        }
+
+        SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+
+        span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+        _(span).wont_be_nil
+        _(span.attributes.to_h).must_equal(expected_attributes)
+      end
+    end
+
     describe 'when platform_authorized is enabled' do
       let(:config) { { enable_platform_authorized: true } }
 
@@ -143,6 +172,41 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
+    describe 'when platform_authorized is enabled without legacy naming' do
+      let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: false } }
+
+      it 'traces .authorized' do
+        skip unless supports_authorized_and_resolved_types?
+        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+        span = spans.find do |s|
+          s.name == 'graphql.authorized' &&
+            s.attributes['graphql.type.name'] == 'Query'
+        end
+        _(span).wont_be_nil
+
+        span = spans.find do |s|
+          s.name == 'graphql.authorized' &&
+            s.attributes['graphql.type.name'] == 'SlightlyComplex'
+        end
+        _(span).wont_be_nil
+      end
+
+      it 'includes attributes' do
+        skip unless supports_authorized_and_resolved_types?
+        expected_attributes = {
+          'graphql.type.name' => 'OtherQuery',
+          'graphql.lazy' => false
+        }
+
+        SomeOtherGraphQLAppSchema.execute('{ simpleField }')
+
+        span = spans.find { |s| s.name == 'graphql.authorized' }
+        _(span).wont_be_nil
+        _(span.attributes.to_h).must_equal(expected_attributes)
+      end
+    end
+
     describe 'when platform_resolve_type is enabled' do
       let(:config) { { enable_platform_resolve_type: true } }
 
@@ -152,6 +216,32 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
 
         span = spans.find { |s| s.name == 'Vehicle.resolve_type' }
         _(span).wont_be_nil
+      end
+    end
+
+    describe 'when platform_resolve_type is enabled without legacy naming' do
+      let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: false } }
+
+      it 'traces .resolve_type' do
+        skip unless supports_authorized_and_resolved_types?
+        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+        span = spans.find { |s| s.name == 'graphql.resolve_type' && s.attributes['graphql.type.name'] == 'Vehicle' }
+        _(span).wont_be_nil
+      end
+
+      it 'includes attributes' do
+        skip unless supports_authorized_and_resolved_types?
+        expected_attributes = {
+          'graphql.type.name' => 'Vehicle',
+          'graphql.lazy' => false
+        }
+
+        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+        span = spans.find { |s| s.name == 'graphql.resolve_type' }
+        _(span).wont_be_nil
+        _(span.attributes.to_h).must_equal(expected_attributes)
       end
     end
 
@@ -182,11 +272,13 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
   end
 
   module Old
-    Truck = Struct.new(:price)
+    Truck = Struct.new(:price, :model)
   end
 
   module Vehicle
     include GraphQL::Schema::Interface
+
+    field :model, String, null: true, trace: true # Allow for this scalar to be traced
   end
 
   class Car < GraphQL::Schema::Object
@@ -222,7 +314,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
     field :vehicle, Vehicle, null: true
 
     def vehicle
-      Old::Truck.new(50)
+      Old::Truck.new(50, 'Model T')
     end
 
     def simple_field

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -117,8 +117,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_field is enabled' do
-      let(:config) { { enable_platform_field: true } }
+    describe 'when platform_field is enabled with legacy naming' do
+      let(:config) { { enable_platform_field: true, legacy_platform_span_names: true } }
 
       it 'traces execute_field' do
         SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
@@ -128,8 +128,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_field is enabled without legacy naming' do
-      let(:config) { { enable_platform_field: true, legacy_platform_span_names: false } }
+    describe 'when platform_field is enabled' do
+      let(:config) { { enable_platform_field: true } }
 
       it 'traces execute_field' do
         SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
@@ -157,8 +157,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_authorized is enabled' do
-      let(:config) { { enable_platform_authorized: true } }
+    describe 'when platform_authorized is enabled with legacy naming' do
+      let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: true } }
 
       it 'traces .authorized' do
         skip unless supports_authorized_and_resolved_types?
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_authorized is enabled without legacy naming' do
+    describe 'when platform_authorized is enabled' do
       let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: false } }
 
       it 'traces .authorized' do
@@ -207,8 +207,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_resolve_type is enabled' do
-      let(:config) { { enable_platform_resolve_type: true } }
+    describe 'when platform_resolve_type is enabled with legacy naming' do
+      let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: true } }
 
       it 'traces .resolve_type' do
         skip unless supports_authorized_and_resolved_types?
@@ -219,8 +219,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       end
     end
 
-    describe 'when platform_resolve_type is enabled without legacy naming' do
-      let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: false } }
+    describe 'when platform_resolve_type is enabled' do
+      let(:config) { { enable_platform_resolve_type: true } }
 
       it 'traces .resolve_type' do
         skip unless supports_authorized_and_resolved_types?


### PR DESCRIPTION
For the GraphQL integration, this:
- introduces new attributes to existing platform spans
- seeks to normalize platform span names for easier identification and future aggregation

### New Attributes

Builds on https://github.com/open-telemetry/opentelemetry-specification/pull/2456 and work done in [opentelemetry-js-contrib](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/79b2d3ff08904ce84c6bc48427cd98906c2f0d79/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts#L125-L129)

There are some differences between the GraphQL implementations in different languages that may make it harder to have globally consistent names without working with the library authors. For example, `graphql-ruby` separates out reporting of lazy (delayed, possibly async) work from its sync work, resulting in multiple spans for one [`graphql-js` "resolve" concept](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/79b2d3ff08904ce84c6bc48427cd98906c2f0d79/plugins/node/opentelemetry-instrumentation-graphql/src/enum.ts#L51).

#### Field resolve/execute

- `graphql.field.parent`: Field's parent type. For interfaces, this is the concrete type's name, not interface name.
- `graphql.field.name`: Field's name, matches [`opentelemetry-js`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/79b2d3ff08904ce84c6bc48427cd98906c2f0d79/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts#L126)
- `graphql.lazy`: Is this the lazy part of the resolver. There will always at least an inline/sync portion (e.g. `false`), and will sometimes have lazy work to be subsequently done at a later time. No `opentelemetry-js` equivalent as they use promises.
- `graphql.field.path`: Did **not** add at this time, but the [information is available via `graphql-ruby`](https://graphql-ruby.org/api-doc/2.0.16/GraphQL/Tracing) if we want to report it. There is a [`opentelemetry-js`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/79b2d3ff08904ce84c6bc48427cd98906c2f0d79/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts#L127) equivalent. Thoughts?
 
#### Type authorization

- `graphql.type.name`: Type name having its authorization check run
- `graphql.lazy`: Is this the lazy part of the authorization.

#### Type resolution

When a field’s return type is an interface, GraphQL has to figure out what specific object type to use for the return value.
- `graphql.type.name`: Interface name having its object type determined
- `graphql.lazy`: Is this the lazy part of the type resolution.

### Span Name Normalization

In talking with @robertlaurin about how we can use this data for analysis across many requests, we found we wanted to have a consistent span name to easily identify specify types of spans. So I moved the type/field names to attributes.

This change was made in a backwards compatible manner via `legacy_platform_span_names` config. To keep the original behaviour, set `true`. I figure if/when this gem moves to v1, we can remove this config option.