### PR TITLE
fix: fix flaky tests for resque.

### DIFF
--- a/instrumentation/resque/test/opentelemetry/instrumentation/resque/patches/resque_job_test.rb
+++ b/instrumentation/resque/test/opentelemetry/instrumentation/resque/patches/resque_job_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::Resque::Patches::ResqueJob do
   let(:config) { {} }
 
   before do
+    clear_job_queue
     instrumentation.install(config)
     exporter.reset
   end
@@ -190,6 +191,12 @@ describe OpenTelemetry::Instrumentation::Resque::Patches::ResqueJob do
   def work_off_jobs
     while (job = Resque.reserve(:super_urgent))
       job.perform
+    end
+  end
+
+  def clear_job_queue
+    [ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper, DummyJob, BaggageTestingJob, ExceptionTestingJob].each do |jobtype|
+      Resque::Job.destroy(:super_urgent, jobtype)
     end
   end
 end


### PR DESCRIPTION
It seems that _sometimes_ Resque jobs are not processed fast enough during tests; so that calling `work_off_jobs` returns another job than expected.

This PR makes sure the job queue is cleared before starting another tests; hence only the expected job will be returned, which resolves the flaky tests.

Unblocks: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/117 