### PR TITLE
Fix incorrect error type being recorded when Sinatra route raises exception

### DIFF
--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -168,6 +168,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       get '/one/error'
 
       _(exporter.finished_spans.first.events[0].attributes['exception.type']).must_equal('CustomError')
+      _(exporter.finished_spans.first.events[0].attributes['exception.message']).must_equal('custom message')
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/292

Wait, we're *deleting* code? YUP!

tl;dr: The Rack instrumentation already catches exceptions, adds the data to the current span and marks the error status on it. 

The primary problem is if an exception is raised in `@app.call(env)`, `response` would be nil, so the error checking code in `trace_response` will throw a new exception for trying to use `response`. That *new* exception is then caught by the Rack instrumentation (I believe, or higher level instrumentation that I found when debugging). 

So, if we were to make this work and catch exceptions, record them and then raise it again (as we should since this is middleware and we don't want to interfere with other exception handling), the higher level OTEL exception handler will also catch it and record it, giving us 2 exception events. That is what I originally did and saw 2 exception events, which is not correct.

This is a draft, please feel free to do a full review and make suggestions or ask questions. I'm new to this codebase so I could have done this completely wrong!