### PR TITLE
fix: add exceptions to sinatra spans, ruboproof test.

### DIFF
--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -16,17 +16,25 @@ module OpenTelemetry
           end
 
           def call(env)
-            @app.call(env)
+            response = @app.call(env)
           ensure
-            trace_response(env)
+            trace_response(env, response)
           end
 
-          def trace_response(env)
+          def trace_response(env, response)
             span = OpenTelemetry::Instrumentation::Rack.current_span
             return unless span.recording?
 
             span.set_attribute('http.route', env['sinatra.route'].split.last) if env['sinatra.route']
             span.name = env['sinatra.route'] if env['sinatra.route']
+
+            return if response.nil?
+
+            sinatra_response = ::Sinatra::Response.new([], response.first)
+            return unless sinatra_response.server_error?
+
+            span.record_exception(env['sinatra.error']) if env['sinatra.error']
+            span.status = OpenTelemetry::Trace::Status.error
           end
         end
       end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -12,9 +12,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Sinatra::Instrumentation.instance }
   let(:exporter) { EXPORTER }
 
-  class CustomError < StandardError
-
-  end
+  class CustomError < StandardError; end
 
   let(:app_one) do
     Class.new(Sinatra::Application) do


### PR DESCRIPTION
This will essentially revert https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/317 , but adds a guard clause since unhandled exceptions in Sinatra will return `response = nil`.

I've tried to check if I could add the exception event in the Rack middleware; but the Sinatra exception is not available there.

@rdoherty-fastly since your tests pass, I believe it's OK. Nevertheless I would love your :eyes: on this as well.

Fixes: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/327