### PR TITLE
ActiveJob instrumentation:  Adds ActiveJob::Core `provider_job_id` attribute

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
@@ -75,7 +75,7 @@ module OpenTelemetry
               'messaging.active_job.scheduled_at' => job.scheduled_at,
               'messaging.active_job.priority' => job.priority
             }
-            
+
             otel_attributes['net.transport'] = 'inproc' if %w[async inline].include?(job.class.queue_adapter_name)
 
             otel_attributes.compact

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
@@ -71,10 +71,10 @@ module OpenTelemetry
               'messaging.system' => job.class.queue_adapter_name,
               'messaging.destination' => job.queue_name,
               'messaging.message_id' => job.job_id,
+              'messaging.active_job.provider_job_id' => job.provider_job_id,
               'messaging.active_job.scheduled_at' => job.scheduled_at,
               'messaging.active_job.priority' => job.priority
             }
-
             otel_attributes['net.transport'] = 'inproc' if %w[async inline].include?(job.class.queue_adapter_name)
 
             otel_attributes.compact

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
@@ -75,6 +75,7 @@ module OpenTelemetry
               'messaging.active_job.scheduled_at' => job.scheduled_at,
               'messaging.active_job.priority' => job.priority
             }
+            
             otel_attributes['net.transport'] = 'inproc' if %w[async inline].include?(job.class.queue_adapter_name)
 
             otel_attributes.compact

--- a/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
+++ b/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
@@ -215,6 +215,18 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Patches::ActiveJobCallbacks 
       end
     end
 
+    describe 'messaging.active_job.provider_job_id' do
+      it 'is empty for a job that do not sets provider_job_id' do
+        TestJob.perform_now
+        _(process_span.attributes['messaging.active_job.provider_job_id']).must_be_nil
+      end
+
+      it 'sets the correct value if provider_job_id is provided' do
+        job = TestJob.perform_later
+        _(process_span.attributes['messaging.active_job.provider_job_id']).must_equal(job.provider_job_id)
+      end
+    end
+
     it 'generally sets other attributes as expected' do
       job = TestJob.perform_later
 


### PR DESCRIPTION
Some instrumentations like the one for Sidekiq or DelayedJob, use their own id as the value for `messaging.message_id` while the spans produced by active job instrumentation use the `job.job_id` UUID.

Examples:

- Que: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/6e89c92f189bc6e187da06ea2af4e38531b93601/instrumentation/que/lib/opentelemetry/instrumentation/que/patches/que_job.rb#L78
- DelayedJob: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/8f40eda20e0257bc740508b4b50758285d93e895/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb#L37
- Sidekiq: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/a11d8b135d9ac4c28521619dc3b4744692ae2e6e/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb#L19


We could use the `provider_job_id` since it's [guaranteed to be there](https://github.com/rails/rails/blob/812bae8167488ee5984043ef71125e055352b873/activejob/lib/active_job/core.rb#L26), at least with a nil value, and most adapter seem to define a correct value:

- Sidekiq adapter: https://github.com/rails/rails/blob/927b3b5a8449638a81ef934b0cd56def8bed4a74/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb#L29
- DelayedJob adapter: https://github.com/rails/rails/blob/c50721b88b624c4014f97fd21145b6c641c1e540/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb#L21

Having this attribute in each active job span could make it possible to eventually link both traces.