### PR TITLE
CONTRIBUTING.md should contain API and SDK docker compose services.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,16 +98,6 @@ To test using Docker:
  3. Build the `opentelemetry/opentelemetry-ruby-contrib` image
     * `docker-compose build`
     * This makes the image available locally
- 4. API:
-     1. Install dependencies
-         *  `docker-compose run api bundle install`
-     2. Run the tests
-         *  `docker-compose run api bundle exec rake test`
- 5. SDK:
-     1. Install dependencies
-         *  `docker-compose run sdk bundle install`
-     2. Run the tests for the sdk
-         *  `docker-compose run sdk bundle exec rake test`
 
 ## Processing and visualizing traces locally
 


### PR DESCRIPTION
The contributing document makes reference to two services that were removed in the PR: #3 

Maybe instead of removing the text, we should indicate that these steps should be applied to the open telemetry ruby repo.