### PR TITLE
fix: Ensure encoding errors handled during SQL obfuscation for Trilogy

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -78,7 +78,8 @@ module OpenTelemetry
               obfuscated = 'Failed to obfuscate SQL query - quote characters remained after obfuscation' if detect_unmatched_pairs(obfuscated)
               obfuscated
             end
-          rescue StandardError
+          rescue StandardError => e
+            OpenTelemetry.handle_error(message: 'Failed to obfuscate SQL', exception: e)
             'OpenTelemetry error: failed to obfuscate sql'
           end
 

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -172,6 +172,19 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_s
       end
+
+      it 'encodes invalid byte sequences for db.statement' do
+        # \255 is off-limits https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
+        sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com\255'"
+        obfuscated_sql = 'SELECT * from users where users.id = ? and users.email = ?'
+
+        expect do
+          client.query(sql)
+        end.must_raise Mysql2::Error
+
+        _(span.name).must_equal 'mysql'
+        _(span.attributes['db.statement']).must_equal obfuscated_sql
+      end
     end
 
     describe 'when db_statement set as omit' do

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -87,10 +87,13 @@ module OpenTelemetry
             if sql.size > 2000
               'SQL query too large to remove sensitive data ...'
             else
-              obfuscated = sql.gsub(FULL_SQL_REGEXP, '?')
+              obfuscated = OpenTelemetry::Common::Utilities.utf8_encode(sql, binary: true)
+              obfuscated = obfuscated.gsub(FULL_SQL_REGEXP, '?')
               obfuscated = 'Failed to obfuscate SQL query - quote characters remained after obfuscation' if detect_unmatched_pairs(obfuscated)
               obfuscated
             end
+          rescue StandardError
+            'OpenTelemetry error: failed to obfuscate sql'
           end
 
           def detect_unmatched_pairs(obfuscated)
@@ -140,6 +143,7 @@ module OpenTelemetry
             QUERY_NAME_RE.match(sql) { |match| match[1].downcase } unless sql.nil?
           rescue StandardError => e
             OpenTelemetry.logger.error("Error extracting sql statement type: #{e.message}")
+            nil
           end
         end
       end

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -92,7 +92,8 @@ module OpenTelemetry
               obfuscated = 'Failed to obfuscate SQL query - quote characters remained after obfuscation' if detect_unmatched_pairs(obfuscated)
               obfuscated
             end
-          rescue StandardError
+          rescue StandardError => e
+            OpenTelemetry.handle_error(message: 'Failed to obfuscate SQL', exception: e)
             'OpenTelemetry error: failed to obfuscate sql'
           end
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -20,6 +20,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
       port: port,
       username: username,
       password: password,
+      database: database,
       ssl: false
     }
   end
@@ -243,6 +244,65 @@ describe OpenTelemetry::Instrumentation::Trilogy do
 
         _(span.name).must_equal 'select'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_be_nil
+      end
+    end
+
+    describe 'when db_statement is configured via environment variable' do
+      describe 'when db_statement set as omit' do
+        it 'omits db.statement attribute' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=omit;') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            _(span.attributes['db.system']).must_equal 'mysql'
+            _(span.name).must_equal 'select'
+            _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_be_nil
+          end
+        end
+      end
+
+      describe 'when db_statement set as obfuscate' do
+        it 'obfuscates SQL parameters in db.statement' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate;') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            obfuscated_sql = 'SELECT * from users where users.id = ? and users.email = ?'
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            _(span.attributes['db.system']).must_equal 'mysql'
+            _(span.name).must_equal 'select'
+            _(span.attributes['db.statement']).must_equal obfuscated_sql
+          end
+        end
+      end
+
+      describe 'when db_statement is set differently than local config' do
+        let(:config) { { db_statement: :omit } }
+
+        it 'overrides local config and obfuscates SQL parameters in db.statement' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            obfuscated_sql = 'SELECT * from users where users.id = ? and users.email = ?'
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            _(span.attributes['db.system']).must_equal 'mysql'
+            _(span.name).must_equal 'select'
+            _(span.attributes['db.statement']).must_equal obfuscated_sql
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Shopify is planning to start migrating apps from Mysql2 to Trilogy as a SQL database client. Ensuring parity between OpenTelemetry instrumentation for Mysql2 and Trilogy is important before we move to Trilogy.

This PR ensures that invalid byte sequences are handled appropriately when obfuscating SQL, taking inspiration from https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/160. I also added some additional tests to the Trilogy spec around configuring `db_statement` via an environment variable.

I noticed the Mysql2 test around invalid byte encoding was removed in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/265 when the `enable_sql_obfuscation` config went away, and I'm not sure if that was intentional. I've added a test to the Mysql2 spec to ensure there's coverage for an invalid byte sequence appearing in SQL.