### PR TITLE
feat: add with_attributes context propagation to Trilogy instrumentation

### DIFF
--- a/instrumentation/trilogy/README.md
+++ b/instrumentation/trilogy/README.md
@@ -40,6 +40,17 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+The `trilogy` instrumentation allows the user to supply additional attributes via the `with_attributes` method. This makes it possible to supply additional attributes on trilogy spans. Attributes supplied in `with_attributes` supersede those automatically generated within `trilogy`'s automatic instrumentation. If you supply a `db.statement` attribute in `with_attributes`, this library's `:db_statement` configuration will not be applied.
+
+```ruby
+require 'opentelemetry-instrumentation-trilogy'
+
+client = Trilogy.new(:host => 'localhost', :username => 'root')
+OpenTelemetry::Instrumentation::Trilogy.with_attributes('pizzatoppings' => 'mushrooms') do
+  client.query('SELECT 1')
+end
+```
+
 ## How can I get involved?
 
 The `opentelemetry-instrumentation-trilogy` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy.rb
@@ -11,6 +11,45 @@ module OpenTelemetry
   module Instrumentation
     # Contains the OpenTelemetry instrumentation for the Trilogy gem
     module Trilogy
+      extend self
+
+      CURRENT_ATTRIBUTES_KEY = Context.create_key('trilogy-attributes-hash')
+
+      private_constant :CURRENT_ATTRIBUTES_KEY
+
+      # Returns the attributes hash representing the Trilogy context found
+      # in the optional context or the current context if none is provided.
+      #
+      # @param [optional Context] context The context to lookup the current
+      #   attributes hash. Defaults to Context.current
+      def attributes(context = nil)
+        context ||= Context.current
+        context.value(CURRENT_ATTRIBUTES_KEY) || {}
+      end
+
+      # Returns a context containing the merged attributes hash, derived from the
+      # optional parent context, or the current context if one was not provided.
+      #
+      # @param [optional Context] context The context to use as the parent for
+      #   the returned context
+      def context_with_attributes(attributes_hash, parent_context: Context.current)
+        attributes_hash = attributes(parent_context).merge(attributes_hash)
+        parent_context.set_value(CURRENT_ATTRIBUTES_KEY, attributes_hash)
+      end
+
+      # Activates/deactivates the merged attributes hash within the current Context,
+      # which makes the "current attributes hash" available implicitly.
+      #
+      # On exit, the attributes hash that was active before calling this method
+      # will be reactivated.
+      #
+      # @param [Span] span the span to activate
+      # @yield [Hash, Context] yields attributes hash and a context containing the
+      #   attributes hash to the block.
+      def with_attributes(attributes_hash)
+        attributes_hash = attributes.merge(attributes_hash)
+        Context.with_value(CURRENT_ATTRIBUTES_KEY, attributes_hash) { |c, h| yield h, c }
+      end
     end
   end
 end

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -56,7 +56,7 @@ module OpenTelemetry
           def query(sql)
             tracer.in_span(
               database_span_name(sql),
-              attributes: client_attributes(sql),
+              attributes: client_attributes(sql).merge!(OpenTelemetry::Instrumentation::Trilogy.attributes),
               kind: :client
             ) do
               super(sql)

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -101,6 +101,28 @@ describe OpenTelemetry::Instrumentation::Trilogy do
       instrumentation.install(config)
     end
 
+    describe '.attributes' do
+      let(:attributes) { { 'db.statement' => 'foobar' } }
+
+      it 'returns an empty hash by default' do
+        _(OpenTelemetry::Instrumentation::Trilogy.attributes).must_equal({})
+      end
+
+      it 'returns the current attributes hash' do
+        OpenTelemetry::Instrumentation::Trilogy.with_attributes(attributes) do
+          _(OpenTelemetry::Instrumentation::Trilogy.attributes).must_equal(attributes)
+        end
+      end
+
+      it 'sets span attributes according to with_attributes hash' do
+        OpenTelemetry::Instrumentation::Trilogy.with_attributes(attributes) do
+          client.query('SELECT 1')
+        end
+
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'foobar'
+      end
+    end
+
     describe 'with default options' do
       it 'obfuscates sql' do
         client.query('SELECT 1')


### PR DESCRIPTION
Attempting to reach feature parity between Mysql2 instrumentation and Trilogy instrumentation. I believe we'll want to make additional attributes available to Trilogy spans as with Mysql2 spans.