### PR TITLE
feat: add option to configure span name for trilogy

### DIFF
--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
@@ -24,6 +24,7 @@ module OpenTelemetry
 
         option :peer_service, default: nil, validate: :string
         option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
+        option :span_name, default: :statement_type, validate: %I[statement_type db_name db_operation_and_name]
 
         private
 

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -106,20 +106,27 @@ module OpenTelemetry
             %r{'|"|\/\*|\*\/}.match(obfuscated)
           end
 
-          def database_span_name(sql)
-            # Setting span name to the SQL query without obfuscation would
-            # result in PII + cardinality issues.
-            # First attempt to infer the statement type then fallback to
-            # current Otel approach {database.component_name}.{database_instance_name}
-            # https://github.com/open-telemetry/opentelemetry-python/blob/39fa078312e6f41c403aa8cad1868264011f7546/ext/opentelemetry-ext-dbapi/tests/test_dbapi_integration.py#L53
-            # This creates span names like mysql.default, mysql.replica, postgresql.staging etc.
+          def database_span_name(sql) # rubocop:disable Metrics/CyclomaticComplexity
+            case config[:span_name]
+            when :statement_type
+              extract_statement_type(sql)
+            when :db_name
+              database_name
+            when :db_operation_and_name
+              op = OpenTelemetry::Instrumentation::Trilogy.attributes['db.operation']
+              name = database_name
+              if op && name
+                "#{op} #{name}"
+              elsif op
+                op
+              elsif name
+                name
+              end
+            end || 'mysql'
+          end
 
-            statement_type = extract_statement_type(sql)
-
-            return statement_type unless statement_type.nil?
-
-            # fallback
-            'mysql'
+          def database_name
+            connection_options[:database]
           end
 
           def net_peer_name

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -340,5 +340,135 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         end
       end
     end
+
+    describe 'when span_name is set as statement_type' do
+      it 'sets span name to statement type' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=statement_type') do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+
+          sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+          expect do
+            client.query(sql)
+          end.must_raise Trilogy::Error
+
+          _(span.name).must_equal 'select'
+        end
+      end
+
+      it 'sets span name to mysql when statement type is not recognized' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=statement_type') do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+
+          sql = 'DESELECT 1'
+          expect do
+            client.query(sql)
+          end.must_raise Trilogy::Error
+
+          _(span.name).must_equal 'mysql'
+        end
+      end
+    end
+
+    describe 'when span_name is set as db_name' do
+      it 'sets span name to db name' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_name') do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+
+          sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+          expect do
+            client.query(sql)
+          end.must_raise Trilogy::Error
+
+          _(span.name).must_equal 'mysql'
+        end
+      end
+
+      describe 'when db name is nil' do
+        let(:database) { nil }
+
+        it 'sets span name to mysql' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_name') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            _(span.name).must_equal 'mysql'
+          end
+        end
+      end
+    end
+
+    describe 'when span_name is set as db_operation_and_name' do
+      it 'sets span name to db operation and name' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_operation_and_name') do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+
+          sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+          OpenTelemetry::Instrumentation::Trilogy.with_attributes('db.operation' => 'foo') do
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+          end
+
+          _(span.name).must_equal 'foo mysql'
+        end
+      end
+
+      it 'sets span name to db name when db.operation is not set' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_operation_and_name') do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+
+          sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+          expect do
+            client.query(sql)
+          end.must_raise Trilogy::Error
+
+          _(span.name).must_equal 'mysql'
+        end
+      end
+
+      describe 'when db name is nil' do
+        let(:database) { nil }
+
+        it 'sets span name to db operation' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_operation_and_name') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            OpenTelemetry::Instrumentation::Trilogy.with_attributes('db.operation' => 'foo') do
+              expect do
+                client.query(sql)
+              end.must_raise Trilogy::Error
+            end
+
+            _(span.name).must_equal 'foo'
+          end
+        end
+
+        it 'sets span name to mysql when db.operation is not set' do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'span_name=db_operation_and_name') do
+            instrumentation.instance_variable_set(:@installed, false)
+            instrumentation.install
+
+            sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            _(span.name).must_equal 'mysql'
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Dependent on: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/347

Shopify is planning to start migrating apps from Mysql2 to Trilogy as a SQL database client. Ensuring parity between OpenTelemetry instrumentation for Mysql2 and Trilogy is important before we move to Trilogy.

This PR adds configurable span names to the Trilogy instrumentation.