### PR TITLE
ci: Pin setup-ruby action to stable release version

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -57,7 +57,7 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.139.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -68,7 +68,7 @@ runs:
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.139.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"


### PR DESCRIPTION
Using `v1` will always use the latest untested commit on `main`. Hopefully this will provide more stability to CI going forward. 