### PR TITLE
fix!: Lock graphql max version to 2.0.17

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -17,6 +17,6 @@ else
   end
 
   appraise 'graphql-2.0.x' do
-    gem 'graphql', '~> 2.0.16'
+    gem 'graphql', '<= 2.0.16'
   end
 end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -17,6 +17,6 @@ else
   end
 
   appraise 'graphql-2.0.x' do
-    gem 'graphql', '<= 2.0.16'
+    gem 'graphql', '<= 2.0.17'
   end
 end

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -12,7 +12,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          gem_version <= Gem::Version.new('2.0.16')
+          gem_version <= Gem::Version.new('2.0.17')
         end
 
         install do |config|

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -12,7 +12,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          gem_version < Gem::Version.new('3.0.0')
+          gem_version <= Gem::Version.new('2.0.16')
         end
 
         install do |config|

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'
-  spec.add_development_dependency 'graphql', '>= 1.9.0', '< 3.0.0'
+  spec.add_development_dependency 'graphql', '>= 1.9.0', '<= 2.0.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'
-  spec.add_development_dependency 'graphql', '>= 1.9.0', '<= 2.0.16'
+  spec.add_development_dependency 'graphql', '>= 1.9.0', '<= 2.0.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'


### PR DESCRIPTION
2.0.18 introduces a refactoring of the GraphQL Trace API that makes it incompatible with the OTel Instrumentation.

This change locks the existing implementation to lower than 2.0.18

See https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/374 See https://github.com/rmosolgo/graphql-ruby/issues/4380