### PR TITLE
refactor: use semantic calls in the mysql2 instrumentation

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -54,9 +54,9 @@ module OpenTelemetry
             attributes = client_attributes
             case config[:db_statement]
             when :include
-              attributes['db.statement'] = sql
+              attributes[SemanticConventions::Trace::DB_STATEMENT] = sql
             when :obfuscate
-              attributes['db.statement'] = obfuscate_sql(sql)
+              attributes[SemanticConventions::Trace::DB_STATEMENT] = obfuscate_sql(sql)
             end
             tracer.in_span(
               database_span_name(sql),
@@ -103,7 +103,7 @@ module OpenTelemetry
             when :db_name
               database_name
             when :db_operation_and_name
-              op = OpenTelemetry::Instrumentation::Mysql2.attributes['db.operation']
+              op = OpenTelemetry::Instrumentation::Mysql2.attributes[SemanticConventions::Trace::DB_OPERATION]
               name = database_name
               if op && name
                 "#{op} #{name}"
@@ -128,12 +128,12 @@ module OpenTelemetry
             port = query_options[:port].to_s
 
             attributes = {
-              'db.system' => 'mysql',
-              'net.peer.name' => host,
-              'net.peer.port' => port
+              SemanticConventions::Trace::DB_SYSTEM => 'mysql',
+              SemanticConventions::Trace::NET_PEER_NAME => host,
+              SemanticConventions::Trace::NET_PEER_PORT => port
             }
-            attributes['db.name'] = database_name if database_name
-            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+            attributes[SemanticConventions::Trace::DB_NAME] = database_name if database_name
+            attributes[SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] if config[:peer_service]
             attributes
           end
 


### PR DESCRIPTION
Unsure if you want the references to include the full module name or not. eg. `SemanticConventions::Trace::DB_STATEMENT` vs `OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT`, as I tried to see if there was an convention in the repository, but it seems to be mismatched [[1](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/95707f9ce9fb1a485fd7437c313615bb66dc1ffc/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb#L20-L21)] [[2](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/95707f9ce9fb1a485fd7437c313615bb66dc1ffc/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/messaging_helper.rb#L32-L35)].