### PR TITLE
feat: SDK Extension AWS Gem

### DIFF
--- a/sdk_extension/aws/.yardopts
+++ b/sdk_extension/aws/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry SDK Extension AWS
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/sdk/extension/aws/**/*.rb
+./lib/opentelemetry/sdk/extension/aws.rb
+-
+README.md
+CHANGELOG.md

--- a/sdk_extension/aws/CHANGELOG.md
+++ b/sdk_extension/aws/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Release History: opentelemetry-sdk-extension-aws
+
+### v0.1.0
+
+* Initial release.

--- a/sdk_extension/aws/Gemfile
+++ b/sdk_extension/aws/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec

--- a/sdk_extension/aws/LICENSE
+++ b/sdk_extension/aws/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk_extension/aws/README.md
+++ b/sdk_extension/aws/README.md
@@ -1,0 +1,52 @@
+# opentelemetry-sdk-extension-aws
+
+The `opentelemetry-sdk-extension-aws` gem contains ID generators for the
+[AWS XRay format][aws-xray].
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+This gem can be used with any OpenTelemetry SDK implementation. This can be the official `opentelemetry-sdk` gem or any other concrete implementation.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk-extension-aws
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk-extension-aws` in your `Gemfile`.
+
+## To generate AWS XRay compliant IDs:
+```
+require 'opentelemetry/sdk/extension/aws/trace/xray_id_generator'
+
+OpenTelemetry::SDK.configure do |c|
+  c.id_generator = OpenTelemetry::SDK::Extension::AWS::Trace::XRayIdGenerator
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-sdk-extension-aws` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-sdk-extension-aws` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
+[aws-xray]: https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html

--- a/sdk_extension/aws/Rakefile
+++ b/sdk_extension/aws/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/sdk_extension/aws/lib/opentelemetry-sdk-extension-aws.rb
+++ b/sdk_extension/aws/lib/opentelemetry-sdk-extension-aws.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-api'
+require_relative './opentelemetry/sdk/extension/aws/trace/xray_id_generator'

--- a/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/aws.rb
+++ b/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/aws.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-api'
+require 'opentelemetry/sdk/extension/aws/version'
+require 'opentelemetry/sdk/extension/aws/trace/xray_id_generator'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Namespace for OpenTelemetry SDK libraries
+  module SDK
+    # Namespace for OpenTelemetry SDK Extension libraries
+    module Extension
+      # Namespace for OpenTelemetry AWS SDK Extension
+      module Aws
+      end
+    end
+  end
+end

--- a/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/trace/xray_id_generator.rb
+++ b/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/trace/xray_id_generator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Extension
+      module Aws
+        module Trace
+          # This module is intended to only be used as an override for how to generate IDs to be compliant with XRay
+          module XRayIDGenerator
+            extend self
+
+            # Generates a valid trace identifier, a 16-byte string with at least one
+            # non-zero byte.
+            # AWS Docs: https://docs.aws.amazon.com/xray/latest/api/API_PutTraceSegments.html
+            # hi - 4 bytes timestamp, 4 bytes random (Mid)
+            # low - 8 bytes random.
+            # Since we include timestamp, impossible to be invalid.
+            # @return [bytes] a valid trace ID that is compliant with AWS XRay.
+            def generate_trace_id
+              time_hi = generate_time_bytes
+              mid_and_low = Random.bytes(12)
+              time_hi << mid_and_low
+            end
+
+            # Generates a valid span identifier, an 8-byte string with at least one
+            # non-zero byte.
+            #
+            # @return [bytes] a valid span ID.
+            def generate_span_id
+              OpenTelemetry::Trace.generate_span_id
+            end
+
+            private
+
+            # Seconds since epoch converted to 4 bytes in big-endian order.
+            def generate_time_bytes
+              [Time.now.to_i].pack('N')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/version.rb
+++ b/sdk_extension/aws/lib/opentelemetry/sdk/extension/aws/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Extension
+      module Aws
+        VERSION = '0.1.0'
+      end
+    end
+  end
+end

--- a/sdk_extension/aws/opentelemetry-sdk-extension-aws.gemspec
+++ b/sdk_extension/aws/opentelemetry-sdk-extension-aws.gemspec
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'opentelemetry/sdk/extension/aws/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-sdk-extension-aws'
+  spec.version     = OpenTelemetry::SDK::Extension::Aws::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'AWS XRay ID Generation Extension for the OpenTelemetry framework'
+  spec.description = 'AWS XRay ID Generation Extension for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = Dir.glob('lib/**/*.rb') +
+               Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.6.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+
+  spec.add_development_dependency 'bundler', '~> 2.4'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/sdk_extension/aws'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues'
+    spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  end
+end

--- a/sdk_extension/aws/test/aws_xray_trace_test.rb
+++ b/sdk_extension/aws/test/aws_xray_trace_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'test_helper'
+
+describe OpenTelemetry::Trace::SpanContext do
+  let(:id_generator) { OpenTelemetry::SDK::Extension::Aws::Trace::XRayIDGenerator }
+
+  describe 'generate trace id in the correct format' do
+    it 'must generate 16 in length' do
+      trace_id = id_generator.generate_trace_id
+      _(trace_id.length).must_equal(16)
+    end
+    it 'first 4 bytes should be a valid epoch date' do
+      trace_id = id_generator.generate_trace_id
+      # Convert to hex
+      hex = trace_id[0..3].unpack1('H*')
+      # Convert to int
+      time_int = hex.to_i(16)
+      # Convert to datetime
+      begin
+        date = Time.at(time_int).to_datetime
+      rescue ArgumentError
+        date = nil
+      end
+      # Make sure it's valid
+      _(date).wont_be_nil
+    end
+    it 'generate_span_id still works' do
+      trace_id = id_generator.generate_span_id
+      # Make sure it's valid
+      _(trace_id).wont_be_nil
+    end
+  end
+end

--- a/sdk_extension/aws/test/test_helper.rb
+++ b/sdk_extension/aws/test/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'opentelemetry-sdk-extension-aws'
+require 'minitest/autorun'
+
+OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)


### PR DESCRIPTION
This implements #33. This adds a gem opentelemetry-sdk-extension-aws, which allows for XRay ID generation. This lays the groundwork to add resource detectors for AWS resources.

This code is mostly moved from the opentelemetry-propagator-xray gem.