### PR TITLE
ci: do not test a config that will never succeed

### DIFF
--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_test.rb
@@ -42,14 +42,6 @@ describe OpenTelemetry::Instrumentation::Rack::Instrumentation do
 
     it 'skips installation' do
       _(instrumentation).wont_be :installed?
-      _(instrumentation.config[:allowed_request_headers]).must_be_empty
-      _(instrumentation.config[:allowed_response_headers]).must_be_empty
-      _(instrumentation.config[:application]).must_be_nil
-      _(instrumentation.config[:record_frontend_span]).must_equal false
-      _(instrumentation.config[:untraced_endpoints]).must_be_empty
-      _(instrumentation.config[:url_quantization]).must_be_nil
-      _(instrumentation.config[:untraced_requests]).must_be_nil
-      _(instrumentation.config[:response_propagators]).must_be_empty
     end
   end
 end


### PR DESCRIPTION
In this test, we are asserting that the instrumentation is _not_
installed when the `Rack` constant is not present (see the `before`
block for this test case). We then go on to test that the configuration
is the "default" configuration that you'd get with a fresh installation.

The problem is that if the `Rack` constant is not present, then the
`instrumentation-base` code that sets all the defaults for our options
is never run (and logically, why would it?). So these test lines can
never actually succeed.

Unless, of course, the `instrumentation` object we're referring to is
_not_ a pristine, new object. And in fact, depending on what order the
tests run in, our object is _not_ a pristine, new object. If you run
basically any _other_ test in this suite before, then we actually end up
recycling an object that is partially initialzied from a previous test,
and has an internal `@config` object that has some default options.

And so, the test is actually passing some times because of this
non-deterministic behavior. For example, if you run with `SEED=1`, then
the test suite passes (because other tests run first that initialize the
object completely). If you run with `SEED=6372`, it fails (because it is
the very first test run).

The _real_ bug here is that we do not have proper test isolation. I
think that's actually a problem all over the code base, if I'm being
honest about it.

However, I elect not to fix that problem today. We'd need some way to
"reset" instrumentation and the registry in between tests (maybe not
_that_ hard, honestly). That's more than I want to do on a Saturday
afternoon. So to fix the current issue, we just don't bother testing
things that logically could never pass anyways. What we actually care
about is that the instrumentation reports it was not installed, which
does work correctly as it is.

Fixes #387
