### PR TITLE
feat!: Drop support for EoL Ruby 2.7

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -57,7 +57,7 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1.139.0
+      uses: ruby/setup-ruby@v1.144.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -68,7 +68,7 @@ runs:
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1.139.0
+      uses: ruby/setup-ruby@v1.144.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"

--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -37,12 +37,6 @@ jobs:
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -51,7 +45,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
@@ -89,12 +83,6 @@ jobs:
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -103,7 +91,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem

--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -39,12 +39,6 @@ jobs:
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -53,7 +47,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
 
   resource-detectors:
     strategy:
@@ -82,19 +76,13 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
+          ruby: "3.0"
       - name: "Test JRuby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"

--- a/.github/workflows/ci-instrumentation-canary.yml
+++ b/.github/workflows/ci-instrumentation-canary.yml
@@ -72,12 +72,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -107,7 +101,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash

--- a/.github/workflows/ci-instrumentation-with-services-canary.yml
+++ b/.github/workflows/ci-instrumentation-with-services-canary.yml
@@ -44,11 +44,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -74,7 +69,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -38,11 +38,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -50,7 +45,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"
     services:
       memcached:
         image: memcached:alpine
@@ -89,11 +84,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -131,11 +121,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -189,11 +174,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -219,7 +199,7 @@ jobs:
           - que
         os:
           - ubuntu-latest
-    name: mysql / ${{ matrix.gem }} / ${{ matrix.os }}
+    name: postgresql / ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -238,11 +218,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -284,11 +259,6 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -63,12 +63,9 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "2.7"
+          yard: true
+          rubocop: true
+          build: true
       - name: "JRuby Filter"
         id: jruby_skip
         shell: bash
@@ -95,4 +92,4 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
-          ruby: "jruby-9.4.0.0"
+          ruby: "jruby-9.4.2.0"

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -8,7 +8,7 @@ jobs:
   release-process-request:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -9,7 +9,7 @@ jobs:
   release-update-open-requests:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -18,7 +18,7 @@ jobs:
   release-perform:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -12,7 +12,7 @@ jobs:
   release-request:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -15,7 +15,7 @@ jobs:
   release-retry:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -61,7 +61,7 @@ class InstrumentationGenerator < Thor::Group
     insert_into_file("#{instrumentation_all_path}/Gemfile", gemfile_text, after: "gemspec\n")
 
     gemspec_text = "\n  spec.add_dependency '#{instrumentation_gem_name}', '~> 0.0.0'"
-    insert_into_file("#{instrumentation_all_path}/opentelemetry-instrumentation-all.gemspec", gemspec_text, after: "spec.required_ruby_version = '>= 2.6.0'\n")
+    insert_into_file("#{instrumentation_all_path}/opentelemetry-instrumentation-all.gemspec", gemspec_text, after: "spec.required_ruby_version = '>= 3.0'
 
     all_rb_text = "\nrequire '#{instrumentation_gem_name}'"
     insert_into_file("#{instrumentation_all_path}/lib/opentelemetry/instrumentation/all.rb", all_rb_text, after: "# SPDX-License-Identifier: Apache-2.0\n")

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7.6'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> <%= opentelemetry_version %>'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> <%= instrumentation_base_version %>'
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.7.6'
+  TargetRubyVersion: '3.0'
   NewCops: enable
   Exclude:
     - Rakefile
@@ -8,6 +8,8 @@ AllCops:
     - "bin/instrumentation_generator"
     - "**/**/vendor/bundle/**/*"
 Bundler/OrderedGems:
+  Enabled: false
+Gemspec/DevelopmentDependencies:
   Enabled: false
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Configuration for Ruby base image
 ARG ALPINE_VERSION=3.17
-ARG RUBY_VERSION=3.1
+ARG RUBY_VERSION=3.2
 
 FROM ruby:"${RUBY_VERSION}-alpine${ALPINE_VERSION}" as ruby
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.48.0'
+gem 'rubocop', '~> 1.48.1'

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -12,8 +12,6 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  appraise 'rails-7.0' do
-    gem 'rails', '~> 7.0.0'
-  end
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0'
 end

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -12,8 +12,6 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  appraise 'rails-7.0' do
-    gem 'rails', '~> 7.0.0'
-  end
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0'
 end

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.1'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_job/Appraisals
+++ b/instrumentation/active_job/Appraisals
@@ -4,16 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'activejob-6.1' do
-  gem 'activejob', '~> 6.1.0'
-end
-
 appraise 'activejob-6.0' do
   gem 'activejob', '~> 6.0.0'
 end
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  appraise 'rails-7.0' do
-    gem 'rails', '~> 7.0.0'
-  end
+appraise 'activejob-6.1' do
+  gem 'activejob', '~> 6.1.0'
+end
+
+appraise 'activejob-7.0' do
+  gem 'activejob', '~> 7.0.0'
 end

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -4,16 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'activerecord-6.1' do
-  gem 'activerecord', '~> 6.1.0'
-end
-
 appraise 'activerecord-6.0' do
   gem 'activerecord', '~> 6.0.0'
 end
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  appraise 'activerecord-7.0' do
-    gem 'activerecord', '~> 7.0.0'
-  end
+appraise 'activerecord-6.1' do
+  gem 'activerecord', '~> 6.1.0'
+end
+
+appraise 'activerecord-7.0' do
+  gem 'activerecord', '~> 7.0.0'
 end

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/active_support/Appraisals
+++ b/instrumentation/active_support/Appraisals
@@ -12,8 +12,6 @@ appraise 'activesupport-6.1' do
   gem 'activesupport', '~> 6.1.0'
 end
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  appraise 'activesupport-7.0' do
-    gem 'activesupport', '~> 7.0.0'
-  end
+appraise 'activesupport-7.0' do
+  gem 'activesupport', '~> 7.0.0'
 end

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,12 +33,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-instrumentation-active_model_serializers', '~> 0.19.0'
   spec.add_dependency 'opentelemetry-instrumentation-aws_sdk', '~> 0.3.0'
@@ -63,7 +63,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,11 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -61,7 +61,7 @@ module OpenTelemetry
     # For example: OTEL_RUBY_INSTRUMENTATION_SINATRA_ENABLED = false.
     class Base # rubocop:disable Metrics/ClassLength
       class << self
-        NAME_REGEX = /^(?:(?<namespace>[a-zA-Z0-9_:]+):{2})?(?<classname>[a-zA-Z0-9_]+)$/.freeze
+        NAME_REGEX = /^(?:(?<namespace>[a-zA-Z0-9_:]+):{2})?(?<classname>[a-zA-Z0-9_]+)$/
         VALIDATORS = {
           array: ->(v) { v.is_a?(Array) },
           boolean: ->(v) { v == true || v == false }, # rubocop:disable Style/MultipleComparison

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -23,16 +23,16 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-registry', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
+++ b/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bunny'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'concurrent-ruby', '~> 1.1.6'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dalli', '>= 2.7'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'delayed_job_active_record'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ethon', '~> 0.12.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
+# add more tests for excon
+
 appraise 'excon-0.71' do
   gem 'excon', '~> 0.71.0'
-end
-
-# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if RUBY_VERSION < '3'
-  appraise 'excon-0.64' do
-    gem 'excon', '~> 0.64.0'
-  end
 end

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'excon', '~> 0.71.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/faraday/Appraisals
+++ b/instrumentation/faraday/Appraisals
@@ -4,24 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+appraise 'faraday-0.17' do
+  gem 'faraday', '~> 0.17.6'
+end
+
 appraise 'faraday-1.0' do
   gem 'faraday', '~> 1.0.0'
-end
-
-# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if RUBY_VERSION < '3'
-  appraise 'faraday-0.17' do
-    gem 'faraday', '0.17.0'
-  end
-end
-
-appraise 'faraday-0.16' do
-  gem 'faraday', '0.16.2'
-end
-
-# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if RUBY_VERSION < '3'
-  appraise 'faraday-0.13' do
-    gem 'faraday', '0.13.1'
-  end
 end

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday', '~> 0.17.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -4,19 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-current_ruby_version = Gem::Version.new(RUBY_VERSION)
+appraise 'graphql-1.13' do
+  gem 'graphql', '~> 1.13'
+end
 
-# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-if current_ruby_version < Gem::Version.new('3.0.0')
-  appraise 'graphql-1.9' do
-    gem 'graphql', '~> 1.9.0'
-  end
-else
-  appraise 'graphql-1.13' do
-    gem 'graphql', '~> 1.13'
-  end
-
-  appraise 'graphql-2.x' do
-    gem 'graphql', '~> 2', '< 3.0.0'
-  end
+appraise 'graphql-2.x' do
+  gem 'graphql', '~> 2', '< 3.0.0'
 end

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'graphql', '>= 1.9.0', '< 3.0.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -22,7 +22,6 @@ end
 
 # Hack that allows us to reset the internal state of the tracer to test installation
 module SchemaTestPatches
-
   # Reseting @graphql_definition is needed for tests running against version `1.9.x`
   # Other variables are used by ~> 2.0.19
   def _reset_tracer_for_testing

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'http'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'httpclient'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,10 +34,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'koala', '~> 3.0.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'lmdb'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,11 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mongo', '~> 2.5'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mysql2', '>= 0.4.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0.1'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.11.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
@@ -86,7 +86,7 @@ module OpenTelemetry
           multi_line_comments
         ].freeze
 
-        UNMATCHED_PAIRS_REGEX = %r{'|\/\*|\*\/|\$(?!\?)}.freeze
+        UNMATCHED_PAIRS_REGEX = %r{'|\/\*|\*\/|\$(?!\?)}
 
         # These are all alike in that they will have a SQL statement as the first parameter.
         # That statement may possibly be parameterized, but we can still use it - the

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,11 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pg', '>= 1.1.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -34,11 +34,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-instrumentation-pg', '~> 0.20'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pg', '~> 1.1'
   spec.add_development_dependency 'que', '~> 1.2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,11 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'racecar', '~> 2.7'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,12 +34,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-sdk-experimental', '~> 0.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,22 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if Gem::Requirement.new('>= 2.7.0', '< 3.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  appraise 'rails-6.0' do
-    gem 'rails', '~> 6.0.0'
-  end
-
-  appraise 'rails-6.1' do
-    gem 'rails', '~> 6.1.0'
-  end
-
-  appraise 'rails-7.0' do
-    gem 'rails', '~> 7.0.0'
-  end
+appraise 'rails-6.0' do
+  gem 'rails', '~> 6.0.0'
 end
 
-if Gem::Requirement.new('>= 3.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  appraise 'rails-7.0.ruby.3.1' do
-    gem 'rails', '~> 7.0.1'
-  end
+appraise 'rails-6.1' do
+  gem 'rails', '~> 6.1.0'
+end
+
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0'
 end

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-action_pack', '~> 0.5.0'
@@ -37,11 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rack-test', '~> 2.1.0'
-  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
+++ b/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '>= 0.9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -33,11 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rdkafka'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'redis', '~> 4.1.0'
   spec.add_development_dependency 'redis-client', '~> 0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -32,10 +32,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'resque'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rest-client', '~> 2.1.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -32,10 +32,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/ruby_kafka/Appraisals
+++ b/instrumentation/ruby_kafka/Appraisals
@@ -4,17 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'ruby-kafka-1.3.0' do
-  gem 'ruby-kafka', '~> 1.3.0'
-end
-
-# Producer test is timing out on Ruby 3
-if RUBY_VERSION < '3'
-  appraise 'ruby-kafka-1.2.0' do
-    gem 'ruby-kafka', '~> 1.2.0'
-  end
-
-  appraise 'ruby-kafka-1.0.0' do
-    gem 'ruby-kafka', '~> 1.0.0'
+(3..5).each do |i|
+  appraise "ruby-kafka-1.#{i}.x" do
+    gem 'ruby-kafka', "~> 1.#{i}.0"
   end
 end

--- a/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
+++ b/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'ruby-kafka'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'sidekiq', '~> 5.2.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sinatra', '~> 2.0.7'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
@@ -33,12 +33,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.41.1'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'trilogy', '>= 2.0', '< 3.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/propagator/ottrace/lib/opentelemetry/propagator/ottrace/text_map_propagator.rb
+++ b/propagator/ottrace/lib/opentelemetry/propagator/ottrace/text_map_propagator.rb
@@ -18,8 +18,8 @@ module OpenTelemetry
       # Propagates context using OTTrace header format
       class TextMapPropagator
         PADDING = '0' * 16
-        VALID_TRACE_ID_REGEX = /^[0-9a-f]{32}$/i.freeze
-        VALID_SPAN_ID_REGEX = /^[0-9a-f]{16}$/i.freeze
+        VALID_TRACE_ID_REGEX = /^[0-9a-f]{32}$/i
+        VALID_SPAN_ID_REGEX = /^[0-9a-f]{16}$/i
         TRACE_ID_64_BIT_WIDTH = 64 / 4
         TRACE_ID_HEADER = 'ot-tracer-traceid'
         SPAN_ID_HEADER = 'ot-tracer-spanid'
@@ -28,8 +28,8 @@ module OpenTelemetry
         FIELDS = [TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER].freeze
 
         # https://github.com/open-telemetry/opentelemetry-specification/blob/14d123c121b6caa53bffd011292c42a181c9ca26/specification/context/api-propagators.md#textmap-propagator0
-        VALID_BAGGAGE_HEADER_NAME_CHARS = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/.freeze
-        INVALID_BAGGAGE_HEADER_VALUE_CHARS = /[^\t\u0020-\u007E\u0080-\u00FF]/.freeze
+        VALID_BAGGAGE_HEADER_NAME_CHARS = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/
+        INVALID_BAGGAGE_HEADER_VALUE_CHARS = /[^\t\u0020-\u007E\u0080-\u00FF]/
 
         private_constant :PADDING, :VALID_TRACE_ID_REGEX, :VALID_SPAN_ID_REGEX, :TRACE_ID_64_BIT_WIDTH, :TRACE_ID_HEADER,
                          :SPAN_ID_HEADER, :SAMPLED_HEADER, :BAGGAGE_HEADER_PREFIX, :FIELDS, :VALID_BAGGAGE_HEADER_NAME_CHARS,

--- a/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
+++ b/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
+++ b/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
       # Propagates context in carriers in the xray single header format
       class TextMapPropagator
         XRAY_CONTEXT_KEY = 'X-Amzn-Trace-Id'
-        XRAY_CONTEXT_REGEX = /\ARoot=(?<trace_id>([a-z0-9\-]{35}))(?:;Parent=(?<span_id>([a-z0-9]{16})))?(?:;Sampled=(?<sampling_state>[01d](?![0-9a-f])))?(?:;(?<trace_state>.*))?\Z/.freeze # rubocop:disable Lint/MixedRegexpCaptureTypes
+        XRAY_CONTEXT_REGEX = /\ARoot=(?<trace_id>([a-z0-9\-]{35}))(?:;Parent=(?<span_id>([a-z0-9]{16})))?(?:;Sampled=(?<sampling_state>[01d](?![0-9a-f])))?(?:;(?<trace_state>.*))?\Z/ # rubocop:disable Lint/MixedRegexpCaptureTypes
         SAMPLED_VALUES = %w[1 d].freeze
         FIELDS = [XRAY_CONTEXT_KEY].freeze
 

--- a/propagator/xray/opentelemetry-propagator-xray.gemspec
+++ b/propagator/xray/opentelemetry-propagator-xray.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'google-cloud-env'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.48.0'
+  spec.add_development_dependency 'rubocop', '~> 1.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/branches/

> Ruby 2.7
> status: security maintenance
> release date: 2019-12-25
> normal maintenance until: 2022-04-01
> EOL: 2023-03-31 (expected)

Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/363