### PR TITLE
refactor: use semantic calls in the sidekiq instrumentation

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -14,13 +14,13 @@ module OpenTelemetry
           class TracerMiddleware
             def call(_worker_class, job, _queue, _redis_pool)
               attributes = {
-                'messaging.system' => 'sidekiq',
+                SemanticConventions::Trace::MESSAGING_SYSTEM => 'sidekiq',
                 'messaging.sidekiq.job_class' => job['wrapped']&.to_s || job['class'],
-                'messaging.message_id' => job['jid'],
-                'messaging.destination' => job['queue'],
-                'messaging.destination_kind' => 'queue'
+                SemanticConventions::Trace::MESSAGING_MESSAGE_ID => job['jid'],
+                SemanticConventions::Trace::MESSAGING_DESTINATION => job['queue'],
+                SemanticConventions::Trace::MESSAGING_DESTINATION_KIND => 'queue'
               }
-              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
+              attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
 
               span_name = case instrumentation_config[:span_naming]
                           when :job_class then "#{job['wrapped']&.to_s || job['class']} send"

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -14,14 +14,14 @@ module OpenTelemetry
           class TracerMiddleware
             def call(_worker, msg, _queue) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
               attributes = {
-                'messaging.system' => 'sidekiq',
+                SemanticConventions::Trace::MESSAGING_SYSTEM => 'sidekiq',
                 'messaging.sidekiq.job_class' => msg['wrapped']&.to_s || msg['class'],
-                'messaging.message_id' => msg['jid'],
-                'messaging.destination' => msg['queue'],
-                'messaging.destination_kind' => 'queue',
-                'messaging.operation' => 'process'
+                SemanticConventions::Trace::MESSAGING_MESSAGE_ID => msg['jid'],
+                SemanticConventions::Trace::MESSAGING_DESTINATION => msg['queue'],
+                SemanticConventions::Trace::MESSAGING_DESTINATION_KIND => 'queue',
+                SemanticConventions::Trace::MESSAGING_OPERATION => 'process'
               }
-              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
+              attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
 
               span_name = case instrumentation_config[:span_naming]
                           when :job_class then "#{msg['wrapped']&.to_s || msg['class']} process"

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/launcher.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/launcher.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
           def ❤ # rubocop:disable Naming/MethodName, Naming/AsciiIdentifiers
             if instrumentation_config[:trace_launcher_heartbeat]
               attributes = {}
-              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
+              attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Launcher#heartbeat', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/poller.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/poller.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
           def enqueue
             if instrumentation_config[:trace_poller_enqueue]
               attributes = {}
-              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
+              attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Scheduled::Poller#enqueue', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/processor.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/processor.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
           def process_one
             if instrumentation_config[:trace_processor_process_one]
               attributes = {}
-              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
+              attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Processor#process_one', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }


### PR DESCRIPTION
simple change to use semantic names over strings, will slowly make my way through the different instrumentations when I have time