### PR TITLE
fix: skip recording non-utf8 kafka keys in racecar and rdkafka

### DIFF
--- a/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/process_message_subscriber.rb
+++ b/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/process_message_subscriber.rb
@@ -35,7 +35,9 @@ module OpenTelemetry
           'messaging.kafka.offset' => payload[:offset]
         }
 
-        attributes['messaging.kafka.message_key'] = payload[:key] if payload[:key]
+        message_key = extract_message_key(payload[:key])
+        attributes['messaging.kafka.message_key'] = message_key if message_key
+
         attributes
       end
 
@@ -53,6 +55,15 @@ module OpenTelemetry
         span.finish
         OpenTelemetry::Context.detach(token)
         OpenTelemetry::Context.detach(parent_token)
+      end
+
+      def extract_message_key(key)
+        # skip encode if already valid utf8
+        return key if key.nil? || (key.encoding == Encoding::UTF_8 && key.valid_encoding?)
+
+        key.encode(Encoding::UTF_8)
+      rescue Encoding::UndefinedConversionError
+        nil
       end
     end
   end

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/consumer.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/consumer.rb
@@ -20,7 +20,9 @@ module OpenTelemetry
                 'messaging.kafka.offset' => message.offset
               }
 
-              attributes['messaging.kafka.message_key'] = message.key if message.key
+              message_key = extract_message_key(message.key)
+              attributes['messaging.kafka.message_key'] = message_key if message_key
+
               parent_context = OpenTelemetry.propagation.extract(message.headers, getter: OpenTelemetry::Common::Propagation.symbol_key_getter)
               span_context = OpenTelemetry::Trace.current_span(parent_context).context
               links = [OpenTelemetry::Trace::Link.new(span_context)] if span_context.valid?
@@ -62,6 +64,15 @@ module OpenTelemetry
 
           def tracer
             Rdkafka::Instrumentation.instance.tracer
+          end
+
+          def extract_message_key(key)
+            # skip encode if already valid utf8
+            return key if key.nil? || (key.encoding == Encoding::UTF_8 && key.valid_encoding?)
+
+            key.encode(Encoding::UTF_8)
+          rescue Encoding::UndefinedConversionError
+            nil
           end
         end
       end


### PR DESCRIPTION
This PR applies a fix to rdkafka and racecar instrumentations that was previously applied to the ruby Kafka instrumentation: https://github.com/open-telemetry/opentelemetry-ruby/pull/1059

The instrumentation was assuming that message keys are only
valid utf8 strings, but message keys can be any string of bytes. See:
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Responses

This was causing encoding errors in exporters, and lost spans, when they were trying to encode strings into utf8 before transport. These problems were originally described here: https://github.com/open-telemetry/opentelemetry-ruby/issues/751

This fix, as with ruby-kaka, skips recording Kafka message keys that are not encodable as utf-8 strings.