### PR TITLE
docs: Fix typo in rspec example

### DIFF
--- a/instrumentation/rspec/README.md
+++ b/instrumentation/rspec/README.md
@@ -18,7 +18,7 @@ To use the instrumentation, call `use` with the name of the instrumentation:
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::Rspec'
+  c.use 'OpenTelemetry::Instrumentation::RSpec'
 end
 ```
 


### PR DESCRIPTION
This should be an uppercase S in order for the example to run properly.