### PR TITLE
feat: Use Rack Middleware Helper

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/railtie.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/railtie.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
 
           app.middleware.insert_before(
             0,
-            OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+            *OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.middleware_args
           )
         end
       end

--- a/instrumentation/grape/test/test_helper.rb
+++ b/instrumentation/grape/test/test_helper.rb
@@ -40,7 +40,7 @@ end
 
 def build_rack_app(api_class)
   builder = Rack::Builder.app do
-    use OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+    use(*OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.middleware_args)
     run api_class
   end
   Rack::MockRequest.new(builder)

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
@@ -28,8 +28,8 @@ module OpenTelemetry
                 end
               end
             end
-            app.use OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
-            app.use Middlewares::TracerMiddleware
+            app.use(*OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.middleware_args)
+            app.use(Middlewares::TracerMiddleware)
           end
         end
       end


### PR DESCRIPTION
The Rack instrumentation supports the ability to use the Rack::Events API for instrumentation.

This change makes updates instrumentations that depend on the Rack instrumentation to use the Events based instrumentation.