### PR TITLE
fix: Set grape.formatter.type to 'custom' for non-Grape formatters

### DIFF
--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -100,9 +100,15 @@ module OpenTelemetry
           end
 
           def formatter_type(formatter)
+            return 'custom' unless built_in_grape_formatter?(formatter)
+
             basename = formatter.name.split('::').last
             # Convert from CamelCase to snake_case
             basename.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+          end
+
+          def built_in_grape_formatter?(formatter)
+            formatter.respond_to?('name') && formatter.name.include?('Grape::Formatter')
           end
         end
       end


### PR DESCRIPTION
While testing our services with the Grape instrumentation, in some cases I ran into this error:

```
{"error"=>{"code"=>"internal_server_error", "message"=>"undefined method `name' for #<Proc:0x00007f3956ae2d38 /app/app/controllers/api/defaults.rb:20 (lambda)>\n\n            basename = formatter.name.split('::').last\n                                ^^^^^"}}
```

This happens whenever a custom Grape formatter is defined as a proc, as shown [here in the Grape docs](https://github.com/ruby-grape/grape/blob/master/README.md?plain=1#L3038).

This PR intends to fix the issue by setting the `grape.formatter.type` to 'custom' for all custom formatters (i.e. both custom classes and procs), and only keep the original formatter name for the Grape built-in formatters.