### PR TITLE
fix: remove redundant require statement for 'rack' from grape instrumentation

### DIFF
--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'rack'
-
 module OpenTelemetry
   module Instrumentation
     module Grape

--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'


### PR DESCRIPTION
and remove rack as a development dependency since we already have it as a transitive dependency from grape.