### PR TITLE
chore: wrap callables in an error handler

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -296,7 +296,7 @@ module OpenTelemetry
                     option[:default]
                   end
           # rubocop:enable Lint/DuplicateBranch
-          if option[:validation_type] == :callable
+          if option[:validation_type] == :callable && value != nil
             value = wrap_lambda_in_error_handler(value, option[:name])
           end
           h[option_name] = value

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -369,13 +369,11 @@ module OpenTelemetry
       end
 
       def wrap_lambda_in_error_handler(lambda_block, option_name)
-        wrapped_lambda = lambda do |*args|
-            lambda_block.call(*args)
-          rescue StandardError => e
-            OpenTelemetry.handle_error(exception: e, message: "Failed to call callable configuration option #{option_name}")
-          end
-
-        wrapped_lambda
+        lambda do |*args|
+          lambda_block.call(*args)
+        rescue StandardError => e
+          OpenTelemetry.handle_error(exception: e, message: "Failed to call callable configuration option #{option_name}")
+        end
       end
     end
   end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -285,9 +285,9 @@ module OpenTelemetry
                   elsif option[:validator].respond_to?(:include?) && option[:validator].include?(config_value)
                     config_value
                   elsif option[:validator].respond_to?(:call) && option[:validator].call(config_override)
-                    wrap_lambda_in_error_handler(config_override, option[:name])
+                    config_override
                   elsif option[:validator].respond_to?(:call) && option[:validator].call(config_value)
-                    wrap_lambda_in_error_handler(config_value, option[:name])
+                    config_value
                   else
                     OpenTelemetry.logger.warn(
                       "Instrumentation #{name} configuration option #{option_name} value=#{config_value} " \
@@ -295,6 +295,10 @@ module OpenTelemetry
                     )
                     option[:default]
                   end
+
+          if option[:validation_type] == :callable
+            value = wrap_lambda_in_error_handler(value, option[:name])
+          end
           # rubocop:enable Lint/DuplicateBranch
           h[option_name] = value
         rescue StandardError => e

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -296,9 +296,7 @@ module OpenTelemetry
                     option[:default]
                   end
           # rubocop:enable Lint/DuplicateBranch
-          if option[:validation_type] == :callable && value != nil && value.respond_to?(:call)
-            value = wrap_lambda_in_error_handler(value, option[:name])
-          end
+          value = wrap_lambda_in_error_handler(value, option[:name]) if option[:validation_type] == :callable && !value.nil? && value.respond_to?(:call)
           h[option_name] = value
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: "Instrumentation #{name} unexpected configuration error")
@@ -372,14 +370,13 @@ module OpenTelemetry
 
       def wrap_lambda_in_error_handler(lambda_block, option_name)
         wrapped_lambda = lambda do |*args|
-          begin
             lambda_block.call(*args)
           rescue StandardError => e
             OpenTelemetry.handle_error(exception: e, message: "Failed to call callable configuration option #{option_name}")
           end
         end
 
-        return wrapped_lambda
+        wrapped_lambda
       end
     end
   end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -296,7 +296,7 @@ module OpenTelemetry
                     option[:default]
                   end
           # rubocop:enable Lint/DuplicateBranch
-          if option[:validation_type] == :callable && value != nil
+          if option[:validation_type] == :callable && value != nil && value.respond_to?(:call)
             value = wrap_lambda_in_error_handler(value, option[:name])
           end
           h[option_name] = value

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -374,7 +374,6 @@ module OpenTelemetry
           rescue StandardError => e
             OpenTelemetry.handle_error(exception: e, message: "Failed to call callable configuration option #{option_name}")
           end
-        end
 
         wrapped_lambda
       end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -295,11 +295,10 @@ module OpenTelemetry
                     )
                     option[:default]
                   end
-
+          # rubocop:enable Lint/DuplicateBranch
           if option[:validation_type] == :callable
             value = wrap_lambda_in_error_handler(value, option[:name])
           end
-          # rubocop:enable Lint/DuplicateBranch
           h[option_name] = value
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: "Instrumentation #{name} unexpected configuration error")


### PR DESCRIPTION
### Summary

This is an attempt to ensure that any exceptions raised by a `callable` configuration option are handled via the `OpenTelemetry.handle_error` handler, which will swallow and log these exceptions by default. This prevents a configuration option typo from incidentally causing tracing instrumentation to raise an error.  It does so by wrapping the original lambda in a lambda which merely calls the original lambda and passes in the expected arguments, but in a `begin / rescue` block. 