### PR TITLE
Release 0.36.0

### DIFF
--- a/instrumentation/all/lib/opentelemetry/instrumentation/all/version.rb
+++ b/instrumentation/all/lib/opentelemetry/instrumentation/all/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module All
-      VERSION = '0.35.0'
+      VERSION = '0.36.0'
     end
   end
 end


### PR DESCRIPTION
Release v0.36.0 of opentelemetry-instrumentation-all to allow users of this gem to pull in recent changes to the other instrumentation gems