### PR TITLE
Provide support for rdkafka fork for Karafka

### DIFF
--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
@@ -11,8 +11,11 @@ module OpenTelemetry
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('0.10.0')
 
+        GEM_VARIANTS = %w[rdkafka karafka-rdkafka]
+        
         compatible do
-          Gem.loaded_specs['rdkafka'].version >= MINIMUM_VERSION
+          variant = GEM_VARIANTS.find { |variant| !Gem.loaded_specs[variant].nil? }
+          variant.version >= MINIMUM_VERSION
         end
 
         install do |_config|

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
@@ -11,11 +11,8 @@ module OpenTelemetry
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('0.10.0')
 
-        GEM_VARIANTS = %w[rdkafka karafka-rdkafka]
-        
         compatible do
-          variant = GEM_VARIANTS.find { |variant| !Gem.loaded_specs[variant].nil? }
-          variant.version >= MINIMUM_VERSION
+          Gem::Version.new(::Rdkafka::VERSION) >= MINIMUM_VERSION
         end
 
         install do |_config|


### PR DESCRIPTION
[Karafka](karafka.io/) is a Ruby and Rails multi-threaded efficient Kafka processing framework built on top of rdkafka with its own rdkafka fork that is API compatible.

This PR aims to provide support for rdkafka telemetry when rdkafka comes from karafka-rdkafka.

Why fork? karafka-rdkafka receives patches and stability improvements much faster than rdkafka itself. The same applies to updates to the underlying librdkafka C code.

P.S. Karafka integration with opentelemetry is also something I am looking into but it is a separate issue.

This PR requires only change in the detection of source (rdkafka vs karafka-rdkafka), rest within the appropriate API scope works and will work exactly the same.