### PR TITLE
fix: GraphQL tracing

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -34,7 +34,7 @@ module OpenTelemetry
         end
 
         def legacy_tracing_requirement_satisfied?
-          Gem::Requirement.new('<= 2.0.17').satisfied_by?(gem_version) || Gem::Requirement.new('~> 2.0.19').satisfied_by?(gem_version)
+          Gem::Requirement.new('<= 2.0.17').satisfied_by?(gem_version) || Gem::Requirement.new('2.0.19').satisfied_by?(gem_version)
         end
 
         ## Supported configuration keys for the install config hash:


### PR DESCRIPTION
Fixes #481

The `legacy_tracing_requirement_satisfied?` logic was returning `true` for `2.0.22` which meant that the tests were _never_ being in non-legacy mode which was hiding many bugs.

This updates the logic to be strict on matching `2.0.19` which will properly detect `2.0.22` as a non-legacy version now.