### PR TITLE
feat!: Add database name for trilogy traces

### DIFF
--- a/instrumentation/trilogy/Appraisals
+++ b/instrumentation/trilogy/Appraisals
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 appraise 'trilogy-2' do
-  gem 'trilogy', '~> 2.0'
+  gem 'trilogy', '~> 2.3'
 end

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         end
 
         compatible do
-          Gem::Requirement.create('>= 2.0', '< 3.0').satisfied_by?(Gem::Version.new(::Trilogy::VERSION))
+          Gem::Requirement.create('>= 2.3', '< 3.0').satisfied_by?(Gem::Version.new(::Trilogy::VERSION))
         end
 
         option :peer_service, default: nil, validate: :string

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -71,6 +71,7 @@ module OpenTelemetry
               ::OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => net_peer_name
             }
 
+            attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name
             attributes[::OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] unless config[:peer_service].nil?
 
             case config[:db_statement]

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -128,8 +128,18 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         client.query('SELECT 1')
 
         _(span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_be_nil
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
+      end
+
+      it 'includes database name' do
+        client.query('SELECT 1')
+
+        _(span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
       end
@@ -139,6 +149,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         client.query(explain_sql)
 
         _(span.name).must_equal 'explain'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'EXPLAIN SELECT ?'
       end
@@ -149,6 +160,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         end.must_raise Trilogy::Error
 
         _(span.name).must_equal 'mysql'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'DESELECT ?'
       end
@@ -159,6 +171,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(client.connected_host).wont_be_nil
 
         _(span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'select @@hostname'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
@@ -168,6 +181,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         last_span = exporter.finished_spans.last
 
         _(last_span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).wont_equal(host)
@@ -189,6 +203,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(client.connected_host).wont_be_nil
 
         _(span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'select @@hostname'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_match(/sock/)
@@ -198,6 +213,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         last_span = exporter.finished_spans.last
 
         _(last_span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).wont_equal(/sock/)
@@ -212,8 +228,8 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         end.must_raise Trilogy::Error
 
         _(span.name).must_equal 'select'
+        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_be_nil
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT INVALID'
 
         _(span.status.code).must_equal(


### PR DESCRIPTION
Add `DB_NAME` to the default attributes for the Trilogy instrumentation. 

This follows the `mysql2` instrumentation: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb#L137 