### PR TITLE
feat!: Separate logical MySQL host from connected host

### DIFF
--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -48,11 +48,6 @@ module OpenTelemetry
 
           FULL_SQL_REGEXP = Regexp.union(MYSQL_COMPONENTS.map { |component| COMPONENTS_REGEX_MAP[component] })
 
-          def initialize(args)
-            @_otel_net_peer_name = args[:host]
-            super
-          end
-
           def query(sql)
             tracer.in_span(
               database_span_name(sql),
@@ -68,11 +63,12 @@ module OpenTelemetry
           def client_attributes(sql)
             attributes = {
               ::OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM => 'mysql',
-              ::OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => net_peer_name
+              ::OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => connection_options.fetch(:host, 'unknown sock'),
             }
 
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name
             attributes[::OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] unless config[:peer_service].nil?
+            attributes['db.mysql.instance.host.name'] = @connected_host if defined?(@connected_host)
 
             case config[:db_statement]
             when :obfuscate
@@ -129,16 +125,6 @@ module OpenTelemetry
 
           def database_name
             connection_options[:database]
-          end
-
-          def net_peer_name
-            if defined?(@connected_host)
-              @connected_host
-            elsif @_otel_net_peer_name
-              @_otel_net_peer_name
-            else
-              'unknown sock'
-            end
           end
 
           def tracer

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -68,7 +68,7 @@ module OpenTelemetry
 
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name
             attributes[::OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] unless config[:peer_service].nil?
-            attributes['db.mysql.instance.host.name'] = @connected_host if defined?(@connected_host)
+            attributes['db.mysql.instance.address'] = @connected_host if defined?(@connected_host)
 
             case config[:db_statement]
             when :obfuscate

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -63,7 +63,7 @@ module OpenTelemetry
           def client_attributes(sql)
             attributes = {
               ::OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM => 'mysql',
-              ::OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => connection_options.fetch(:host, 'unknown sock'),
+              ::OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => connection_options.fetch(:host, 'unknown sock')
             }
 
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -128,13 +128,10 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         client.query('SELECT 1')
 
         _(span.name).must_equal 'select'
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
       end
 
-      it 'includes database name' do
+      it 'includes database connection information' do
         client.query('SELECT 1')
 
         _(span.name).must_equal 'select'
@@ -142,6 +139,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
+        _(span.attributes['db.mysql.instance.host.name']).must_be_nil
       end
 
       it 'extracts statement type' do
@@ -175,6 +173,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'select @@hostname'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
+        _(span.attributes['db.mysql.instance.host.name']).must_be_nil
 
         client.query('SELECT 1')
 
@@ -184,8 +183,8 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_NAME]).must_equal(database)
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).wont_equal(host)
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal client.connected_host
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
+        _(last_span.attributes['db.mysql.instance.host.name']).must_equal client.connected_host
       end
     end
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -73,25 +73,24 @@ describe OpenTelemetry::Instrumentation::Trilogy do
   describe '#compatible?' do
     describe 'when an unsupported version is installed' do
       it 'is incompatible' do
-        stub_const('Trilogy::VERSION', '2.0.0.beta') do
-          _(instrumentation.compatible?).must_equal false
-        end
+        stub_const('Trilogy::VERSION', '2.2.0')
+        _(instrumentation.compatible?).must_equal false
 
-        stub_const('Trilogy::VERSION', '3.0.0') do
-          _(instrumentation.compatible?).must_equal false
-        end
+        stub_const('Trilogy::VERSION', '2.3.0.beta')
+        _(instrumentation.compatible?).must_equal false
+
+        stub_const('Trilogy::VERSION', '3.0.0')
+        _(instrumentation.compatible?).must_equal false
       end
     end
 
     describe 'when supported version is installed' do
       it 'is compatible' do
-        stub_const('Trilogy::VERSION', '2.0.0') do
-          _(instrumentation.compatible?).must_equal true
-        end
+        stub_const('Trilogy::VERSION', '2.3.0')
+        _(instrumentation.compatible?).must_equal true
 
-        stub_const('Trilogy::VERSION', '3.0.0.rc1') do
-          _(instrumentation.compatible?).must_equal true
-        end
+        stub_const('Trilogy::VERSION', '3.0.0.rc1')
+        _(instrumentation.compatible?).must_equal true
       end
     end
   end
@@ -184,7 +183,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
-        _(last_span.attributes['db.mysql.instance.host.name']).must_equal client.connected_host
+        _(last_span.attributes['db.mysql.instance.address']).must_equal client.connected_host
       end
     end
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -138,7 +138,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
-        _(span.attributes['db.mysql.instance.host.name']).must_be_nil
+        _(span.attributes[''db.mysql.instance.address']).must_be_nil
       end
 
       it 'extracts statement type' do
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'select @@hostname'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
-        _(span.attributes['db.mysql.instance.host.name']).must_be_nil
+        _(span.attributes[''db.mysql.instance.address']).must_be_nil
 
         client.query('SELECT 1')
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -138,7 +138,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'SELECT ?'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
-        _(span.attributes[''db.mysql.instance.address']).must_be_nil
+        _(span.attributes['db.mysql.instance.address']).must_be_nil
       end
 
       it 'extracts statement type' do
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_SYSTEM]).must_equal 'mysql'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal 'select @@hostname'
         _(span.attributes[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME]).must_equal(host)
-        _(span.attributes[''db.mysql.instance.address']).must_be_nil
+        _(span.attributes['db.mysql.instance.address']).must_be_nil
 
         client.query('SELECT 1')
 


### PR DESCRIPTION
MySQL server instances have a logical host name and an instance node names.

This is particularly useful when running in clustered mode where a logical hostname is used to connect to a cluster but you also want to record what specific node is executing your query.

Trilogy exposes the instance node name via `@connected_host` as well as the configured `host` name in its `connection_options`.

This breaking change ensures that the `net.peer.name` is always set to the logical host name, while the individual instance name is being recorded in a separate attribute.

cc: @cschleiden 