### PR TITLE
fix: Base config options

### DIFF
--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.1'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activejob', '>= 6.0.0'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'active_model_serializers', '>= 0.10.0'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'ruby2_keywords'
 
   spec.add_development_dependency 'activerecord'

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'aws-sdk', '>= 2.0'

--- a/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
+++ b/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   spec.add_development_dependency 'activesupport'

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activerecord', '~> 6.0'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-instrumentation-active_job', '~> 0.5.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_record', '~> 0.6.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.4.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.4.1'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
+++ b/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
+++ b/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activejob', '>= 6.0'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-semantic_conventions', '>= 1.8.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'


### PR DESCRIPTION
This forces the minimum version of base to include change that evaluates the config options in order to make it availble in the compatible block for GraphQL instrumentation.

This change ensures the min base version is required by all instrumentation gems

https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/498