### PR TITLE
fix: Ensure Rack Events Handler Exists

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -40,7 +40,7 @@ module OpenTelemetry
         #   end
         # @return [Array] consisting of a middleware and arguments used in rack builders
         def middleware_args
-          if config.fetch(:use_rack_events, false) == true && defined?(::Rack::Events)
+          if config.fetch(:use_rack_events, false) == true && defined?(OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler)
             [::Rack::Events, [OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler.new]]
           else
             [OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware]
@@ -50,7 +50,7 @@ module OpenTelemetry
         private
 
         def require_dependencies
-          require_relative 'middlewares/event_handler' if defined?(Rack::Events)
+          require_relative 'middlewares/event_handler' if defined?(::Rack::Events)
           require_relative 'middlewares/tracer_middleware'
         end
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/518

When attempting to use the Rack Events Handler via ActionPack, the install process raises the following error:

```ruby
Failure/Error: Rails.application.initialize!

NameError:
  uninitialized constant OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler

              [::Rack::Events, [OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler.new]]
                                                                                 ^^^^^^^^^^^^^^
# /usr/local/rvm/gems/ruby-3.1.4/gems/opentelemetry-instrumentation-rack-0.23.1/lib/opentelemetry/instrumentation/rack/instrumentation.rb:44:in `middleware_args'
# /usr/local/rvm/gems/ruby-3.1.4/gems/opentelemetry-instrumentation-action_pack-0.7.0/lib/opentelemetry/instrumentation/action_pack/railtie.rb:17:in `block in <class:Railtie>'
```

This is due to constant value shadowing occurring in the instrumentation namespace, where the defined check in require_dependencies is not searching the root namespace and is instead searching the OpenTelemetry::Instrumentation::Rack namespace:

```ruby
Rack::Events
(ruby) defined?(Rack::Events)
nil
(ruby) defined?(::Rack::Events)
"constant"
```

This results in the Event Handler source not being loaded. 