### PR TITLE
chore(deps): update opentelemetry-common from 0.19.3 to 0.20.0

### DIFF
--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activejob', '>= 6.0'

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 


### PR DESCRIPTION
Common bumped minor when it dropped Ruby 2.7 support. Instrumentation had already dropped Ruby support < 3.0, so this is a patch change to allow instrumentation to coexist with newer -common and therefore also coexist with newer -sdk that requires newer -common.

Another use of Budget Dependabot:

```bash
❯ git ls-files \*.gemspec \
  | xargs \
    sed -i '' \
        -E "s/'opentelemetry-common', '~> [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'/'opentelemetry-common', '~> 0.20.0'/"
```

Quick check:

```bash
❯ git ls-files \*.gemspec \
  | xargs grep "opentelemetry-common" \
  | wc -l
      13

❯ git ls-files \*.gemspec \
  | xargs grep "opentelemetry-common" \
  | grep "0.20.0" \
  | wc -l
      13
```