### PR TITLE
Removed appraise for 1.x

### DIFF
--- a/instrumentation/sinatra/Appraisals
+++ b/instrumentation/sinatra/Appraisals
@@ -12,6 +12,4 @@ appraise 'sinatra-2.x' do
   gem 'sinatra', '~> 2.1'
 end
 
-appraise 'sinatra-1.x' do
-  gem 'sinatra', '~> 1.4'
-end
+


### PR DESCRIPTION
This PR is for:
Upgrade minimal gemspec dependencies to Sinatra > 2
Issue:  https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/364

