### PR TITLE
fix: GraphQL tests and installation

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -9,7 +9,11 @@ appraise 'graphql-1.13' do
 end
 
 appraise 'graphql-2.0.17' do
-  gem 'graphql', '~> 2.0.17'
+  gem 'graphql', '2.0.17'
+end
+
+appraise 'graphql-2.0.18' do
+  gem 'graphql', '2.0.18'
 end
 
 appraise 'graphql-2.x' do

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -12,7 +12,11 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          config[:legacy_tracing] || supports_new_tracer?
+          if config[:legacy_tracing]
+            supports_legacy_tracer?
+          else
+            supports_new_tracer?
+          end
         end
 
         install do |config|
@@ -29,8 +33,12 @@ module OpenTelemetry
           defined?(::GraphQL)
         end
 
+        def supports_legacy_tracer?
+          Gem::Requirement.new('!= 2.0.18').satisfied_by?(gem_version)
+        end
+
         def supports_new_tracer?
-          Gem::Requirement.new('>= 2.0.18').satisfied_by?(gem_version)
+          Gem::Requirement.new('>= 2.0.19').satisfied_by?(gem_version)
         end
 
         ## Supported configuration keys for the install config hash:

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -12,11 +12,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          if config[:legacy_tracing]
-            legacy_tracing_requirement_satisfied?
-          else
-            Gem::Requirement.new('>= 2.0.18', '< 3.0.0').satisfied_by?(gem_version)
-          end
+          config[:legacy_tracing] || supports_new_tracer?
         end
 
         install do |config|
@@ -33,8 +29,8 @@ module OpenTelemetry
           defined?(::GraphQL)
         end
 
-        def legacy_tracing_requirement_satisfied?
-          Gem::Requirement.new('<= 2.0.17').satisfied_by?(gem_version) || Gem::Requirement.new('2.0.19').satisfied_by?(gem_version)
+        def supports_new_tracer?
+          Gem::Requirement.new('>= 2.0.18').satisfied_by?(gem_version)
         end
 
         ## Supported configuration keys for the install config hash:

--- a/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
@@ -73,7 +73,7 @@ describe OpenTelemetry::Instrumentation::GraphQL do
         _(SomeGraphQLAppSchema.tracers[0].class).must_equal(expected_tracer)
       end
 
-      it 'does not install instrumentation on gem versions that don't support it' do
+      it 'does not install instrumentation on gem versions that do not support it' do
         skip if instrumentation.supports_legacy_tracer?
 
         instrumentation.install(config)

--- a/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
@@ -73,7 +73,7 @@ describe OpenTelemetry::Instrumentation::GraphQL do
         _(SomeGraphQLAppSchema.tracers[0].class).must_equal(expected_tracer)
       end
 
-      it 'installs the GraphQLTracer instrumentation using legacy api' do
+      it 'does not install instrumentation on gem versions that don't support it' do
         skip if instrumentation.supports_legacy_tracer?
 
         instrumentation.install(config)

--- a/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'test_helper'
-
+require 'opentelemetry-test-helpers'
 require_relative '../../../lib/opentelemetry/instrumentation/graphql'
 
 describe OpenTelemetry::Instrumentation::GraphQL do
@@ -27,16 +27,69 @@ describe OpenTelemetry::Instrumentation::GraphQL do
   end
 
   describe '#install' do
+    let(:config) { { schemas: [SomeGraphQLAppSchema], legacy_tracing: false } }
+
+    it 'installs the GraphQLTrace instrumentation using the latest api' do
+      skip unless instrumentation.supports_new_tracer?
+
+      expected_tracer = OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace
+      instrumentation.install(config)
+      _(SomeGraphQLAppSchema.trace_class.ancestors).must_include(expected_tracer)
+    end
+
+    it 'does not install on incompatible versions of GraphQL' do
+      skip if instrumentation.supports_new_tracer?
+
+      instrumentation.install(config)
+      _(instrumentation.installed?).must_equal(false)
+    end
+
     describe 'when a user supplies an invalid schema' do
-      let(:config) { { schemas: [Old::Truck], legacy_tracing: instrumentation.legacy_tracing_requirement_satisfied? } }
+      let(:config) { { schemas: [Old::Truck], legacy_tracing: false } }
 
       it 'fails gracefully and logs the error' do
-        mock_logger = Minitest::Mock.new
-        mock_logger.expect(:error, nil, [String])
-        OpenTelemetry.stub :logger, mock_logger do
+        skip unless instrumentation.supports_new_tracer?
+
+        OpenTelemetry::TestHelpers.with_test_logger do |log|
           instrumentation.install(config)
+          _(log.string).must_match(
+            / Unable to patch schema Old::Truck: undefined method `trace_with' for Old::Truck:Class/
+          )
         end
-        mock_logger.verify
+      end
+
+      it 'does not install on incompatible versions of GraphQL' do
+        skip if instrumentation.supports_new_tracer?
+
+        instrumentation.install(config)
+        _(instrumentation.installed?).must_equal(false)
+      end
+    end
+
+    describe 'when legacy_tracing is enabled' do
+      let(:config) { { schemas: [SomeGraphQLAppSchema], legacy_tracing: true } }
+
+      it 'installs the GraphQLTracer instrumentation using legacy api' do
+        OpenTelemetry::TestHelpers.with_test_logger do |log|
+          expected_tracer = OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer
+          instrumentation.install(config)
+          _(SomeGraphQLAppSchema.tracers[0].class).must_equal(expected_tracer)
+          _(log.string).must_be_empty
+        end
+      end
+
+      describe 'when a user supplies an invalid schema' do
+        let(:config) { { schemas: [Old::Truck], legacy_tracing: true } }
+
+        it 'fails gracefully and logs the error' do
+          OpenTelemetry::TestHelpers.with_test_logger do |log|
+            instrumentation.install(config)
+
+            _(log.string).must_match(
+              /Unable to patch schema Old::Truck: undefined method `use' for Old::Truck:Class/
+            )
+          end
+        end
       end
     end
   end

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/graphql'
+require_relative '../../../../lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace'
+
+describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::GraphQL::Instrumentation.instance }
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+  let(:config) { {} }
+
+  let(:query_string) do
+    <<-GRAPHQL
+      query($id: Int!){
+        simpleField
+        resolvedField(id: $id) {
+          originalValue
+          uppercasedValue
+        }
+      }
+    GRAPHQL
+  end
+
+  before do
+    # Reset various instance variables to clear state between tests
+    [GraphQL::Schema, SomeOtherGraphQLAppSchema, SomeGraphQLAppSchema].each(&:_reset_tracer_for_testing)
+    instrumentation.instance_variable_set(:@installed, false)
+
+    # This test file is all about testing the GraphQLTrace class
+    # so we're always going to force legacy_tracing to be false
+    config[:legacy_tracing] = false
+    instrumentation.install(config)
+
+    exporter.reset
+  end
+
+  if Gem::Requirement.new('>= 2.0.18').satisfied_by?(gem_version)
+    describe '#platform_trace' do
+      it 'traces platform keys' do
+        expected_spans = [
+          'graphql.lex',
+          'graphql.parse',
+          'graphql.validate',
+          'graphql.analyze_multiplex',
+          'graphql.analyze_query',
+          'graphql.execute_query',
+          'graphql.execute_query_lazy',
+          'graphql.execute_multiplex'
+        ]
+
+        expected_result = {
+          'simpleField' => 'Hello.',
+          'resolvedField' => { 'originalValue' => 'testing=1', 'uppercasedValue' => 'TESTING=1' }
+        }
+
+        result = SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+        _(spans.map(&:name)).must_equal(expected_spans)
+        _(result.to_h['data']).must_equal(expected_result)
+      end
+
+      it 'includes operation attributes for execute_query' do
+        expected_attributes = {
+          'graphql.operation.name' => 'SimpleQuery',
+          'graphql.operation.type' => 'query',
+          'graphql.document' => 'query SimpleQuery{ simpleField }'
+        }
+
+        SomeGraphQLAppSchema.execute('query SimpleQuery{ simpleField }')
+
+        span = spans.find { |s| s.name == 'graphql.execute_query' }
+        _(span).wont_be_nil
+        _(span.attributes.to_h).must_equal(expected_attributes)
+      end
+
+      it 'omits nil attributes for execute_query' do
+        expected_attributes = {
+          'graphql.operation.type' => 'query',
+          'graphql.document' => '{ simpleField }'
+        }
+
+        SomeGraphQLAppSchema.execute('{ simpleField }')
+
+        span = spans.find { |s| s.name == 'graphql.execute_query' }
+        _(span).wont_be_nil
+        _(span.attributes.to_h).must_equal(expected_attributes)
+      end
+
+      describe 'when a set of schemas is provided' do
+        let(:config) { { schemas: [SomeOtherGraphQLAppSchema] } }
+
+        after do
+          # Reset various instance variables to clear state between tests
+          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
+          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
+        end
+
+        it 'traces the provided schemas' do
+          SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+          _(spans.size).must_equal(8)
+        end
+
+        it 'does not trace all schemas' do
+          SomeGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+          _(spans).must_be(:empty?)
+        end
+      end
+
+      describe 'when platform_field is enabled with legacy naming' do
+        let(:config) { { enable_platform_field: true, legacy_platform_span_names: true } }
+
+        it 'traces execute_field' do
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find { |s| s.name == 'Query.resolvedField' }
+          _(span).wont_be_nil
+        end
+      end
+
+      describe 'when platform_field is enabled' do
+        let(:config) { { enable_platform_field: true } }
+
+        it 'traces execute_field' do
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find do |s|
+            s.name == 'graphql.execute_field' &&
+              s.attributes['graphql.field.parent'] == 'Query' &&
+              s.attributes['graphql.field.name'] == 'resolvedField'
+          end
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes using platform types' do
+          skip if uses_platform_interfaces?
+          expected_attributes = {
+            'graphql.field.parent' => 'Car', # type name, not interface
+            'graphql.field.name' => 'model',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+
+          span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+
+        it 'includes attributes using platform interfaces' do
+          skip unless uses_platform_interfaces?
+          expected_attributes = {
+            'graphql.field.parent' => 'Vehicle', # interface name, not type
+            'graphql.field.name' => 'model',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+
+          span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      describe 'when platform_authorized is enabled with legacy naming' do
+        let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: true } }
+
+        it 'traces .authorized' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find { |s| s.name == 'Query.authorized' }
+          _(span).wont_be_nil
+
+          span = spans.find { |s| s.name == 'SlightlyComplex.authorized' }
+          _(span).wont_be_nil
+        end
+      end
+
+      describe 'when platform_authorized is enabled' do
+        let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: false } }
+
+        it 'traces .authorized' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find do |s|
+            s.name == 'graphql.authorized' &&
+              s.attributes['graphql.type.name'] == 'Query'
+          end
+          _(span).wont_be_nil
+
+          span = spans.find do |s|
+            s.name == 'graphql.authorized' &&
+              s.attributes['graphql.type.name'] == 'SlightlyComplex'
+          end
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes' do
+          skip unless supports_authorized_and_resolved_types?
+          expected_attributes = {
+            'graphql.type.name' => 'OtherQuery',
+            'graphql.lazy' => false
+          }
+
+          SomeOtherGraphQLAppSchema.execute('{ simpleField }')
+
+          span = spans.find { |s| s.name == 'graphql.authorized' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      describe 'when platform_resolve_type is enabled with legacy naming' do
+        let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: true } }
+
+        it 'traces .resolve_type' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'Vehicle.resolve_type' }
+          _(span).wont_be_nil
+        end
+      end
+
+      describe 'when platform_resolve_type is enabled' do
+        let(:config) { { enable_platform_resolve_type: true } }
+
+        it 'traces .resolve_type' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'graphql.resolve_type' && s.attributes['graphql.type.name'] == 'Vehicle' }
+          _(span).wont_be_nil
+        end
+
+        it 'traces .resolve_type_lazy' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }', context: { lazy_type_resolve: true })
+
+          span = spans.find do |s|
+            s.name == 'graphql.resolve_type' &&
+              s.attributes['graphql.type.name'] == 'Vehicle' &&
+              s.attributes['graphql.lazy'] == true
+          end
+
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes' do
+          skip unless supports_authorized_and_resolved_types?
+          expected_attributes = {
+            'graphql.type.name' => 'Vehicle',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'graphql.resolve_type' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      it 'traces validate with events' do
+        SomeGraphQLAppSchema.execute(
+          <<-GRAPHQL
+            {
+              nonExistentField
+            }
+          GRAPHQL
+        )
+        span = spans.find { |s| s.name == 'graphql.validate' }
+        event = span.events.find { |e| e.name == 'graphql.validation.error' }
+        # rubocop:disable Layout/LineLength
+        _(event.attributes['message']).must_equal(
+          "[{\"message\":\"Field 'nonExistentField' doesn't exist on type 'Query'\",\"locations\":[{\"line\":2,\"column\":15}],\"path\":[\"query\",\"nonExistentField\"],\"extensions\":{\"code\":\"undefinedField\",\"typeName\":\"Query\",\"fieldName\":\"nonExistentField\"}}]"
+        )
+        # rubocop:enable Layout/LineLength
+      end
+    end
+  end
+end

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -40,7 +40,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
     exporter.reset
   end
 
-  if Gem::Requirement.new('>= 2.0.18').satisfied_by?(gem_version)
+  if OpenTelemetry::Instrumentation::GraphQL::Instrumentation.instance.supports_new_tracer?
     describe '#platform_trace' do
       it 'traces platform keys' do
         expected_spans = [
@@ -282,7 +282,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
         span = spans.find { |s| s.name == 'graphql.validate' }
         event = span.events.find { |e| e.name == 'graphql.validation.error' }
         # rubocop:disable Layout/LineLength
-        _(event.attributes['message']).must_equal(
+        _(event.attributes['exception.message']).must_equal(
           "[{\"message\":\"Field 'nonExistentField' doesn't exist on type 'Query'\",\"locations\":[{\"line\":2,\"column\":15}],\"path\":[\"query\",\"nonExistentField\"],\"extensions\":{\"code\":\"undefinedField\",\"typeName\":\"Query\",\"fieldName\":\"nonExistentField\"}}]"
         )
         # rubocop:enable Layout/LineLength

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -40,238 +40,238 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
     exporter.reset
   end
 
-  describe '#platform_trace' do
-    it 'traces platform keys' do
-      expected_spans = [
-        'graphql.lex',
-        'graphql.parse',
-        'graphql.validate',
-        'graphql.analyze_query',
-        'graphql.analyze_multiplex',
-        'graphql.execute_query',
-        'graphql.execute_query_lazy',
-        'graphql.execute_multiplex'
-      ]
+  if OpenTelemetry::Instrumentation::GraphQL::Instrumentation.instance.supports_legacy_tracer?
+    describe '#platform_trace' do
+      it 'traces platform keys' do
+        expected_spans = [
+          'graphql.lex',
+          'graphql.parse',
+          'graphql.validate',
+          'graphql.analyze_query',
+          'graphql.analyze_multiplex',
+          'graphql.execute_query',
+          'graphql.execute_query_lazy',
+          'graphql.execute_multiplex'
+        ]
 
-      expected_result = {
-        'simpleField' => 'Hello.',
-        'resolvedField' => { 'originalValue' => 'testing=1', 'uppercasedValue' => 'TESTING=1' }
-      }
-
-      result = SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
-
-      _(spans.map(&:name)).must_equal(expected_spans)
-      _(result.to_h['data']).must_equal(expected_result)
-    end
-
-    it 'includes operation attributes for execute_query' do
-      expected_attributes = {
-        'graphql.operation.name' => 'SimpleQuery',
-        'graphql.operation.type' => 'query',
-        'graphql.document' => 'query SimpleQuery{ simpleField }'
-      }
-
-      SomeGraphQLAppSchema.execute('query SimpleQuery{ simpleField }')
-
-      span = spans.find { |s| s.name == 'graphql.execute_query' }
-      _(span).wont_be_nil
-      _(span.attributes.to_h).must_equal(expected_attributes)
-    end
-
-    it 'omits nil attributes for execute_query' do
-      expected_attributes = {
-        'graphql.operation.type' => 'query',
-        'graphql.document' => '{ simpleField }'
-      }
-
-      SomeGraphQLAppSchema.execute('{ simpleField }')
-
-      span = spans.find { |s| s.name == 'graphql.execute_query' }
-      _(span).wont_be_nil
-      _(span.attributes.to_h).must_equal(expected_attributes)
-    end
-
-    describe 'when a set of schemas is provided' do
-      let(:config) { { schemas: [SomeOtherGraphQLAppSchema] } }
-
-      after do
-        # Reset various instance variables to clear state between tests
-        SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
-        SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
-      end
-
-      it 'traces the provided schemas' do
-        SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
-
-        _(spans.size).must_equal(8)
-      end
-
-      it 'does not trace all schemas' do
-        SomeGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
-
-        _(spans).must_be(:empty?)
-      end
-    end
-
-    describe 'when platform_field is enabled with legacy naming' do
-      let(:config) { { enable_platform_field: true, legacy_platform_span_names: true } }
-
-      it 'traces execute_field' do
-        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
-
-        span = spans.find { |s| s.name == 'Query.resolvedField' }
-        _(span).wont_be_nil
-      end
-    end
-
-    describe 'when platform_field is enabled' do
-      let(:config) { { enable_platform_field: true } }
-
-      it 'traces execute_field' do
-        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
-
-        span = spans.find do |s|
-          s.name == 'graphql.execute_field' &&
-            s.attributes['graphql.field.parent'] == 'Query' &&
-            s.attributes['graphql.field.name'] == 'resolvedField'
-        end
-        _(span).wont_be_nil
-      end
-
-      it 'includes attributes using platform types' do
-        skip if uses_platform_interfaces?
-        expected_attributes = {
-          'graphql.field.parent' => 'Car', # type name, not interface
-          'graphql.field.name' => 'model',
-          'graphql.lazy' => false
+        expected_result = {
+          'simpleField' => 'Hello.',
+          'resolvedField' => { 'originalValue' => 'testing=1', 'uppercasedValue' => 'TESTING=1' }
         }
 
-        SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+        result = SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
 
-        span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+        _(spans.map(&:name)).must_equal(expected_spans)
+        _(result.to_h['data']).must_equal(expected_result)
+      end
+
+      it 'includes operation attributes for execute_query' do
+        expected_attributes = {
+          'graphql.operation.name' => 'SimpleQuery',
+          'graphql.operation.type' => 'query',
+          'graphql.document' => 'query SimpleQuery{ simpleField }'
+        }
+
+        SomeGraphQLAppSchema.execute('query SimpleQuery{ simpleField }')
+
+        span = spans.find { |s| s.name == 'graphql.execute_query' }
         _(span).wont_be_nil
         _(span.attributes.to_h).must_equal(expected_attributes)
       end
 
-      it 'includes attributes using platform interfaces' do
-        skip unless uses_platform_interfaces?
+      it 'omits nil attributes for execute_query' do
         expected_attributes = {
-          'graphql.field.parent' => 'Vehicle', # interface name, not type
-          'graphql.field.name' => 'model',
-          'graphql.lazy' => false
+          'graphql.operation.type' => 'query',
+          'graphql.document' => '{ simpleField }'
         }
 
-        SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+        SomeGraphQLAppSchema.execute('{ simpleField }')
 
-        span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+        span = spans.find { |s| s.name == 'graphql.execute_query' }
         _(span).wont_be_nil
         _(span.attributes.to_h).must_equal(expected_attributes)
       end
-    end
 
-    describe 'when platform_authorized is enabled with legacy naming' do
-      let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: true } }
+      describe 'when a set of schemas is provided' do
+        let(:config) { { schemas: [SomeOtherGraphQLAppSchema] } }
 
-      it 'traces .authorized' do
-        skip unless supports_authorized_and_resolved_types?
-        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
-
-        span = spans.find { |s| s.name == 'Query.authorized' }
-        _(span).wont_be_nil
-
-        span = spans.find { |s| s.name == 'SlightlyComplex.authorized' }
-        _(span).wont_be_nil
-      end
-    end
-
-    describe 'when platform_authorized is enabled' do
-      let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: false } }
-
-      it 'traces .authorized' do
-        skip unless supports_authorized_and_resolved_types?
-        SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
-
-        span = spans.find do |s|
-          s.name == 'graphql.authorized' &&
-            s.attributes['graphql.type.name'] == 'Query'
-        end
-        _(span).wont_be_nil
-
-        span = spans.find do |s|
-          s.name == 'graphql.authorized' &&
-            s.attributes['graphql.type.name'] == 'SlightlyComplex'
-        end
-        _(span).wont_be_nil
-      end
-
-      it 'includes attributes' do
-        skip unless supports_authorized_and_resolved_types?
-        expected_attributes = {
-          'graphql.type.name' => 'OtherQuery',
-          'graphql.lazy' => false
-        }
-
-        SomeOtherGraphQLAppSchema.execute('{ simpleField }')
-
-        span = spans.find { |s| s.name == 'graphql.authorized' }
-        _(span).wont_be_nil
-        _(span.attributes.to_h).must_equal(expected_attributes)
-      end
-    end
-
-    describe 'when platform_resolve_type is enabled with legacy naming' do
-      let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: true } }
-
-      it 'traces .resolve_type' do
-        skip unless supports_authorized_and_resolved_types?
-        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
-
-        span = spans.find { |s| s.name == 'Vehicle.resolve_type' }
-        _(span).wont_be_nil
-      end
-    end
-
-    describe 'when platform_resolve_type is enabled' do
-      let(:config) { { enable_platform_resolve_type: true } }
-
-      it 'traces .resolve_type' do
-        skip unless supports_authorized_and_resolved_types?
-        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
-
-        span = spans.find { |s| s.name == 'graphql.resolve_type' && s.attributes['graphql.type.name'] == 'Vehicle' }
-        _(span).wont_be_nil
-      end
-
-      it 'traces .resolve_type_lazy' do
-        skip unless supports_authorized_and_resolved_types?
-        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }', context: { lazy_type_resolve: true })
-
-        span = spans.find do |s|
-          s.name == 'graphql.resolve_type' &&
-            s.attributes['graphql.type.name'] == 'Vehicle' &&
-            s.attributes['graphql.lazy'] == true
+        after do
+          # Reset various instance variables to clear state between tests
+          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
+          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
         end
 
-        _(span).wont_be_nil
+        it 'traces the provided schemas' do
+          SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+          _(spans.size).must_equal(8)
+        end
+
+        it 'does not trace all schemas' do
+          SomeGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+          _(spans).must_be(:empty?)
+        end
       end
 
-      it 'includes attributes' do
-        skip unless supports_authorized_and_resolved_types?
-        expected_attributes = {
-          'graphql.type.name' => 'Vehicle',
-          'graphql.lazy' => false
-        }
+      describe 'when platform_field is enabled with legacy naming' do
+        let(:config) { { enable_platform_field: true, legacy_platform_span_names: true } }
 
-        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+        it 'traces execute_field' do
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
 
-        span = spans.find { |s| s.name == 'graphql.resolve_type' }
-        _(span).wont_be_nil
-        _(span.attributes.to_h).must_equal(expected_attributes)
+          span = spans.find { |s| s.name == 'Query.resolvedField' }
+          _(span).wont_be_nil
+        end
       end
-    end
 
-    describe 'validate spans' do
-      it 'adds events for validation errors' do
+      describe 'when platform_field is enabled' do
+        let(:config) { { enable_platform_field: true } }
+
+        it 'traces execute_field' do
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find do |s|
+            s.name == 'graphql.execute_field' &&
+              s.attributes['graphql.field.parent'] == 'Query' &&
+              s.attributes['graphql.field.name'] == 'resolvedField'
+          end
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes using platform types' do
+          skip if uses_platform_interfaces?
+          expected_attributes = {
+            'graphql.field.parent' => 'Car', # type name, not interface
+            'graphql.field.name' => 'model',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+
+          span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+
+        it 'includes attributes using platform interfaces' do
+          skip unless uses_platform_interfaces?
+          expected_attributes = {
+            'graphql.field.parent' => 'Vehicle', # interface name, not type
+            'graphql.field.name' => 'model',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { model } }')
+
+          span = spans.find { |s| s.name == 'graphql.execute_field' && s.attributes['graphql.field.name'] == 'model' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      describe 'when platform_authorized is enabled with legacy naming' do
+        let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: true } }
+
+        it 'traces .authorized' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find { |s| s.name == 'Query.authorized' }
+          _(span).wont_be_nil
+
+          span = spans.find { |s| s.name == 'SlightlyComplex.authorized' }
+          _(span).wont_be_nil
+        end
+      end
+
+      describe 'when platform_authorized is enabled' do
+        let(:config) { { enable_platform_authorized: true, legacy_platform_span_names: false } }
+
+        it 'traces .authorized' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute(query_string, variables: { id: 1 })
+
+          span = spans.find do |s|
+            s.name == 'graphql.authorized' &&
+              s.attributes['graphql.type.name'] == 'Query'
+          end
+          _(span).wont_be_nil
+
+          span = spans.find do |s|
+            s.name == 'graphql.authorized' &&
+              s.attributes['graphql.type.name'] == 'SlightlyComplex'
+          end
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes' do
+          skip unless supports_authorized_and_resolved_types?
+          expected_attributes = {
+            'graphql.type.name' => 'OtherQuery',
+            'graphql.lazy' => false
+          }
+
+          SomeOtherGraphQLAppSchema.execute('{ simpleField }')
+
+          span = spans.find { |s| s.name == 'graphql.authorized' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      describe 'when platform_resolve_type is enabled with legacy naming' do
+        let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: true } }
+
+        it 'traces .resolve_type' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'Vehicle.resolve_type' }
+          _(span).wont_be_nil
+        end
+      end
+
+      describe 'when platform_resolve_type is enabled' do
+        let(:config) { { enable_platform_resolve_type: true } }
+
+        it 'traces .resolve_type' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'graphql.resolve_type' && s.attributes['graphql.type.name'] == 'Vehicle' }
+          _(span).wont_be_nil
+        end
+
+        it 'traces .resolve_type_lazy' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }', context: { lazy_type_resolve: true })
+
+          span = spans.find do |s|
+            s.name == 'graphql.resolve_type' &&
+              s.attributes['graphql.type.name'] == 'Vehicle' &&
+              s.attributes['graphql.lazy'] == true
+          end
+
+          _(span).wont_be_nil
+        end
+
+        it 'includes attributes' do
+          skip unless supports_authorized_and_resolved_types?
+          expected_attributes = {
+            'graphql.type.name' => 'Vehicle',
+            'graphql.lazy' => false
+          }
+
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          span = spans.find { |s| s.name == 'graphql.resolve_type' }
+          _(span).wont_be_nil
+          _(span.attributes.to_h).must_equal(expected_attributes)
+        end
+      end
+
+      it 'traces validate with events' do
         SomeGraphQLAppSchema.execute(
           <<-GRAPHQL
             {


### PR DESCRIPTION
Following https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/482#issuecomment-1570289103

- We're now testing each tracer implementation explicitly.
- The installation logic is being tested.
- Remove the logic that disallowed use of the legacy tracer with current releases of graphql