### PR TITLE
ci: Fix Minitest

### DIFF
--- a/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
+++ b/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
@@ -266,7 +266,7 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Patches::ActiveJobCallbacks 
 
   describe 'force_flush option' do
     let(:mock_tracer_provider) do
-      mock_tracer_provider = MiniTest::Mock.new
+      mock_tracer_provider = Minitest::Mock.new
       mock_tracer_provider.expect(:force_flush, true)
 
       mock_tracer_provider

--- a/resource_detectors/test/opentelemetry/detectors/azure_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/azure_test.rb
@@ -59,7 +59,7 @@ describe OpenTelemetry::Resource::Detectors::Azure do
       end
 
       before do
-        metadata = MiniTest::Mock.new
+        metadata = Minitest::Mock.new
         metadata.expect(:code, 200)
         metadata.expect(:body, azure_metadata)
         metadata.expect(:nil?, false)

--- a/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
@@ -41,7 +41,7 @@ describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
       let(:project_id) { 'opentelemetry' }
 
       before do
-        gcp_env_mock = MiniTest::Mock.new
+        gcp_env_mock = Minitest::Mock.new
         gcp_env_mock.expect(:compute_engine?, true)
         gcp_env_mock.expect(:project_id, project_id)
         gcp_env_mock.expect(:instance_attribute, 'us-central1', %w[cluster-location])


### PR DESCRIPTION
Minitest 5.19 removes the automatic compatability layer that allowed users to use `MiniTest` camel case module name.

https://github.com/minitest/minitest/compare/v5.18.1...v5.19.0

Rather than continuing to support antiquated code lets bring ourselves up to date with a rename that happened almost 10 years ago.