### PR TITLE
chore: rename opentelemetry-resource-detector-container gem for symmetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -178,6 +178,6 @@ updates:
   schedule:
     interval: weekly
 - package-ecosystem: bundler
-  directory: "/resource_detectors/container"
+  directory: "/resources/container"
   schedule:
     interval: weekly

--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         gem:
           - resource_detectors
-          - resource_detectors-container
+          - resource-detector-container
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         gem:
           - resource_detectors
-          - resource_detectors-container
+          - resource-detector-container
         os:
           - ubuntu-latest
     name: "opentelemetry-${{ matrix.gem }} / ${{ matrix.os }}"

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -204,7 +204,7 @@ gems:
     version_rb_path: lib/opentelemetry/resource/detectors/version.rb
     version_constant: [OpenTelemetry, Resource, Detectors, VERSION]
 
-  - name: opentelemetry-resource_detectors-container
+  - name: opentelemetry-resource-detector-container
     directory: resources/container
-    version_rb_path: lib/opentelemetry/resource/detectors/container/version.rb
-    version_constant: [OpenTelemetry, Resource, Detectors, Container, VERSION]
+    version_rb_path: lib/opentelemetry/resource/detector/container/version.rb
+    version_constant: [OpenTelemetry, Resource, Detector, Container, VERSION]

--- a/resources/container/CHANGELOG.md
+++ b/resources/container/CHANGELOG.md
@@ -1,8 +1,4 @@
-# Release History: opentelemetry-resourcedetector-container
-
-### v0.1.0 /
-
-* Initial release
+# Release History: opentelemetry-resource-detector-container
 
 ### v0.1.0 / 2023-07-29
 

--- a/resources/container/README.md
+++ b/resources/container/README.md
@@ -1,6 +1,6 @@
-# Opentelemetry::Resource::Detectors::Container
+# OpenTelemetry::Resource::Detector::Container
 
-The `opentelemetry-resource_detectors-container` gem provides a container resource detector for OpenTelemetry.
+The `opentelemetry-resource-detector-container` gem provides a container resource detector for OpenTelemetry.
 
 ## What is OpenTelemetry?
 
@@ -10,7 +10,7 @@ OpenTelemetry provides a single set of APIs, libraries, agents, and collector se
 
 ## How does this gem fit in?
 
-The `opentelemetry-resource_detectors-container` gem provides a means of retrieving a resource for supported environments following the resource semantic conventions.
+The `opentelemetry-resource-detector-container` gem provides a means of retrieving a resource for supported environments following the resource semantic conventions.
 
 ## How do I get started?
 
@@ -18,28 +18,31 @@ Install the gem using:
 
 ```
 gem install opentelemetry-sdk
-gem install opentelemetry-resource_detectors-container
+gem install opentelemetry-resource-detector-container
 ```
 
-Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource_detectors-container` in your `Gemfile`.
+Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource-detector-container` in your `Gemfile`.
 
 ```rb
 require 'opentelemetry/sdk'
-require 'opentelemetry/resource/detectors'
+require 'opentelemetry/resource/detector'
 
 OpenTelemetry::SDK.configure do |c|
-  c.resource = OpenTelemetry::Resource::Detectors::Container.detect
+  c.resource = OpenTelemetry::Resource::Detector::Container.detect
 end
 ```
 
+This will populate the `container.id` resource attribute for processes running on containers. Further enrichment might be performed using the [Kubernetes Attributes Processor][k8sattributesprocessor-url] in the OpenTelemetry Collector.
+
 ## How can I get involved?
 
-The `opentelemetry-resource_detectors-container` gem source is on github, along with related gems.
+The `opentelemetry-resource-detector-container` gem source is on GitHub, along with related gems.
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the meeting calendar for dates and times. For more information on this and other language SIGs, see the OpenTelemetry community page.
 
 ## License
 
-The `opentelemetry-resource_detectors-container` gem is distributed under the Apache 2.0 license. See LICENSE for more information.
+The `opentelemetry-resource-detector-container` gem is distributed under the Apache 2.0 license. See LICENSE for more information.
 
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions
+[k8sattributesprocessor-url]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md

--- a/resources/container/lib/opentelemetry-resource-detector-container.rb
+++ b/resources/container/lib/opentelemetry-resource-detector-container.rb
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative 'opentelemetry/resource/detectors'
+require_relative 'opentelemetry/resource/detector'

--- a/resources/container/lib/opentelemetry/resource/detector.rb
+++ b/resources/container/lib/opentelemetry/resource/detector.rb
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry/sdk'
-require 'opentelemetry/resource/detectors/container'
-require 'opentelemetry/resource/detectors/container/version'
+require 'opentelemetry/resource/detector/container'
+require 'opentelemetry/resource/detector/container/version'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation
@@ -16,8 +16,8 @@ require 'opentelemetry/resource/detectors/container/version'
 # See the documentation for the `opentelemetry-api` gem for details.
 module OpenTelemetry
   module Resource
-    # Detectors contains the resource detectors
-    module Detectors
+    # Detector contains the resource detectors
+    module Detector
     end
   end
 end

--- a/resources/container/lib/opentelemetry/resource/detector/container.rb
+++ b/resources/container/lib/opentelemetry/resource/detector/container.rb
@@ -6,7 +6,7 @@
 
 module OpenTelemetry
   module Resource
-    module Detectors
+    module Detector
       # Container contains detect class method for determining container resource attributes
       module Container
         extend self

--- a/resources/container/lib/opentelemetry/resource/detector/container/version.rb
+++ b/resources/container/lib/opentelemetry/resource/detector/container/version.rb
@@ -6,7 +6,7 @@
 
 module OpenTelemetry
   module Resource
-    module Detectors
+    module Detector
       module Container
         VERSION = '0.1.0'
       end

--- a/resources/container/opentelemetry-resource-detector-container.gemspec
+++ b/resources/container/opentelemetry-resource-detector-container.gemspec
@@ -6,11 +6,11 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'opentelemetry/resource/detectors/container/version'
+require 'opentelemetry/resource/detector/container/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'opentelemetry-resource_detectors-container'
-  spec.version     = OpenTelemetry::Resource::Detectors::Container::VERSION
+  spec.name        = 'opentelemetry-resource-detector-container'
+  spec.version     = OpenTelemetry::Resource::Detector::Container::VERSION
   spec.authors     = ['OpenTelemetry Authors']
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
-    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/resource_detectors/container'
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/resources/container'
     spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues'
     spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
   end

--- a/resources/container/test/opentelemetry/resource/detector/container_test.rb
+++ b/resources/container/test/opentelemetry/resource/detector/container_test.rb
@@ -6,8 +6,8 @@
 
 require 'test_helper'
 
-describe OpenTelemetry::Resource::Detectors::Container do
-  let(:detector) { OpenTelemetry::Resource::Detectors::Container }
+describe OpenTelemetry::Resource::Detector::Container do
+  let(:detector) { OpenTelemetry::Resource::Detector::Container }
 
   describe '.detect' do
     let(:detected_resource) { detector.detect }

--- a/resources/container/test/test_helper.rb
+++ b/resources/container/test/test_helper.rb
@@ -10,7 +10,7 @@ Bundler.require(:default, :development, :test)
 SimpleCov.minimum_coverage 85
 SimpleCov.start
 
-require 'opentelemetry-resource_detectors-container'
+require 'opentelemetry-resource-detector-container'
 require 'minitest/autorun'
 require 'webmock/minitest'
 


### PR DESCRIPTION
Renames the (currently unreleased) `opentelemetry-resource_detectors-container` gem to `opentelemetry-resource-detector-container`.
This is to achieve symmetry with e.g. [JS resource detector](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container) and [Python resource detector](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/resource/opentelemetry-resource-detector-container)