### PR TITLE
fix: Fix opentelemetry-api version constraint in grape gemspec

### DIFF
--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 


### PR DESCRIPTION
Fixes issue reported in https://cloud-native.slack.com/archives/C01NWKKMKMY/p1690982323934849

> Hi, we’ve run into an issue with the most recent opentelemetry-api release to 1.2x causing opentelemetry-instrumentation-all to be downgraded by dependabot. From what I can gather this is due to some instrumentation having dependencies of opentelemetry-api <~ 1.1 rather than opentelemetry-api <~ 1 .
> Looks like it is just the grape instrumentation from a quick check: https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-ruby-contrib+spec.add_dependency+%27opentelemetry-api%27+1.1&type=code

![image](https://github.com/open-telemetry/opentelemetry-ruby-contrib/assets/24720032/63b8a42b-1ac1-4c2d-9b3c-8c69722c001e)