### PR TITLE
ci: Run Latest Gem Versions

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -24,6 +24,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  latest:
+    description: Build against the latest version of the gem
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: composite
@@ -50,8 +55,11 @@ runs:
         fi
 
         echo "appraisals=false" >> $GITHUB_OUTPUT
-        if [[ -f "${dir}/Appraisals" ]]; then
-          echo "appraisals=true" >> $GITHUB_OUTPUT
+
+        if [[ "${{ inputs.latest }}" != "true" ]]; then
+          if [[ -f "${dir}/Appraisals" ]]; then
+            echo "appraisals=true" >> $GITHUB_OUTPUT
+          fi
         fi
 
     # Install ruby and bundle dependencies and cache!

--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -26,17 +26,20 @@ jobs:
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.2"
+          latest: "true"
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.1"
+          latest: "true"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "3.0"
+          latest: "true"
           yard: true
           rubocop: true
           build: true
@@ -46,12 +49,14 @@ jobs:
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "jruby-9.4.2.0"
+          latest: "true"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-propagator-${{ matrix.gem }}"
           ruby: "truffleruby"
+          latest: "true"
 
   resource-detectors:
     strategy:
@@ -73,17 +78,20 @@ jobs:
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.2"
+          latest: "true"
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.1"
+          latest: "true"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "3.0"
+          latest: "true"
           yard: true
           rubocop: true
           build: true
@@ -93,9 +101,11 @@ jobs:
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "jruby-9.4.2.0"
+          latest: "true"
       - name: "Test truffleruby"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-${{ matrix.gem }}"
           ruby: "truffleruby"
+          latest: "true"

--- a/.github/workflows/ci-instrumentation-canary.yml
+++ b/.github/workflows/ci-instrumentation-canary.yml
@@ -62,17 +62,20 @@ jobs:
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.2"
+          latest: "true"
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.1"
+          latest: "true"
       - name: "Test Ruby 3.0"
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
+          latest: "true"
           yard: true
           rubocop: true
           build: true
@@ -102,6 +105,7 @@ jobs:
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          latest: "true"
           ruby: "jruby-9.4.2.0"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
@@ -124,3 +128,4 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "truffleruby"
+          latest: "true"

--- a/.github/workflows/ci-instrumentation-with-services-canary.yml
+++ b/.github/workflows/ci-instrumentation-with-services-canary.yml
@@ -34,16 +34,19 @@ jobs:
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.2"
+          latest: "true"
       - name: "Test Ruby 3.1"
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.1"
+          latest: "true"
       - name: "Test Ruby 3.0"
         uses: ./.github/actions/test_gem
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "3.0"
+          latest: "true"
           yard: true
           rubocop: true
           build: true
@@ -70,6 +73,7 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "jruby-9.4.2.0"
+          latest: "true"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash
@@ -86,6 +90,7 @@ jobs:
         with:
           gem:  "opentelemetry-instrumentation-${{ matrix.gem }}"
           ruby: "truffleruby"
+          latest: "true"
     services:
       zookeeper:
         image: confluentinc/cp-zookeeper:latest


### PR DESCRIPTION
This change updates the canary builds to only run against the latest version of gems.

This will give us a heads up when newer versions of a gem are released and are not covered by appraisals.