### PR TITLE
chore: Fix changelogs

### DIFF
--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-instrumentation-base
 
+### v0.22.2 / 2023-08-03
+
+* FIXED: Remove inline linter rules
+
 ### v0.22.1 / 2023-06-02
 
 * feat: make config available to compatible blocks #453
@@ -49,7 +53,3 @@
 ### v0.17.0 / 2021-04-22
 
 * Initial release.
-
-### v0.22.2 / 2023-08-03
-
-* FIXED: Remove inline linter rules

--- a/resource_detectors/CHANGELOG.md
+++ b/resource_detectors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-resource_detectors
 
+### v0.24.1 / 2023-08-03
+
+* FIXED: Remove inline linter rules
+
 ### v0.24.0 / 2023-08-02
 
 * ADDED: Add container resource detector
@@ -96,11 +100,3 @@
 
 * FIXED: Rename Resource labels to attributes 
 * ADDED: Environment variable resource detection
-
-### v0.24.1 / 2023-08-03
-
-* FIXED: Remove inline linter rules
-
-### v0.24.0 / 2023-08-02
-
-* ADDED: Add container resource detector.


### PR DESCRIPTION
The auto-generated changelogs caused failures in releasing resource detectors and base

https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/611