### PR TITLE
Ensure Sidekiq TracerMiddleware is in expected order

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -67,7 +67,7 @@ module OpenTelemetry
         def add_client_middleware
           ::Sidekiq.configure_client do |config|
             config.client_middleware do |chain|
-              chain.add Middlewares::Client::TracerMiddleware
+              chain.prepend Middlewares::Client::TracerMiddleware
             end
           end
         end
@@ -75,16 +75,16 @@ module OpenTelemetry
         def add_server_middleware
           ::Sidekiq.configure_server do |config|
             config.client_middleware do |chain|
-              chain.add Middlewares::Client::TracerMiddleware
+              chain.prepend Middlewares::Client::TracerMiddleware
             end
             config.server_middleware do |chain|
-              chain.add Middlewares::Server::TracerMiddleware
+              chain.prepend Middlewares::Server::TracerMiddleware
             end
           end
 
           if defined?(::Sidekiq::Testing) # rubocop:disable Style/GuardClause
             ::Sidekiq::Testing.server_middleware do |chain|
-              chain.add Middlewares::Server::TracerMiddleware
+              chain.prepend Middlewares::Server::TracerMiddleware
             end
           end
         end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/instrumentation_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/instrumentation_test.rb
@@ -29,4 +29,93 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Instrumentation do
       _(instrumentation.compatible?).must_equal true
     end
   end
+
+  describe '#install' do
+    before do
+      @sidekiq_config = if Sidekiq.respond_to?(:client_middleware) # Sidekiq < 7.0.0
+                          Sidekiq
+                        else # Sidekiq >= 7.0.0
+                          Sidekiq.default_configuration
+                        end
+
+      @orig_client_wares = @sidekiq_config.client_middleware.entries.dup
+      @orig_server_wares = @sidekiq_config.server_middleware.entries.dup
+      @orig_testin_wares = Sidekiq::Testing.server_middleware.entries.dup
+    end
+
+    after do
+      # Force re-install of instrumentation
+      instrumentation.instance_variable_set(:@installed, false)
+
+      # Reset the middleware chains
+      @sidekiq_config.client_middleware.instance_variable_set(:@entries, @orig_client_wares)
+      @sidekiq_config.server_middleware.instance_variable_set(:@entries, @orig_server_wares)
+      Sidekiq::Testing.server_middleware.instance_variable_set(:@entries, @orig_testin_wares)
+    end
+
+    describe 'configuring the Sidekiq Client' do
+      before do
+        Sidekiq.stub(:server?, false) do
+          Sidekiq.configure_client do |config|
+            config.client_middleware do |chain|
+              chain.add(Frontkiq::SweetClientMiddleware)
+            end
+          end
+        end
+      end
+
+      it 'prepends the Client::TracerMiddleware to the Sidekiq Client middleware chain' do
+        Sidekiq.stub(:server?, false) do
+          instrumentation.install
+        end
+
+        middlewares = @sidekiq_config.client_middleware.entries
+        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
+        _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+      end
+    end
+
+    describe 'configuring the Sidekiq Server' do
+      before do
+        Sidekiq.stub(:server?, true) do
+          Sidekiq.configure_server do |config|
+            config.client_middleware do |chain|
+              chain.add(Frontkiq::SweetClientMiddleware)
+            end
+            config.server_middleware do |chain|
+              chain.add(Frontkiq::SweetServerMiddleware)
+            end
+          end
+
+          Sidekiq::Testing.server_middleware do |chain|
+            chain.add(Frontkiq::SweetServerMiddleware)
+          end
+        end
+      end
+
+      it 'prepends the Client::TracerMiddleware to the Sidekiq Client middleware chain' do
+        Sidekiq.stub(:server?, true) do
+          instrumentation.install
+        end
+
+        middlewares = @sidekiq_config.client_middleware.entries
+        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
+        _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+      end
+
+      it 'prepends the Server::TracerMiddleware to the Sidekiq Server middleware chain' do
+        Sidekiq.stub(:server?, true) do
+          instrumentation.install
+        end
+
+        middlewares = @sidekiq_config.server_middleware.entries
+        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
+        _(middlewares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
+
+        testing_wares = Sidekiq::Testing.server_middleware.entries
+        _(testing_wares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
+        _(testing_wares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
+      end
+    end
+  end
 end

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -88,3 +88,25 @@ class ExceptionTestingJob
     raise 'a little hell'
   end
 end
+
+module Frontkiq
+  class SweetClientMiddleware
+    # Use middleware base classes that come with Sidekiq >= 7.0.0
+    include ::Sidekiq::ClientMiddleware if defined?(::Sidekiq::ClientMiddleware)
+
+    # see https://github.com/sidekiq/sidekiq/wiki/Middleware
+    def call(_job_class_or_string, _job, _queue, _redis_pool)
+      yield
+    end
+  end
+
+  class SweetServerMiddleware
+    # Use middleware base classes that come with Sidekiq >= 7.0.0
+    include ::Sidekiq::ServerMiddleware if defined?(::Sidekiq::ServerMiddleware)
+
+    # see https://github.com/sidekiq/sidekiq/wiki/Middleware
+    def call(_job_instance, _job_payload, _queue_name)
+      yield
+    end
+  end
+end


### PR DESCRIPTION
This change will ensure the middleware is put at the front of the Client and Server middleware chains, by default. This is a change from the existing behavior which will add them to the end of the chain, and that position is determined entirely by when the SDK is configured. In a Rails app, that usually means it depends on the name of the `config/initializers/*.rb` file `OpenTelemetry::SDK.configure` is called from.

I'm not sure if we should consider this a breaking change or not. I suppose _maybe_ as someone could have accidentally been depending on the order the middleware was kinda-sorta-randomly being installed. Thoughts?