### PR TITLE
fix: ensure that transaction name property is used, rather than self

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/transactions_class_methods.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/transactions_class_methods.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
           # Contains ActiveRecord::Transactions::ClassMethods to be patched
           module ClassMethods
             def transaction(**options, &block)
-              tracer.in_span("#{self}.transaction") do
+              tracer.in_span('ActiveRecord.transaction', attributes: { 'code.namespace' => name }) do
                 super
               end
             end

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/transactions_class_methods_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/transactions_class_methods_test.rb
@@ -19,14 +19,33 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::TransactionsClas
     it 'traces' do
       User.transaction { User.create! }
 
-      transaction_span = spans.find { |s| s.name == 'User.transaction' }
+      transaction_span = spans.find { |s| s.attributes['code.namespace'] == 'User' }
       _(transaction_span).wont_be_nil
     end
 
     it 'traces base transactions' do
       ActiveRecord::Base.transaction { User.create! }
 
-      transaction_span = spans.find { |s| s.name == 'ActiveRecord::Base.transaction' }
+      transaction_span = spans.find { |s| s.name == 'ActiveRecord.transaction' }
+      _(transaction_span).wont_be_nil
+    end
+
+    it 'traces dynamically created transaction classes' do
+      klass = Class.new(User) do
+        def self.name
+          'Klass'
+        end
+      end
+      klass.transaction { klass.create! }
+
+      transaction_span = spans.find { |s| s.attributes['code.namespace'] == 'Klass' }
+      _(transaction_span).wont_be_nil
+    end
+
+    it 'records transaction name as code namespace' do
+      ActiveRecord::Base.transaction { User.create! }
+
+      transaction_span = spans.find { |s| s.attributes['code.namespace'] == 'ActiveRecord::Base' }
       _(transaction_span).wont_be_nil
     end
   end


### PR DESCRIPTION
~~This ensures that if a class is dynamically instantiated (singleton class / metaclass) such as by the [Blazer](https://github.com/ankane/blazer/blob/ade703d022bc98c2bd1a1259010daab3043fd102/lib/blazer/adapters/sql_adapter.rb#L12) gem, the transaction name string is used rather than something like `#<Class:0x00007fc635f69cf0>(FooBar)`.~~

This ensures that if a class is dynamically instantiated (singleton class / metaclass) such as by the Blazer gem, the transaction name string is used for the code namespace rather than setting the span name to something like #<Class:0x00007fc635f69cf0>(FooBar)