### PR TITLE
fix: improve GraphQL tracing compatibility with other tracers

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -15,9 +15,9 @@ module OpenTelemetry
         module GraphQLTrace # rubocop:disable Metrics/ModuleLength
           def initialize(trace_scalars: false, **_options)
             @trace_scalars = trace_scalars
-            @platform_field_key_cache = Hash.new { |h, k| h[k] = platform_field_key(k) }
-            @platform_authorized_key_cache = Hash.new { |h, k| h[k] = platform_authorized_key(k) }
-            @platform_resolve_type_key_cache = Hash.new { |h, k| h[k] = platform_resolve_type_key(k) }
+            @_otel_field_key_cache = Hash.new { |h, k| h[k] = _otel_field_key(k) }
+            @_otel_authorized_key_cache = Hash.new { |h, k| h[k] = _otel_authorized_key(k) }
+            @_otel_resolve_type_key_cache = Hash.new { |h, k| h[k] = _otel_resolve_type_key(k) }
             super
           end
 
@@ -72,7 +72,7 @@ module OpenTelemetry
           end
 
           def execute_field(field:, query:, ast_node:, arguments:, object:, &block)
-            platform_key = platform_execute_field_key(field: field)
+            platform_key = _otel_execute_field_key(field: field)
             return super unless platform_key
 
             attributes = {}
@@ -84,7 +84,7 @@ module OpenTelemetry
           end
 
           def execute_field_lazy(field:, query:, ast_node:, arguments:, object:, &block)
-            platform_key = platform_execute_field_key(field: field)
+            platform_key = _otel_execute_field_key(field: field)
             return super unless platform_key
 
             attributes = {}
@@ -96,7 +96,7 @@ module OpenTelemetry
           end
 
           def authorized(query:, type:, object:, &block)
-            platform_key = @platform_authorized_key_cache[type]
+            platform_key = @_otel_authorized_key_cache[type]
             return super unless platform_key
 
             attributes = {}
@@ -107,7 +107,7 @@ module OpenTelemetry
           end
 
           def authorized_lazy(query:, type:, object:, &block)
-            platform_key = @platform_authorized_key_cache[type]
+            platform_key = @_otel_authorized_key_cache[type]
             return super unless platform_key
 
             attributes = {}
@@ -118,7 +118,7 @@ module OpenTelemetry
           end
 
           def resolve_type(query:, type:, object:, &block)
-            platform_key = @platform_resolve_type_key_cache[type]
+            platform_key = @_otel_resolve_type_key_cache[type]
 
             attributes = {}
             attributes['graphql.type.name'] = type.graphql_name
@@ -128,7 +128,7 @@ module OpenTelemetry
           end
 
           def resolve_type_lazy(query:, type:, object:, &block)
-            platform_key = @platform_resolve_type_key_cache[type]
+            platform_key = @_otel_resolve_type_key_cache[type]
 
             attributes = {}
             attributes['graphql.type.name'] = type.graphql_name
@@ -139,9 +139,9 @@ module OpenTelemetry
 
           private
 
-          def platform_execute_field_key(field:, &block)
+          def _otel_execute_field_key(field:, &block)
             trace_field = trace_field?(field)
-            platform_key = @platform_field_key_cache[field] if trace_field
+            platform_key = @_otel_field_key_cache[field] if trace_field
             platform_key if platform_key && trace_field
           end
 
@@ -155,7 +155,7 @@ module OpenTelemetry
             end
           end
 
-          def platform_field_key(field)
+          def _otel_field_key(field)
             return unless config[:enable_platform_field]
 
             if config[:legacy_platform_span_names]
@@ -165,7 +165,7 @@ module OpenTelemetry
             end
           end
 
-          def platform_authorized_key(type)
+          def _otel_authorized_key(type)
             return unless config[:enable_platform_authorized]
 
             if config[:legacy_platform_span_names]
@@ -175,7 +175,7 @@ module OpenTelemetry
             end
           end
 
-          def platform_resolve_type_key(type)
+          def _otel_resolve_type_key(type)
             return unless config[:enable_platform_resolve_type]
 
             if config[:legacy_platform_span_names]


### PR DESCRIPTION
All of the graphql-ruby built-in tracers use the common [`PlatformTrace` module](https://github.com/rmosolgo/graphql-ruby/blob/15cf025a2fd34518529c95054a10d4be1985ff22/lib/graphql/tracing/platform_trace.rb). OpenTelemetry's tracer does not use it directly, but uses the same underlying instance variable and method names.

This can cause conflicts because the new tracing API mixes in trace modules into a single class. This means OpenTelemetry's trace module could override other ones (or vice versa).

This fix avoids conflicts entirely by using the `opentelemetry` prefix for some methods and instance variables instead of the ones used in `PlatformTrace`.

An alternative solution would be to refactor this implementation to actually use `PlatformTrace`. I chose against it some reason originally but I don't remember why 😅 I figured this is just easier for now.

cc @rmosolgo