### PR TITLE
feat: Add ability to configure propagation style per job/queue in Sidekiq instrumentation

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -29,6 +29,7 @@ module OpenTelemetry
 
         option :span_naming,                 default: :queue, validate: %I[job_class queue]
         option :propagation_style,           default: :link,  validate: %i[link child none]
+        option :propagation_style_per_job,   default: nil,   validate: :callable
         option :trace_launcher_heartbeat,    default: false, validate: :boolean
         option :trace_poller_enqueue,        default: false, validate: :boolean
         option :trace_poller_wait,           default: false, validate: :boolean


### PR DESCRIPTION
Currently, propagation style can be configured for the whole app and it will be applied to all jobs. If `propagation_style` is set to `child`, then it's convenient to see a trace where the two "producer" and "consumer" spans are shown next to each other and there is a little (usually several ms) between them. 
However, in some cases, we schedule jobs to be performed over a longer period, for example in several days. Then if  `propagation_style` is set to `child` then visually the trace will be unreadable because there will be a huge gap between the spans where nothing happens.
This PR adds a new `propagation_style_per_job` option that allows dynamically choose propagation style per job or queue.

Example:
```ruby
c.use 'OpenTelemetry::Instrumentation::Sidekiq',
  propagation_style: :child,
  propagation_style_per_job: lambda { |job_class_str, _queue|
    :link if job_class_str == 'SomeJob'
  }
```