### PR TITLE
refactor: split resource_detectors into their own gems.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -178,6 +178,14 @@ updates:
   schedule:
     interval: weekly
 - package-ecosystem: bundler
+  directory: "/resources/azure"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
   directory: "/resources/container"
+  schedule:
+    interval: weekly
+- package-ecosystem: bundler
+  directory: "/resources/google_cloud_platform"
   schedule:
     interval: weekly

--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -64,7 +64,9 @@ jobs:
       matrix:
         gem:
           - resource_detectors
+          - resource-detector-azure
           - resource-detector-container
+          - resource-detector-google_cloud_platform
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -55,7 +55,9 @@ jobs:
       matrix:
         gem:
           - resource_detectors
+          - resource-detector-azure
           - resource-detector-container
+          - resource-detector-google_cloud_platform
         os:
           - ubuntu-latest
     name: "opentelemetry-${{ matrix.gem }} / ${{ matrix.os }}"

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -208,7 +208,17 @@ gems:
     version_rb_path: lib/opentelemetry/resource/detectors/version.rb
     version_constant: [OpenTelemetry, Resource, Detectors, VERSION]
 
+  - name: opentelemetry-resource-detector-azure
+    directory: resources/azure
+    version_rb_path: lib/opentelemetry/resource/detector/azure/version.rb
+    version_constant: [OpenTelemetry, Resource, Detector, Azure, VERSION]
+
   - name: opentelemetry-resource-detector-container
     directory: resources/container
     version_rb_path: lib/opentelemetry/resource/detector/container/version.rb
     version_constant: [OpenTelemetry, Resource, Detector, Container, VERSION]
+
+  - name: opentelemetry-resource-detector-google_cloud_platform
+    directory: resources/google_cloud_platform
+    version_rb_path: lib/opentelemetry/resource/detector/google_cloud_platform/version.rb
+    version_constant: [OpenTelemetry, Resource, Detector, GoogleCloudPlatform, VERSION]

--- a/releases/Gemfile
+++ b/releases/Gemfile
@@ -51,3 +51,10 @@ Dir['../instrumentation/**/version.rb'].each do |f|
   version = File.read(f).match(/VERSION = '([\d\.]+)'/)[1]
   gem "opentelemetry-instrumentation-#{name}", version
 end
+
+Dir['../resources/**/version.rb'].each do |f|
+  name = f.match(%r{resources/(\w+)/lib})[1]
+
+  version = File.read(f).match(/VERSION = '([\d\.]+)'/)[1]
+  gem "opentelemetry-resource-detector-#{name}", version
+end

--- a/resource_detectors/lib/opentelemetry/resource/detectors/azure.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/azure.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
 
         def detect
           OpenTelemetry.logger.warn('Azure resource detector - The Azure resource detector has been moved to a separate gem. ' \
-                                       'Please use the "opentelemetry-resource-detector-azure" gem onwards.')
+                                    'Please use the "opentelemetry-resource-detector-azure" gem onwards.')
 
           metadata = azure_metadata
           resource_attributes = {}

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -36,6 +36,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'
 
+  spec.post_install_message = 'This gem has been deprecated. Please use opentelemetry-resource-detector-azure ' \
+                              'or opentelemetry-resource-detector-google_cloud_platform onwards.'
+
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
     spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/resource_detectors'

--- a/resources/azure/.rubocop.yml
+++ b/resources/azure/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/resources/azure/.yardopts
+++ b/resources/azure/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=OpenTelemetry Resource Detector Container
+--title=OpenTelemetry Resource Detector Azure
 --markup=markdown
 --main=README.md
 ./lib/opentelemetry/resource/detector/**/*.rb

--- a/resources/azure/CHANGELOG.md
+++ b/resources/azure/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-resource-detector-azure

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+group :development, :test do
+  gem 'byebug' unless RUBY_PLATFORM == 'java'
+  gem 'pry'
+end

--- a/resources/azure/LICENSE
+++ b/resources/azure/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/resources/azure/README.md
+++ b/resources/azure/README.md
@@ -1,0 +1,58 @@
+# OpenTelemetry::Resource::Detector::Azure
+
+The `opentelemetry-resource-detector-azure` gem provides a Azure resource detector for OpenTelemetry.
+
+## What is OpenTelemetry?
+
+OpenTelemetry is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-resource-detector-azure` gem provides a means of retrieving a resource for supported environments following the resource semantic conventions.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk
+gem install opentelemetry-resource-detector-azure
+```
+
+Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource-detector-azure` in your `Gemfile`.
+
+```rb
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector'
+
+OpenTelemetry::SDK.configure do |c|
+  c.resource = OpenTelemetry::Resource::Detector::Azure.detect
+end
+```
+
+This will populate the following resource attributes for compute running on Azure:
+
+* `cloud.provider`
+* `cloud.account.id`
+* `cloud.platform`
+* `cloud.region`
+* `cloud.availability_zone`
+* `host.id`
+* `host.image.id`
+* `host.name`
+* `host.type`
+
+## How can I get involved?
+
+The `opentelemetry-resource-detector-azure` gem source is on GitHub, along with related gems.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the meeting calendar for dates and times. For more information on this and other language SIGs, see the OpenTelemetry community page.
+
+## License
+
+The `opentelemetry-resource-detector-azure` gem is distributed under the Apache 2.0 license. See LICENSE for more information.
+
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions
+[k8sattributesprocessor-url]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md

--- a/resources/azure/Rakefile
+++ b/resources/azure/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/resources/azure/lib/opentelemetry-resource-detector-azure.rb
+++ b/resources/azure/lib/opentelemetry-resource-detector-azure.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'opentelemetry/resource/detector'

--- a/resources/azure/lib/opentelemetry/resource/detector.rb
+++ b/resources/azure/lib/opentelemetry/resource/detector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector/azure'
+require 'opentelemetry/resource/detector/azure/version'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  module Resource
+    # Detector contains the resource detectors
+    module Detector
+    end
+  end
+end

--- a/resources/azure/lib/opentelemetry/resource/detector/azure.rb
+++ b/resources/azure/lib/opentelemetry/resource/detector/azure.rb
@@ -8,22 +8,14 @@ require 'net/http'
 
 module OpenTelemetry
   module Resource
-    module Detectors
+    module Detector
       # Azure contains detect class method for determining Azure environment resource attributes
-      #
-      # This gem has been moved into a separate gem:
-      # opentelemetry-resource-detector-azure
-      #
-      # Log a warning if someone still uses this gem for Azure Resource Detection
       module Azure
         extend self
 
         AZURE_METADATA_URI = 'http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15'
 
         def detect
-          OpenTelemetry.logger.warn('Azure resource detector - The Azure resource detector has been moved to a separate gem. ' \
-                                       'Please use the "opentelemetry-resource-detector-azure" gem onwards.')
-
           metadata = azure_metadata
           resource_attributes = {}
 

--- a/resources/azure/lib/opentelemetry/resource/detector/azure/version.rb
+++ b/resources/azure/lib/opentelemetry/resource/detector/azure/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Resource
+    module Detector
+      module Azure
+        VERSION = '0.1.0'
+      end
+    end
+  end
+end

--- a/resources/azure/opentelemetry-resource-detector-azure.gemspec
+++ b/resources/azure/opentelemetry-resource-detector-azure.gemspec
@@ -6,16 +6,16 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'opentelemetry/resource/detector/container/version'
+require 'opentelemetry/resource/detector/azure/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'opentelemetry-resource-detector-container'
-  spec.version     = OpenTelemetry::Resource::Detector::Container::VERSION
+  spec.name        = 'opentelemetry-resource-detector-azure'
+  spec.version     = OpenTelemetry::Resource::Detector::Azure::VERSION
   spec.authors     = ['OpenTelemetry Authors']
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
-  spec.summary     = 'Container resource detection helpers for OpenTelemetry'
-  spec.description = 'Container resource detection helpers for OpenTelemetry'
+  spec.summary     = 'Azure resource detection helpers for OpenTelemetry'
+  spec.description = 'Azure resource detection helpers for OpenTelemetry'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
 
@@ -30,9 +30,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.55.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/resources/azure/opentelemetry-resource-detector-azure.gemspec
+++ b/resources/azure/opentelemetry-resource-detector-azure.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/resources/azure/test/opentelemetry/resource/detector/azure_test.rb
+++ b/resources/azure/test/opentelemetry/resource/detector/azure_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Resource::Detector::Azure do
+  before do
+    WebMock.disable_net_connect!
+    stub_request(:get, 'http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15')
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host' => '169.254.169.254',
+          'Metadata' => 'true',
+          'User-Agent' => 'Ruby'
+        }
+      ).to_raise(SocketError)
+  end
+
+  after do
+    WebMock.allow_net_connect!
+  end
+
+  let(:detector) { OpenTelemetry::Resource::Detector::Azure }
+
+  describe '.detect' do
+    let(:detected_resource) { detector.detect }
+    let(:detected_resource_attributes) { detected_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) { {} }
+
+    describe 'when NOT in an azure environment' do
+      it 'returns an empty resource' do
+        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+        _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      end
+    end
+
+    describe 'when in an azure VM environment' do
+      let(:project_id) { 'opentelemetry' }
+      let(:azure_metadata) do
+        {
+          'subscriptionId' => project_id,
+          'provider' => 'Microsoft.Compute',
+          'location' => 'westeurope',
+          'zone' => '2',
+          'vmId' => '012345671234-abcd-1234-0123456789ab',
+          'storageProfile' => {
+            'imageReference' => {
+              'id' => '/subscriptions/12345678-abcd-1234-abcd-0123456789ab/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/1804gen2containerd/versions/2022.06.22'
+            }
+          },
+          'vmSize' => 'Standard_D2s_v3',
+          'name' => 'opentelemetry'
+        }.to_json
+      end
+
+      before do
+        metadata = Minitest::Mock.new
+        metadata.expect(:code, 200)
+        metadata.expect(:body, azure_metadata)
+        metadata.expect(:nil?, false)
+
+        WebMock.disable_net_connect!
+        stub_request(:get, 'http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Host' => '169.254.169.254',
+              'Metadata' => 'true',
+              'User-Agent' => 'Ruby'
+            }
+          ).to_return(status: 200, body: azure_metadata, headers: {})
+      end
+
+      after do
+        WebMock.allow_net_connect!
+      end
+
+      let(:expected_resource_attributes) do
+        {
+          'cloud.provider' => 'azure',
+          'cloud.account.id' => 'opentelemetry',
+          'cloud.platform' => 'azure_vm',
+          'cloud.region' => 'westeurope',
+          'cloud.availability_zone' => '2',
+          'host.id' => '012345671234-abcd-1234-0123456789ab',
+          'host.image.id' => '/subscriptions/12345678-abcd-1234-abcd-0123456789ab/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/1804gen2containerd/versions/2022.06.22',
+          'host.name' => 'opentelemetry',
+          'host.type' => 'Standard_D2s_v3'
+        }
+      end
+
+      it 'returns a resource with azure attributes' do
+        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+        _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      end
+
+      describe 'and a nil resource value is detected' do
+        let(:project_id) { nil }
+
+        it 'returns a resource without that attribute' do
+          _(detected_resource_attributes.key?('cloud.account.id')).must_equal(false)
+        end
+      end
+
+      describe 'and an empty string resource value is detected' do
+        let(:project_id) { '' }
+
+        it 'returns a resource without that attribute' do
+          _(detected_resource_attributes.key?('cloud.account.id')).must_equal(false)
+        end
+      end
+    end
+  end
+end

--- a/resources/azure/test/test_helper.rb
+++ b/resources/azure/test/test_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+SimpleCov.minimum_coverage 85
+SimpleCov.start
+
+require 'opentelemetry-resource-detector-azure'
+require 'minitest/autorun'
+require 'webmock/minitest'
+
+OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/resources/container/test/test_helper.rb
+++ b/resources/container/test/test_helper.rb
@@ -12,6 +12,5 @@ SimpleCov.start
 
 require 'opentelemetry-resource-detector-container'
 require 'minitest/autorun'
-require 'webmock/minitest'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/resources/google_cloud_platform/.rubocop.yml
+++ b/resources/google_cloud_platform/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/resources/google_cloud_platform/.yardopts
+++ b/resources/google_cloud_platform/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=OpenTelemetry Resource Detector Container
+--title=OpenTelemetry Resource Detector Google Cloud Platform
 --markup=markdown
 --main=README.md
 ./lib/opentelemetry/resource/detector/**/*.rb

--- a/resources/google_cloud_platform/CHANGELOG.md
+++ b/resources/google_cloud_platform/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-resource-detector-google_cloud_platform

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+group :development, :test do
+  gem 'byebug' unless RUBY_PLATFORM == 'java'
+  gem 'pry'
+end

--- a/resources/google_cloud_platform/LICENSE
+++ b/resources/google_cloud_platform/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/resources/google_cloud_platform/README.md
+++ b/resources/google_cloud_platform/README.md
@@ -1,0 +1,72 @@
+# OpenTelemetry::Resource::Detector::GoogleCloudPlatform
+
+The `opentelemetry-resource-detector-google_cloud_platform` gem provides a Google Cloud Platform resource detector for OpenTelemetry.
+
+## What is OpenTelemetry?
+
+OpenTelemetry is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-resource-detector-google_cloud_platform` gem provides a means of retrieving a resource for supported environments following the resource semantic conventions.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk
+gem install opentelemetry-resource-detector-google_cloud_platform
+```
+
+Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource-detector-google_cloud_platform` in your `Gemfile`.
+
+```rb
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector'
+
+OpenTelemetry::SDK.configure do |c|
+  c.resource = OpenTelemetry::Resource::Detector::GoogleCloudPlatform.detect
+end
+```
+
+
+This will populate the following resource attributes for compute running on Google Cloud Platform:
+
+* Compute Engine:
+* * `cloud.provider`
+* * `cloud.account.id`
+* * `cloud.region`
+* * `cloud.availability_zone`
+* * `host.id`
+* * `host.name`
+
+* Google Kubernetes Engine:
+* * `k8s.cluster.name`
+* * `k8s.namespace.name`
+* * `k8s.pod.name`
+* * `k8s.node.name`
+* * `container.name`
+
+* Google Cloud Run:
+* * `cloud.provider`
+* * `cloud.account.id`
+* * `cloud.region`
+* * `cloud.availability_zone`
+* * `faas.name`
+* * `faas.version`
+
+## How can I get involved?
+
+The `opentelemetry-resource-detector-google_cloud_platform` gem source is on GitHub, along with related gems.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the meeting calendar for dates and times. For more information on this and other language SIGs, see the OpenTelemetry community page.
+
+## License
+
+The `opentelemetry-resource-detector-google_cloud_platform` gem is distributed under the Apache 2.0 license. See LICENSE for more information.
+
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions
+[k8sattributesprocessor-url]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md

--- a/resources/google_cloud_platform/Rakefile
+++ b/resources/google_cloud_platform/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/resources/google_cloud_platform/lib/opentelemetry-resource-detector-google_cloud_platform.rb
+++ b/resources/google_cloud_platform/lib/opentelemetry-resource-detector-google_cloud_platform.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'opentelemetry/resource/detector'

--- a/resources/google_cloud_platform/lib/opentelemetry/resource/detector.rb
+++ b/resources/google_cloud_platform/lib/opentelemetry/resource/detector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector/google_cloud_platform'
+require 'opentelemetry/resource/detector/google_cloud_platform/version'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  module Resource
+    # Detector contains the resource detectors
+    module Detector
+    end
+  end
+end

--- a/resources/google_cloud_platform/lib/opentelemetry/resource/detector/google_cloud_platform.rb
+++ b/resources/google_cloud_platform/lib/opentelemetry/resource/detector/google_cloud_platform.rb
@@ -8,20 +8,12 @@ require 'google-cloud-env'
 
 module OpenTelemetry
   module Resource
-    module Detectors
+    module Detector
       # GoogleCloudPlatform contains detect class method for determining gcp environment resource attributes
-      #
-      # This gem has been moved into a separate gem:
-      # opentelemetry-resource-detector-google_cloud_platform
-      #
-      # Log a warning if someone still uses this gem for GoogleCloudPlatform Resource Detection
       module GoogleCloudPlatform
         extend self
 
         def detect
-          OpenTelemetry.logger.warn('GoogleCloudPlatform resource detector - The GoogleCloudPlatform resource detector has been moved to a separate gem. ' \
-                                    'Please use the "opentelemetry-resource-detector-google_cloud_platform" gem onwards.')
-
           gcp_env = Google::Cloud::Env.new
           resource_attributes = {}
 

--- a/resources/google_cloud_platform/lib/opentelemetry/resource/detector/google_cloud_platform/version.rb
+++ b/resources/google_cloud_platform/lib/opentelemetry/resource/detector/google_cloud_platform/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Resource
+    module Detector
+      module GoogleCloudPlatform
+        VERSION = '0.1.0'
+      end
+    end
+  end
+end

--- a/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
+++ b/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
+++ b/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
@@ -6,16 +6,16 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'opentelemetry/resource/detector/container/version'
+require 'opentelemetry/resource/detector/google_cloud_platform/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'opentelemetry-resource-detector-container'
-  spec.version     = OpenTelemetry::Resource::Detector::Container::VERSION
+  spec.name        = 'opentelemetry-resource-detector-google_cloud_platform'
+  spec.version     = OpenTelemetry::Resource::Detector::GoogleCloudPlatform::VERSION
   spec.authors     = ['OpenTelemetry Authors']
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
-  spec.summary     = 'Container resource detection helpers for OpenTelemetry'
-  spec.description = 'Container resource detection helpers for OpenTelemetry'
+  spec.summary     = 'Google Cloud Platform resource detection helpers for OpenTelemetry'
+  spec.description = 'Google Cloud Platform resource detection helpers for OpenTelemetry'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
 
@@ -25,14 +25,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6.0'
 
+  spec.add_dependency 'google-cloud-env'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.55.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'webmock', '~> 3.18.1'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/resources/google_cloud_platform/test/opentelemetry/resource/detector/google_cloud_platform_test.rb
+++ b/resources/google_cloud_platform/test/opentelemetry/resource/detector/google_cloud_platform_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Resource::Detector::GoogleCloudPlatform do
+  let(:detector) { OpenTelemetry::Resource::Detector::GoogleCloudPlatform }
+
+  describe '.detect' do
+    before do
+      WebMock.disable_net_connect!
+      stub_request(:get, 'http://169.254.169.254/')
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Metadata-Flavor' => 'Google',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: '', headers: {})
+    end
+
+    after do
+      WebMock.allow_net_connect!
+    end
+
+    let(:detected_resource) { detector.detect }
+    let(:detected_resource_attributes) { detected_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) { {} }
+
+    it 'returns an empty resource' do
+      _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+      _(detected_resource_attributes).must_equal(expected_resource_attributes)
+    end
+
+    describe 'when in a gcp environment' do
+      let(:project_id) { 'opentelemetry' }
+
+      before do
+        gcp_env_mock = Minitest::Mock.new
+        gcp_env_mock.expect(:compute_engine?, true)
+        gcp_env_mock.expect(:project_id, project_id)
+        gcp_env_mock.expect(:instance_attribute, 'us-central1', %w[cluster-location])
+        gcp_env_mock.expect(:instance_zone, 'us-central1-a')
+        gcp_env_mock.expect(:lookup_metadata, 'opentelemetry-test', %w[instance id])
+        gcp_env_mock.expect(:lookup_metadata, 'opentelemetry-node-1', %w[instance hostname])
+        gcp_env_mock.expect(:instance_attribute, 'opentelemetry-cluster', %w[cluster-name])
+        gcp_env_mock.expect(:kubernetes_engine?, true)
+        gcp_env_mock.expect(:kubernetes_engine_namespace_id, 'default')
+        gcp_env_mock.expect(:knative?, true)
+        gcp_env_mock.expect(:project_id, project_id)
+        gcp_env_mock.expect(:knative_service_id, 'test-google-cloud-function')
+        gcp_env_mock.expect(:knative_service_revision, '2')
+        gcp_env_mock.expect(:instance_zone, 'us-central1-a')
+
+        Socket.stub(:gethostname, 'opentelemetry-test') do
+          old_hostname = ENV.fetch('HOSTNAME', nil)
+          ENV['HOSTNAME'] = 'opentelemetry-host-name-1'
+          begin
+            Google::Cloud::Env.stub(:new, gcp_env_mock) { detected_resource }
+          ensure
+            ENV['HOSTNAME'] = old_hostname
+          end
+        end
+      end
+
+      let(:expected_resource_attributes) do
+        {
+          'cloud.provider' => 'gcp',
+          'cloud.account.id' => 'opentelemetry',
+          'cloud.region' => 'us-central1',
+          'cloud.availability_zone' => 'us-central1-a',
+          'host.id' => 'opentelemetry-test',
+          'host.name' => 'opentelemetry-host-name-1',
+          'k8s.cluster.name' => 'opentelemetry-cluster',
+          'k8s.namespace.name' => 'default',
+          'k8s.pod.name' => 'opentelemetry-host-name-1',
+          'k8s.node.name' => 'opentelemetry-node-1',
+          'faas.name' => 'test-google-cloud-function',
+          'faas.version' => '2'
+        }
+      end
+
+      it 'returns a resource with gcp attributes' do
+        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+        _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      end
+
+      describe 'and a nil resource value is detected' do
+        let(:project_id) { nil }
+
+        it 'returns a resource without that attribute' do
+          _(detected_resource_attributes.key?('cloud.account.id')).must_equal(false)
+        end
+      end
+
+      describe 'and an empty string resource value is detected' do
+        let(:project_id) { '' }
+
+        it 'returns a resource without that attribute' do
+          _(detected_resource_attributes.key?('cloud.account.id')).must_equal(false)
+        end
+      end
+    end
+  end
+end

--- a/resources/google_cloud_platform/test/test_helper.rb
+++ b/resources/google_cloud_platform/test/test_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+SimpleCov.minimum_coverage 85
+SimpleCov.start
+
+require 'opentelemetry-resource-detector-google_cloud_platform'
+require 'minitest/autorun'
+require 'webmock/minitest'
+
+OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)


### PR DESCRIPTION
This refactoring results in the current resource detectors split into their own separate gems (as is already the case for the [Container Resource Detector](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/resources/container)).

The current all-encompassing gem will still be available for now. When someone still uses it; a WARN log message will be shown stating that the new gems should be used onwards.

In a subsequent PR the all-encompassing gem (`opentelemetry-resource_detectors`) will be removed.