### PR TITLE
fix(instrumentation): Align messaging instrumentation operation names

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
             base.class_eval do
               around_enqueue do |job, block|
                 span_kind = job.class.queue_adapter_name == 'inline' ? :client : :producer
-                span_name = "#{otel_config[:span_naming] == :job_class ? job.class : job.queue_name} send"
+                span_name = "#{otel_config[:span_naming] == :job_class ? job.class : job.queue_name} publish"
                 span_attributes = job_attributes(job)
                 otel_tracer.in_span(span_name, attributes: span_attributes, kind: span_kind) do
                   OpenTelemetry.propagation.inject(job.metadata)

--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
@@ -95,7 +95,7 @@ module OpenTelemetry
         def span_name(context, client_method)
           case client_method
           when SQS_SEND_MESSAGE, SQS_SEND_MESSAGE_BATCH, SNS_PUBLISH
-            "#{MessagingHelper.queue_name(context)} send"
+            "#{MessagingHelper.queue_name(context)} publish"
           when SQS_RECEIVE_MESSAGE
             "#{MessagingHelper.queue_name(context)} receive"
           else

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -205,7 +205,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         sns_client.publish message: 'msg', phone_number: '123456'
 
         _(last_span.attributes['messaging.destination']).must_equal 'phone_number'
-        _(last_span.name).must_equal 'phone_number send'
+        _(last_span.name).must_equal 'phone_number publish'
       end
     end
   end

--- a/instrumentation/bunny/lib/opentelemetry/instrumentation/bunny/patch_helpers.rb
+++ b/instrumentation/bunny/lib/opentelemetry/instrumentation/bunny/patch_helpers.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
           attributes = basic_attributes(channel, channel.connection, exchange, routing_key)
           destination = destination_name(exchange, routing_key)
 
-          tracer.in_span("#{destination} send", attributes: attributes, kind: :producer, &block)
+          tracer.in_span("#{destination} publish", attributes: attributes, kind: :producer, &block)
         end
 
         def self.with_process_span(channel, tracer, delivery_info, properties, &block)

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/channel_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/channel_test.rb
@@ -48,17 +48,17 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Channel do
 
     _(spans.size >= 3).must_equal(true)
 
-    send_span = spans.find { |span| span.name == "#{topic}.ruby.news send" }
-    _(send_span).wont_be_nil
-    _(send_span.kind).must_equal(:producer)
-    _(send_span.attributes['messaging.system']).must_equal('rabbitmq')
-    _(send_span.attributes['messaging.destination']).must_equal(topic)
-    _(send_span.attributes['messaging.destination_kind']).must_equal('topic')
-    _(send_span.attributes['messaging.protocol']).must_equal('AMQP')
-    _(send_span.attributes['messaging.protocol_version']).must_equal('0.9.1')
-    _(send_span.attributes['messaging.rabbitmq.routing_key']).must_equal('ruby.news')
-    _(send_span.attributes['net.peer.name']).must_equal(host)
-    _(send_span.attributes['net.peer.port']).must_equal(port.to_i)
+    publish_span = spans.find { |span| span.name == "#{topic}.ruby.news publish" }
+    _(publish_span).wont_be_nil
+    _(publish_span.kind).must_equal(:producer)
+    _(publish_span.attributes['messaging.system']).must_equal('rabbitmq')
+    _(publish_span.attributes['messaging.destination']).must_equal(topic)
+    _(publish_span.attributes['messaging.destination_kind']).must_equal('topic')
+    _(publish_span.attributes['messaging.protocol']).must_equal('AMQP')
+    _(publish_span.attributes['messaging.protocol_version']).must_equal('0.9.1')
+    _(publish_span.attributes['messaging.rabbitmq.routing_key']).must_equal('ruby.news')
+    _(publish_span.attributes['net.peer.name']).must_equal(host)
+    _(publish_span.attributes['net.peer.port']).must_equal(port.to_i)
 
     receive_span = spans.find { |span| span.name == "#{topic}.ruby.news receive" }
     _(receive_span).wont_be_nil
@@ -78,7 +78,7 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Channel do
     _(process_span.trace_id).must_equal(receive_span.trace_id)
 
     linked_span_context = process_span.links.first.span_context
-    _(linked_span_context.trace_id).must_equal(send_span.trace_id)
-    _(linked_span_context.span_id).must_equal(send_span.span_id)
+    _(linked_span_context.trace_id).must_equal(publish_span.trace_id)
+    _(linked_span_context.span_id).must_equal(publish_span.span_id)
   end
 end unless ENV['OMIT_SERVICES']

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
@@ -53,9 +53,9 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Consumer do
 
     _(spans.size >= 3).must_equal(true)
 
-    send_span = spans.find { |span| span.name == "#{topic}.ruby.news send" }
-    _(send_span).wont_be_nil
-    _(send_span.kind).must_equal(:producer)
+    publish_span = spans.find { |span| span.name == "#{topic}.ruby.news publish" }
+    _(publish_span).wont_be_nil
+    _(publish_span.kind).must_equal(:producer)
 
     receive_span = spans.find { |span| span.name == "#{topic}.ruby.news receive" }
     _(receive_span).wont_be_nil
@@ -68,7 +68,7 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Consumer do
     _(process_span.trace_id).must_equal(receive_span.trace_id)
 
     linked_span_context = process_span.links.first.span_context
-    _(linked_span_context.trace_id).must_equal(send_span.trace_id)
-    _(linked_span_context.span_id).must_equal(send_span.span_id)
+    _(linked_span_context.trace_id).must_equal(publish_span.trace_id)
+    _(linked_span_context.span_id).must_equal(publish_span.span_id)
   end
 end unless ENV['OMIT_SERVICES']

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
@@ -47,8 +47,8 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Queue do
 
       queue.pop { |_delivery_info, _metadata, _payload| break }
 
-      send_span = spans.find { |span| span.name == ".#{queue_name} send" }
-      _(send_span).wont_be_nil
+      publish_span = spans.find { |span| span.name == ".#{queue_name} publish" }
+      _(publish_span).wont_be_nil
 
       receive_span = spans.find { |span| span.name == ".#{queue_name} receive" }
       _(receive_span).wont_be_nil
@@ -58,7 +58,7 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Queue do
       _(process_span.kind).must_equal(:consumer)
 
       linked_span_context = process_span.links.first.span_context
-      _(linked_span_context.trace_id).must_equal(send_span.trace_id)
+      _(linked_span_context.trace_id).must_equal(publish_span.trace_id)
     end
 
     it 'traces messages returned' do

--- a/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
+++ b/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
@@ -17,10 +17,10 @@ module OpenTelemetry
               return block.call(job) unless enabled?
 
               attributes = build_attributes(job)
-              attributes['messaging.operation'] = 'send'
+              attributes['messaging.operation'] = 'publish'
               attributes.compact!
 
-              tracer.in_span("#{job_queue(job)} send", attributes: attributes, kind: :producer) do |span|
+              tracer.in_span("#{job_queue(job)} publish", attributes: attributes, kind: :producer) do |span|
                 yield job
                 span.set_attribute('messaging.message_id', job.id.to_s)
                 add_events(span, job)

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin_test.rb
@@ -65,13 +65,13 @@ describe OpenTelemetry::Instrumentation::DelayedJob::Plugins::TracerPlugin do
       _(exporter.finished_spans.size).must_equal 1
 
       _(span).must_be_kind_of OpenTelemetry::SDK::Trace::SpanData
-      _(span.name).must_equal 'default send'
+      _(span.name).must_equal 'default publish'
       _(span.attributes['messaging.system']).must_equal 'delayed_job'
       _(span.attributes['messaging.destination']).must_equal 'default'
       _(span.attributes['messaging.destination_kind']).must_equal 'queue'
       _(span.attributes['messaging.delayed_job.name']).must_equal 'BasicPayload'
       _(span.attributes['messaging.delayed_job.priority']).must_equal 0
-      _(span.attributes['messaging.operation']).must_equal 'send'
+      _(span.attributes['messaging.operation']).must_equal 'publish'
       _(span.attributes['messaging.message_id']).must_be_kind_of String
 
       _(span.events.size).must_equal 2
@@ -122,7 +122,7 @@ describe OpenTelemetry::Instrumentation::DelayedJob::Plugins::TracerPlugin do
       _(exporter.finished_spans).must_equal []
       job_enqueue
       _(exporter.finished_spans.size).must_equal 1
-      _(exporter.finished_spans.first.name).must_equal 'default send'
+      _(exporter.finished_spans.first.name).must_equal 'default publish'
       job_run
       _(exporter.finished_spans.size).must_equal 2
 

--- a/instrumentation/que/lib/opentelemetry/instrumentation/que/patches/que_job.rb
+++ b/instrumentation/que/lib/opentelemetry/instrumentation/que/patches/que_job.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
               tracer = Que::Instrumentation.instance.tracer
               otel_config = Que::Instrumentation.instance.config
 
-              tracer.in_span('send', kind: :producer) do |span|
+              tracer.in_span('publish', kind: :producer) do |span|
                 # Que doesn't have a good place to store metadata. There are
                 # basically two options: the job payload and the job tags.
                 #
@@ -57,7 +57,7 @@ module OpenTelemetry
                   job_attrs = job.que_attrs
                 end
 
-                span.name = "#{job_attrs[:job_class]} send"
+                span.name = "#{job_attrs[:job_class]} publish"
                 span.add_attributes(QueJob.job_attributes(job_attrs))
 
                 job
@@ -73,7 +73,7 @@ module OpenTelemetry
             attributes = {
               'messaging.system' => 'que',
               'messaging.destination_kind' => 'queue',
-              'messaging.operation' => 'send',
+              'messaging.operation' => 'publish',
               'messaging.destination' => job_attrs[:queue] || 'default',
               'messaging.que.job_class' => job_attrs[:job_class],
               'messaging.que.priority' => job_attrs[:priority] || 100

--- a/instrumentation/que/test/opentelemetry/instrumentation/que_test.rb
+++ b/instrumentation/que/test/opentelemetry/instrumentation/que_test.rb
@@ -35,7 +35,7 @@ describe OpenTelemetry::Instrumentation::Que do
       TestJobAsync.enqueue
 
       span = finished_spans.last
-      _(span.name).must_equal('TestJobAsync send')
+      _(span.name).must_equal('TestJobAsync publish')
     end
 
     it 'records attributes' do
@@ -45,7 +45,7 @@ describe OpenTelemetry::Instrumentation::Que do
       _(attributes['messaging.system']).must_equal('que')
       _(attributes['messaging.destination']).must_equal('default')
       _(attributes['messaging.destination_kind']).must_equal('queue')
-      _(attributes['messaging.operation']).must_equal('send')
+      _(attributes['messaging.operation']).must_equal('publish')
       _(attributes['messaging.message_id']).must_be_instance_of(Integer)
       _(attributes['messaging.que.job_class']).must_equal('TestJobAsync')
       _(attributes['messaging.que.priority']).must_equal(100)
@@ -117,7 +117,7 @@ describe OpenTelemetry::Instrumentation::Que do
       TestJobSync.enqueue
 
       span1 = finished_spans.last
-      _(span1.name).must_equal('TestJobSync send')
+      _(span1.name).must_equal('TestJobSync publish')
 
       span2 = finished_spans.first
       _(span2.name).must_equal('TestJobSync process')
@@ -171,14 +171,14 @@ describe OpenTelemetry::Instrumentation::Que do
 
         _(finished_spans.size).must_equal(2)
 
-        send_span = finished_spans.first
+        publish_span = finished_spans.first
         process_span = finished_spans.last
 
-        _(send_span.trace_id).wont_equal(process_span.trace_id)
+        _(publish_span.trace_id).wont_equal(process_span.trace_id)
 
         _(process_span.total_recorded_links).must_equal(1)
-        _(process_span.links[0].span_context.trace_id).must_equal(send_span.trace_id)
-        _(process_span.links[0].span_context.span_id).must_equal(send_span.span_id)
+        _(process_span.links[0].span_context.trace_id).must_equal(publish_span.trace_id)
+        _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
       end
     end
 
@@ -191,11 +191,11 @@ describe OpenTelemetry::Instrumentation::Que do
 
         _(finished_spans.size).must_equal(2)
 
-        send_span = finished_spans.first
+        publish_span = finished_spans.first
         process_span = finished_spans.last
 
-        _(send_span.trace_id).must_equal(process_span.trace_id)
-        _(process_span.parent_span_id).must_equal(send_span.span_id)
+        _(publish_span.trace_id).must_equal(process_span.trace_id)
+        _(process_span.parent_span_id).must_equal(publish_span.span_id)
         _(process_span.total_recorded_links).must_equal(0)
       end
     end
@@ -221,11 +221,11 @@ describe OpenTelemetry::Instrumentation::Que do
 
         _(finished_spans.size).must_equal(2)
 
-        send_span = finished_spans.first
+        publish_span = finished_spans.first
         process_span = finished_spans.last
 
-        _(send_span.trace_id).wont_equal(process_span.trace_id)
-        _(send_span.total_recorded_links).must_equal(0)
+        _(publish_span.trace_id).wont_equal(process_span.trace_id)
+        _(publish_span.total_recorded_links).must_equal(0)
         _(process_span.total_recorded_links).must_equal(0)
       end
     end
@@ -281,7 +281,7 @@ describe OpenTelemetry::Instrumentation::Que do
           end
 
           span = finished_spans.last
-          _(span.name).must_equal('TestJobAsync send')
+          _(span.name).must_equal('TestJobAsync publish')
         end
 
         it 'links spans together' do
@@ -293,14 +293,14 @@ describe OpenTelemetry::Instrumentation::Que do
 
           _(finished_spans.size).must_equal(2)
 
-          send_span = finished_spans.first
+          publish_span = finished_spans.first
           process_span = finished_spans.last
 
-          _(send_span.trace_id).wont_equal(process_span.trace_id)
+          _(publish_span.trace_id).wont_equal(process_span.trace_id)
 
           _(process_span.total_recorded_links).must_equal(1)
-          _(process_span.links[0].span_context.trace_id).must_equal(send_span.trace_id)
-          _(process_span.links[0].span_context.span_id).must_equal(send_span.span_id)
+          _(process_span.links[0].span_context.trace_id).must_equal(publish_span.trace_id)
+          _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
         end
       end
 
@@ -376,7 +376,7 @@ describe OpenTelemetry::Instrumentation::Que do
           end
 
           span1 = finished_spans.first
-          _(span1.name).must_equal('TestJobSync send')
+          _(span1.name).must_equal('TestJobSync publish')
 
           span2 = finished_spans.last
           _(span2.name).must_equal('TestJobSync process')
@@ -429,14 +429,14 @@ describe OpenTelemetry::Instrumentation::Que do
 
             _(finished_spans.size).must_equal(2)
 
-            send_span = finished_spans.first
+            publish_span = finished_spans.first
             process_span = finished_spans.last
 
-            _(send_span.trace_id).wont_equal(process_span.trace_id)
+            _(publish_span.trace_id).wont_equal(process_span.trace_id)
 
             _(process_span.total_recorded_links).must_equal(1)
-            _(process_span.links[0].span_context.trace_id).must_equal(send_span.trace_id)
-            _(process_span.links[0].span_context.span_id).must_equal(send_span.span_id)
+            _(process_span.links[0].span_context.trace_id).must_equal(publish_span.trace_id)
+            _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
           end
         end
 
@@ -452,11 +452,11 @@ describe OpenTelemetry::Instrumentation::Que do
 
             _(finished_spans.size).must_equal(2)
 
-            send_span = finished_spans.first
+            publish_span = finished_spans.first
             process_span = finished_spans.last
 
-            _(send_span.trace_id).must_equal(process_span.trace_id)
-            _(process_span.parent_span_id).must_equal(send_span.span_id)
+            _(publish_span.trace_id).must_equal(process_span.trace_id)
+            _(process_span.parent_span_id).must_equal(publish_span.span_id)
             _(process_span.total_recorded_links).must_equal(0)
           end
         end
@@ -482,11 +482,11 @@ describe OpenTelemetry::Instrumentation::Que do
 
             _(finished_spans.size).must_equal(2)
 
-            send_span = finished_spans.first
+            publish_span = finished_spans.first
             process_span = finished_spans.last
 
-            _(send_span.trace_id).wont_equal(process_span.trace_id)
-            _(send_span.total_recorded_links).must_equal(0)
+            _(publish_span.trace_id).wont_equal(process_span.trace_id)
+            _(publish_span.total_recorded_links).must_equal(0)
             _(process_span.total_recorded_links).must_equal(0)
           end
         end

--- a/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/patches/consumer.rb
+++ b/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/patches/consumer.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
 
             headers ||= {}
 
-            tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
+            tracer.in_span("#{topic} publish", attributes: attributes, kind: :producer) do
               OpenTelemetry.propagation.inject(headers)
               super
             end

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/producer.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/producer.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
 
             headers ||= {}
 
-            tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
+            tracer.in_span("#{topic} publish", attributes: attributes, kind: :producer) do
               OpenTelemetry.propagation.inject(headers)
               super
             end

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
@@ -72,7 +72,7 @@ unless ENV['OMIT_SERVICES']
 
         process_spans = spans.select { |s| s.name == "#{topic_name} process" }
 
-        # First pair for send and process spans
+        # First pair for publish and process spans
         first_process_span = process_spans[0]
         _(first_process_span.name).must_equal("#{topic_name} process")
         _(first_process_span.kind).must_equal(:consumer)
@@ -82,12 +82,12 @@ unless ENV['OMIT_SERVICES']
         first_process_span_link = first_process_span.links[0]
         linked_span_context = first_process_span_link.span_context
 
-        linked_send_span = spans.find { |s| s.span_id == linked_span_context.span_id }
-        _(linked_send_span.name).must_equal("#{topic_name} send")
-        _(linked_send_span.trace_id).must_equal(first_process_span.trace_id)
-        _(linked_send_span.trace_id).must_equal(linked_span_context.trace_id)
+        linked_publish_span = spans.find { |s| s.span_id == linked_span_context.span_id }
+        _(linked_publish_span.name).must_equal("#{topic_name} publish")
+        _(linked_publish_span.trace_id).must_equal(first_process_span.trace_id)
+        _(linked_publish_span.trace_id).must_equal(linked_span_context.trace_id)
 
-        # Second pair of send and process spans
+        # Second pair of publish and process spans
         second_process_span = process_spans[1]
         _(second_process_span.name).must_equal("#{topic_name} process")
         _(second_process_span.kind).must_equal(:consumer)
@@ -95,10 +95,10 @@ unless ENV['OMIT_SERVICES']
         second_process_span_link = second_process_span.links[0]
         linked_span_context = second_process_span_link.span_context
 
-        linked_send_span = spans.find { |s| s.span_id == linked_span_context.span_id }
-        _(linked_send_span.name).must_equal("#{topic_name} send")
-        _(linked_send_span.trace_id).must_equal(second_process_span.trace_id)
-        _(linked_send_span.trace_id).must_equal(linked_span_context.trace_id)
+        linked_publish_span = spans.find { |s| s.span_id == linked_span_context.span_id }
+        _(linked_publish_span.name).must_equal("#{topic_name} publish")
+        _(linked_publish_span.trace_id).must_equal(second_process_span.trace_id)
+        _(linked_publish_span.trace_id).must_equal(linked_span_context.trace_id)
 
         event = second_process_span.events.first
         _(event.name).must_equal('exception')
@@ -148,7 +148,7 @@ unless ENV['OMIT_SERVICES']
         _(spans.size).must_equal(4)
         process_spans = spans.select { |s| s.name == "#{topic_name} process" }
 
-        # First pair for send and process spans
+        # First pair for publish and process spans
         first_process_span = process_spans[0]
         _(first_process_span.attributes).wont_include('messaging.kafka.message_key')
 

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
@@ -48,7 +48,7 @@ unless ENV['OMIT_SERVICES']
 
         delivery_handles.each(&:wait)
 
-        _(spans.first.name).must_equal("#{topic_name} send")
+        _(spans.first.name).must_equal("#{topic_name} publish")
         _(spans.first.kind).must_equal(:producer)
 
         _(spans.first.attributes['messaging.system']).must_equal('kafka')

--- a/instrumentation/resque/lib/opentelemetry/instrumentation/resque/patches/resque_module.rb
+++ b/instrumentation/resque/lib/opentelemetry/instrumentation/resque/patches/resque_module.rb
@@ -35,8 +35,8 @@ module OpenTelemetry
               }
 
               span_name = case config[:span_naming]
-                          when :job_class then "#{job_class} send"
-                          else "#{queue} send"
+                          when :job_class then "#{job_class} publish"
+                          else "#{queue} publish"
                           end
 
               tracer.in_span(span_name, attributes: attributes, kind: :producer) do

--- a/instrumentation/resque/test/opentelemetry/instrumentation/resque/patches/resque_test.rb
+++ b/instrumentation/resque/test/opentelemetry/instrumentation/resque/patches/resque_test.rb
@@ -26,7 +26,7 @@ describe OpenTelemetry::Instrumentation::Resque::Patches::ResqueModule do
     it 'traces' do
       Resque.enqueue(DummyJob)
 
-      _(enqueue_span.name).must_equal('super_urgent send')
+      _(enqueue_span.name).must_equal('super_urgent publish')
       _(enqueue_span.attributes['messaging.system']).must_equal('resque')
       _(enqueue_span.attributes['messaging.resque.job_class']).must_equal('DummyJob')
       _(enqueue_span.attributes['messaging.destination']).must_equal('super_urgent')
@@ -35,7 +35,7 @@ describe OpenTelemetry::Instrumentation::Resque::Patches::ResqueModule do
 
     it 'traces when enqueued with Active Job' do
       DummyJobWithActiveJob.perform_later(1, 2)
-      _(enqueue_span.name).must_equal('super_urgent send')
+      _(enqueue_span.name).must_equal('super_urgent publish')
       _(enqueue_span.attributes['messaging.system']).must_equal('resque')
       _(enqueue_span.attributes['messaging.resque.job_class']).must_equal('DummyJobWithActiveJob')
       _(enqueue_span.attributes['messaging.destination']).must_equal('super_urgent')
@@ -48,12 +48,12 @@ describe OpenTelemetry::Instrumentation::Resque::Patches::ResqueModule do
       it 'uses the job class name for the span name' do
         Resque.enqueue(DummyJob)
 
-        _(enqueue_span.name).must_equal('DummyJob send')
+        _(enqueue_span.name).must_equal('DummyJob publish')
       end
 
       it 'uses the job class name when enqueued with Active Job' do
         DummyJobWithActiveJob.perform_later(1, 2)
-        _(enqueue_span.name).must_equal('DummyJobWithActiveJob send')
+        _(enqueue_span.name).must_equal('DummyJobWithActiveJob publish')
       end
     end
   end

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
@@ -24,7 +24,7 @@ module OpenTelemetry
 
             attributes['messaging.kafka.partition'] = partition if partition
 
-            tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
+            tracer.in_span("#{topic} publish", attributes: attributes, kind: :producer) do
               OpenTelemetry.propagation.inject(headers)
               super
             end

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
             # Thread's context, so the next two lines preserve the correct Thread-local context.
             ctx = OpenTelemetry.propagation.extract(headers)
             OpenTelemetry::Context.with_current(ctx) do
-              tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
+              tracer.in_span("#{topic} publish", attributes: attributes, kind: :producer) do
                 OpenTelemetry.propagation.inject(headers)
                 super
               end

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
@@ -40,7 +40,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Client do
     kafka.each_message(topic: topic) { |_msg| break } # rubocop:disable Lint/UnreachableLoop
 
     _(spans.size).must_equal(2)
-    _(spans[0].name).must_equal("#{topic} send")
+    _(spans[0].name).must_equal("#{topic} publish")
     _(spans[0].kind).must_equal(:producer)
 
     _(spans[1].name).must_equal("#{topic} process")
@@ -57,9 +57,9 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Client do
       break if counter >= 2
     end
 
-    send_spans = spans.select { |s| s.name == "#{topic} send" }
-    _(send_spans[0].attributes).wont_include('messaging.kafka.message_key')
-    _(send_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
+    publish_spans = spans.select { |s| s.name == "#{topic} publish" }
+    _(publish_spans[0].attributes).wont_include('messaging.kafka.message_key')
+    _(publish_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
 
     process_spans = spans.select { |s| s.name == "#{topic} process" }
     _(process_spans[0].attributes).wont_include('messaging.kafka.message_key')

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
@@ -58,7 +58,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
 
       process_spans = spans.select { |s| s.name == "#{topic} process" }
 
-      # First pair for send and process spans
+      # First pair for publish and process spans
       first_process_span = process_spans[0]
       _(first_process_span.name).must_equal("#{topic} process")
       _(first_process_span.kind).must_equal(:consumer)
@@ -68,12 +68,12 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
       first_process_span_link = first_process_span.links[0]
       linked_span_context = first_process_span_link.span_context
 
-      linked_send_span = spans.find { |s| s.span_id == linked_span_context.span_id }
-      _(linked_send_span.name).must_equal("#{topic} send")
-      _(linked_send_span.trace_id).must_equal(first_process_span.trace_id)
-      _(linked_send_span.trace_id).must_equal(linked_span_context.trace_id)
+      linked_publish_span = spans.find { |s| s.span_id == linked_span_context.span_id }
+      _(linked_publish_span.name).must_equal("#{topic} publish")
+      _(linked_publish_span.trace_id).must_equal(first_process_span.trace_id)
+      _(linked_publish_span.trace_id).must_equal(linked_span_context.trace_id)
 
-      # Second pair of send and process spans
+      # Second pair of publish and process spans
       second_process_span = process_spans[1]
       _(second_process_span.name).must_equal("#{topic} process")
       _(second_process_span.kind).must_equal(:consumer)
@@ -81,10 +81,10 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
       second_process_span_link = second_process_span.links[0]
       linked_span_context = second_process_span_link.span_context
 
-      linked_send_span = spans.find { |s| s.span_id == linked_span_context.span_id }
-      _(linked_send_span.name).must_equal("#{topic} send")
-      _(linked_send_span.trace_id).must_equal(second_process_span.trace_id)
-      _(linked_send_span.trace_id).must_equal(linked_span_context.trace_id)
+      linked_publish_span = spans.find { |s| s.span_id == linked_span_context.span_id }
+      _(linked_publish_span.name).must_equal("#{topic} publish")
+      _(linked_publish_span.trace_id).must_equal(second_process_span.trace_id)
+      _(linked_publish_span.trace_id).must_equal(linked_span_context.trace_id)
 
       event = second_process_span.events.first
       _(event.name).must_equal('exception')
@@ -106,7 +106,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
 
       process_spans = spans.select { |s| s.name == "#{topic} process" }
 
-      # First pair for send and process spans
+      # First pair for publish and process spans
       first_process_span = process_spans[0]
       _(first_process_span.attributes).wont_include('messaging.kafka.message_key')
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -25,8 +25,8 @@ module OpenTelemetry
               attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
 
               span_name = case instrumentation_config[:span_naming]
-                          when :job_class then "#{job['wrapped']&.to_s || job['class']} send"
-                          else "#{job['queue']} send"
+                          when :job_class then "#{job['wrapped']&.to_s || job['class']} publish"
+                          else "#{job['queue']} publish"
                           end
 
               tracer.in_span(span_name, attributes: attributes, kind: :producer) do |span|

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware_test.rb
@@ -35,7 +35,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMid
 
       _(exporter.finished_spans.size).must_equal 1
 
-      _(enqueue_span.name).must_equal 'default send'
+      _(enqueue_span.name).must_equal 'default publish'
       _(enqueue_span.kind).must_equal :producer
       _(enqueue_span.parent_span_id).must_equal OpenTelemetry::Trace::INVALID_SPAN_ID
       _(enqueue_span.attributes['messaging.system']).must_equal 'sidekiq'
@@ -49,7 +49,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMid
 
     it 'traces when enqueued with Active Job' do
       SimpleJobWithActiveJob.perform_later(1, 2)
-      _(enqueue_span.name).must_equal('default send')
+      _(enqueue_span.name).must_equal('default publish')
       _(enqueue_span.attributes['messaging.system']).must_equal('sidekiq')
       _(enqueue_span.attributes['messaging.sidekiq.job_class']).must_equal('SimpleJobWithActiveJob')
       _(enqueue_span.attributes['messaging.destination']).must_equal('default')
@@ -62,12 +62,12 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMid
       it 'uses the job class name for the span name' do
         SimpleJob.perform_async
 
-        _(enqueue_span.name).must_equal('SimpleJob send')
+        _(enqueue_span.name).must_equal('SimpleJob publish')
       end
 
       it 'uses the job class name when enqueued with Active Job' do
         SimpleJobWithActiveJob.perform_later(1, 2)
-        _(enqueue_span.name).must_equal('SimpleJobWithActiveJob send')
+        _(enqueue_span.name).must_equal('SimpleJobWithActiveJob publish')
       end
     end
 

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -123,7 +123,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
 
         # root job that enqueues another job
         _(root_span.parent_span_id).must_equal OpenTelemetry::Trace::INVALID_SPAN_ID
-        _(root_span.name).must_equal 'default send'
+        _(root_span.name).must_equal 'default publish'
         _(root_span.kind).must_equal :producer
 
         # process span is linked to the root enqueuing job
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
 
         # enquene span is child to the parent process job
         child_span2 = spans.find { |s| s.parent_span_id == child_span1.span_id }
-        _(child_span2.name).must_equal 'default send'
+        _(child_span2.name).must_equal 'default publish'
         _(child_span2.kind).must_equal :producer
 
         # last process job is linked back to the process job that enqueued it
@@ -182,7 +182,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(exporter.finished_spans.size).must_equal 4
 
         _(root_span.parent_span_id).must_equal OpenTelemetry::Trace::INVALID_SPAN_ID
-        _(root_span.name).must_equal 'default send'
+        _(root_span.name).must_equal 'default publish'
         _(root_span.kind).must_equal :producer
 
         child_span1 = spans.find { |s| s.parent_span_id == root_span.span_id }
@@ -190,7 +190,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(child_span1.kind).must_equal :consumer
 
         child_span2 = spans.find { |s| s.parent_span_id == child_span1.span_id }
-        _(child_span2.name).must_equal 'default send'
+        _(child_span2.name).must_equal 'default publish'
         _(child_span2.kind).must_equal :producer
 
         child_span3 = spans.find { |s| s.parent_span_id == child_span2.span_id }


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/561

This PR renames spans related to the client-side operation of creating a job from `* send` to `* publish` in various queuing instrumentations.

The diff might seem sizeable but I believe the changes are very repetitive thus it was better to bundle it together.