### PR TITLE
fix(bunny): headers property needs to exist

### DIFF
--- a/instrumentation/bunny/lib/opentelemetry/instrumentation/bunny/patch_helpers.rb
+++ b/instrumentation/bunny/lib/opentelemetry/instrumentation/bunny/patch_helpers.rb
@@ -35,6 +35,7 @@ module OpenTelemetry
         def self.extract_context(properties)
           # use the receive span as parent context
           parent_context = OpenTelemetry.propagation.extract(properties[:tracer_receive_headers])
+          return [parent_context, nil] if properties[:headers].nil?
 
           # link to the producer context
           producer_context = OpenTelemetry.propagation.extract(properties[:headers])

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patch_helpers_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patch_helpers_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative '../../../../lib/opentelemetry/instrumentation/bunny/patch_helpers'
+
+describe OpenTelemetry::Instrumentation::Bunny::PatchHelpers do
+  let(:properties) do
+    {
+      headers: {
+        'traceparent' => '00-eab67ae26433f603121bd5674149d9e1-2007f3325d3cb6d6-01'
+      },
+      tracer_receive_headers: {
+        'traceparent' => '00-cd52775b3cb38931adf5fa880f890c25-cddb52a470027489-01'
+      }
+    }
+  end
+
+  describe '.extract_context' do
+    it 'returns the parent context with links when headers from producer exists' do
+      parent_context, links = OpenTelemetry::Instrumentation::Bunny::PatchHelpers.extract_context(properties)
+      _(parent_context).must_be_instance_of(OpenTelemetry::Context)
+      _(links).must_be_instance_of(Array)
+      _(links.first).must_be_instance_of(OpenTelemetry::Trace::Link)
+    end
+
+    it 'returns the parent context with no links when headers from producer not present' do
+      properties.delete(:headers)
+      parent_context, links = OpenTelemetry::Instrumentation::Bunny::PatchHelpers.extract_context(properties)
+      _(parent_context).must_be_instance_of(OpenTelemetry::Context)
+      _(links).must_be_nil
+    end
+  end
+end

--- a/instrumentation/bunny/test/test_helper.rb
+++ b/instrumentation/bunny/test/test_helper.rb
@@ -19,4 +19,5 @@ OpenTelemetry::SDK.configure do |c|
   c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
   c.add_span_processor SPAN_PROCESSOR
+  c.propagators = [OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator]
 end


### PR DESCRIPTION
bunny instrumentation errors when rabbitmq messages don't have `headers` property, e.g. published by an app that isn't instrumented yet.

```
E, [2023-09-07T12:01:06.688026 #1] ERROR -- #<Bunny::Session:0x29d88 hidden@hidden:5672, vhost=hidden, addresses=[hidden:5672]>: Uncaught exception from consumer #<Bunny::Consumer:101200 @channel_id=1 @queue=hidden @consumer_tag=hidden>: #<NoMethodError: undefined method `[]' for nil:NilClass 

carrier[key]
^^^^^> @ /gems/ruby/3.1.0/gems/opentelemetry-api-1.2.2/lib/opentelemetry/context/propagation/text_map_getter.rb:16:in `get'
```

you can reproduce the issue by spiting the [example](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/bunny/example/bunny.rb) file into a publisher without instrumentation and a consumer with.