### PR TITLE
Micro optimization: build Hash w/ `{}`

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -75,10 +75,11 @@ module OpenTelemetry
             platform_key = _otel_execute_field_key(field: field)
             return super unless platform_key
 
-            attributes = {}
-            attributes['graphql.field.parent'] = field.owner&.graphql_name
-            attributes['graphql.field.name'] = field.graphql_name
-            attributes['graphql.lazy'] = false
+            attributes = {
+              'graphql.field.parent' => field.owner&.graphql_name,
+              'graphql.field.name' => field.graphql_name,
+              'graphql.lazy' => false
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end
@@ -87,10 +88,11 @@ module OpenTelemetry
             platform_key = _otel_execute_field_key(field: field)
             return super unless platform_key
 
-            attributes = {}
-            attributes['graphql.field.parent'] = field.owner&.graphql_name
-            attributes['graphql.field.name'] = field.graphql_name
-            attributes['graphql.lazy'] = true
+            attributes = {
+              'graphql.field.parent' => field.owner&.graphql_name,
+              'graphql.field.name' => field.graphql_name,
+              'graphql.lazy' => true
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end
@@ -99,9 +101,10 @@ module OpenTelemetry
             platform_key = @_otel_authorized_key_cache[type]
             return super unless platform_key
 
-            attributes = {}
-            attributes['graphql.type.name'] = type.graphql_name
-            attributes['graphql.lazy'] = false
+            attributes = {
+              'graphql.type.name' => type.graphql_name,
+              'graphql.lazy' => false
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end
@@ -110,9 +113,10 @@ module OpenTelemetry
             platform_key = @_otel_authorized_key_cache[type]
             return super unless platform_key
 
-            attributes = {}
-            attributes['graphql.type.name'] = type.graphql_name
-            attributes['graphql.lazy'] = true
+            attributes = {
+              'graphql.type.name' => type.graphql_name,
+              'graphql.lazy' => true
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end
@@ -120,9 +124,10 @@ module OpenTelemetry
           def resolve_type(query:, type:, object:, &block)
             platform_key = @_otel_resolve_type_key_cache[type]
 
-            attributes = {}
-            attributes['graphql.type.name'] = type.graphql_name
-            attributes['graphql.lazy'] = false
+            attributes = {
+              'graphql.type.name' => type.graphql_name,
+              'graphql.lazy' => false
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end
@@ -130,9 +135,10 @@ module OpenTelemetry
           def resolve_type_lazy(query:, type:, object:, &block)
             platform_key = @_otel_resolve_type_key_cache[type]
 
-            attributes = {}
-            attributes['graphql.type.name'] = type.graphql_name
-            attributes['graphql.lazy'] = true
+            attributes = {
+              'graphql.type.name' => type.graphql_name,
+              'graphql.lazy' => true
+            }
 
             tracer.in_span(platform_key, attributes: attributes, &block)
           end


### PR DESCRIPTION
For cases where all keys are present, create the Hash with all its keys with `{...}` instead of building it incrementally with multiple `Hash[]` calls.

It really is a micro-optimization, but `execute_field` is on the hot path.

Bench:
```ruby

require "benchmark/ips"

Benchmark.ips do |x|
  x.report("[]=") do
    hash = {}
    hash["a"] = 1
    hash["b"] = 2
    hash["c"] = 3
  end

  x.report("{}") do
    { "a" => 1, "b" => 2, "c" => 3 }
  end

  x.compare
```

Result:

```
Warming up --------------------------------------
                  []=  577.660k i/100ms
                  {}     1.438M i/100ms
Calculating -------------------------------------
                  []=     5.809M (± 2.9%) i/s -     29.461M in   5.076542s
                  {}     15.373M (± 0.3%) i/s -     77.651M in   5.051278s

Comparison:
                  {}=: 15372655.4 i/s
                  []:   5808733.8 i/s - 2.65x  slower
```