### PR TITLE
spike: Rewrite using AS notifications

### DIFF
--- a/instrumentation/active_job/example/Gemfile
+++ b/instrumentation/active_job/example/Gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'activejob'
-gem 'opentelemetry-api'
-gem 'opentelemetry-instrumentation-active_job'
-gem 'opentelemetry-sdk'

--- a/instrumentation/active_job/example/active_job.rb
+++ b/instrumentation/active_job/example/active_job.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ENV['OTEL_SERVICE_NAME'] ||= 'otel-active-job-demo'
 require 'rubygems'
 require 'bundler/inline'
 
@@ -12,6 +13,7 @@ gemfile do
   gem 'activejob', require: 'active_job'
   # gem 'opentelemetry-instrumentation-active_job', path: '../'
   gem 'opentelemetry-sdk'
+  gem 'opentelemetry-exporter-otlp'
 end
 
 require_relative '../lib/opentelemetry/instrumentation/active_job/subscriber'
@@ -20,6 +22,53 @@ ENV['OTEL_TRACES_EXPORTER'] ||= 'console'
 OpenTelemetry::SDK.configure do |c|
   # c.use 'OpenTelemetry::Instrumentation::ActiveJob'
   at_exit { OpenTelemetry.tracer_provider.shutdown }
+end
+
+class FailingJob < ::ActiveJob::Base
+  queue_as :demo
+  def perform
+    raise 'this job failed'
+  end
+end
+
+class FailingRetryJob < ::ActiveJob::Base
+  queue_as :demo
+
+  retry_on StandardError, attempts: 2, wait: 0
+  def perform
+    raise 'this job failed'
+  end
+end
+
+class RetryJob < ::ActiveJob::Base
+  queue_as :demo
+
+  retry_on StandardError, attempts: 3, wait: 0
+  def perform
+    if executions < 3
+      raise 'this job failed'
+    else
+      puts <<~EOS
+
+      --------------------------------------------------
+       Done Retrying!
+      --------------------------------------------------
+
+      EOS
+    end
+  end
+end
+
+class DiscardJob < ::ActiveJob::Base
+  queue_as :demo
+
+  class DiscardError < StandardError; end
+
+  discard_on DiscardError
+
+  def perform
+    raise DiscardError, 'this job failed'
+  end
 end
 
 class TestJob < ::ActiveJob::Base
@@ -34,7 +83,31 @@ class TestJob < ::ActiveJob::Base
   end
 end
 
+class DoItNowJob < ::ActiveJob::Base
+  def perform
+    puts <<~EOS
+
+    --------------------------------------------------
+     Called with perform_now!
+    --------------------------------------------------
+
+    EOS
+  end
+end
+
+class BatchJob < ::ActiveJob::Base
+  def perform
+    TestJob.perform_later
+    FailingJob.perform_later
+    FailingRetryJob.perform_later
+    RetryJob.perform_later
+    DiscardJob.perform_later
+  end
+end
+
 ::ActiveJob::Base.queue_adapter = :async
 
-TestJob.perform_later
-sleep 0.1 # allow the job to complete
+DoItNowJob.perform_now
+BatchJob.perform_later
+
+sleep 1 # allow the job to complete

--- a/instrumentation/active_job/example/active_job.rb
+++ b/instrumentation/active_job/example/active_job.rb
@@ -5,14 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'rubygems'
-require 'bundler/setup'
-require 'active_job'
+require 'bundler/inline'
 
-Bundler.require
+gemfile do
+  source 'https://rubygems.org'
+  gem 'activejob', require: 'active_job'
+  # gem 'opentelemetry-instrumentation-active_job', path: '../'
+  gem 'opentelemetry-sdk'
+end
+
+require_relative '../lib/opentelemetry/instrumentation/active_job/subscriber'
 
 ENV['OTEL_TRACES_EXPORTER'] ||= 'console'
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::ActiveJob'
+  # c.use 'OpenTelemetry::Instrumentation::ActiveJob'
+  at_exit { OpenTelemetry.tracer_provider.shutdown }
 end
 
 class TestJob < ::ActiveJob::Base
@@ -30,4 +37,4 @@ end
 ::ActiveJob::Base.queue_adapter = :async
 
 TestJob.perform_later
-sleep 0.1 # To ensure we see both spans!
+sleep 0.1 # allow the job to complete

--- a/instrumentation/active_job/example/active_job.rb
+++ b/instrumentation/active_job/example/active_job.rb
@@ -107,7 +107,11 @@ end
 
 ::ActiveJob::Base.queue_adapter = :async
 
-DoItNowJob.perform_now
-BatchJob.perform_later
+tracer = OpenTelemetry.tracer_provider.tracer('example', '0.1.0')
 
-sleep 1 # allow the job to complete
+tracer.in_span('run-jobs') do
+  DoItNowJob.perform_now
+  BatchJob.perform_later
+end
+
+sleep 5 # allow the job to complete

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -61,8 +61,8 @@ module OpenTelemetry
             'messaging.system' => job.class.queue_adapter_name,
             'messaging.destination' => job.queue_name,
             'messaging.message_id' => job.job_id,
-            'messaging.active_job.provider_job_id' => job.provider_job_id,
-            'messaging.active_job.priority' => job.priority
+            'rails.active_job.provider_job_id' => job.provider_job_id,
+            'rails.active_job.priority' => job.priority
           }
 
           otel_attributes['net.transport'] = 'inproc' if test_adapters.include?(job.class.queue_adapter_name)

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -49,23 +49,12 @@ end
 module OpenTelemetry
   module Instrumentation
     module ActiveJob
-      class EnqueueSubscriber < ::ActiveSupport::Subscriber
-        TEST_ADAPTERS = %w[async inline]
 
-        attach_to :active_job
+      class GenericSubscriber < ::ActiveSupport::Subscriber
 
-        # The methods below are the events the Subscriber is interested in.
-        def enqueue(...); end
-
-        def start(name, _id, payload)
+        def start(name, id, payload)
           begin
-            span = tracer.start_span("#{payload.fetch(:job).queue_name} publish",
-                                      kind: :producer,
-                                      attributes: job_attributes(payload.fetch(:job)))
-            tokens = [OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))]
-            OpenTelemetry.propagation.inject(payload.fetch(:job).__otel_headers) # This must be transmitted over the wire
-            payload.merge!(__otel: { span: span, ctx_tokens: tokens }) # The payload is _not_ transmitted over the wire
-
+            payload.merge!(__otel: on_start(name, id, payload)) # The payload is _not_ transmitted over the wire
           rescue StandardError => error
             OpenTelemetry.handle_error(exception: error)
           end
@@ -97,6 +86,13 @@ module OpenTelemetry
               OpenTelemetry.handle_error(exception: error)
             end
           end
+        end
+
+        def on_start(name, _id, payload)
+          span = tracer.start_span(name, attributes: job_attributes(payload.fetch(:job)))
+          tokens = [OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))]
+          OpenTelemetry.propagation.inject(payload.fetch(:job).__otel_headers) # This must be transmitted over the wire
+          { span: span, ctx_tokens: tokens }
         end
 
         private
@@ -123,7 +119,25 @@ module OpenTelemetry
         end
       end
 
-      class PerformSubscriber < ::ActiveSupport::Subscriber
+      class EnqueueSubscriber < GenericSubscriber
+        TEST_ADAPTERS = %w[async inline]
+
+        attach_to :active_job
+
+        # The methods below are the events the Subscriber is interested in.
+        def enqueue(...); end
+
+        def on_start(name, _id, payload)
+          span = tracer.start_span("#{payload.fetch(:job).queue_name} publish",
+          kind: :producer,
+          attributes: job_attributes(payload.fetch(:job)))
+          tokens = [OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))]
+          OpenTelemetry.propagation.inject(payload.fetch(:job).__otel_headers) # This must be transmitted over the wire
+          { span: span, ctx_tokens: tokens }
+        end
+      end
+
+      class PerformSubscriber < GenericSubscriber
         TEST_ADAPTERS = %w[async inline]
 
         attach_to :active_job
@@ -131,76 +145,28 @@ module OpenTelemetry
         # The methods below are the events the Subscriber is interested in.
         def perform(...);end
 
-        def start(name, _id, payload)
+        def on_start(name, _id, payload)
           tokens = []
-          begin
-            parent_context = OpenTelemetry.propagation.extract(payload.fetch(:job).__otel_headers)
-            span_context = OpenTelemetry::Trace.current_span(parent_context).context
+          parent_context = OpenTelemetry.propagation.extract(payload.fetch(:job).__otel_headers)
+          span_context = OpenTelemetry::Trace.current_span(parent_context).context
 
-            if span_context.valid?
-              tokens << OpenTelemetry::Context.attach(parent_context)
-              links = [OpenTelemetry::Trace::Link.new(span_context)]
-            end
-
-            span = tracer.start_span("#{payload.fetch(:job).queue_name} process", kind: :consumer, attributes: job_attributes(payload.fetch(:job)), links: links)
-            tokens << OpenTelemetry::Context.attach(
-              OpenTelemetry::Trace.context_with_span(span)
-            )
-            payload.merge!(__otel: { span: span, ctx_tokens: tokens })
-          rescue StandardError => error
-            OpenTelemetry.handle_error(exception: error)
+          if span_context.valid?
+            tokens << OpenTelemetry::Context.attach(parent_context)
+            links = [OpenTelemetry::Trace::Link.new(span_context)]
           end
 
-          super
-        end
+          span = tracer.start_span(
+            "#{payload.fetch(:job).queue_name} process",
+            kind: :consumer,
+            attributes: job_attributes(payload.fetch(:job)),
+            links: links
+          )
 
-        def finish(_name, _id, payload)
-          begin
-            otel = payload.delete(:__otel)
-            span = otel.fetch(:span)
-            tokens = otel.fetch(:ctx_tokens)
-          rescue StandardError => error
-            OpenTelemetry.handle_error(exception: error)
-          end
+          tokens << OpenTelemetry::Context.attach(
+            OpenTelemetry::Trace.context_with_span(span)
+          )
 
-          super
-
-        ensure
-          begin
-            span&.finish
-          rescue StandardError => error
-            OpenTelemetry.handle_error(exception: error)
-          end
-          tokens&.reverse&.each do |token|
-            begin
-              OpenTelemetry::Context.detach(token)
-            rescue StandardError => error
-              OpenTelemetry.handle_error(exception: error)
-            end
-          end
-        end
-
-        private
-
-        def job_attributes(job)
-          otel_attributes = {
-            'code.namespace' => job.class.name,
-            'messaging.destination_kind' => 'queue',
-            'messaging.system' => job.class.queue_adapter_name,
-            'messaging.destination' => job.queue_name,
-            'messaging.message_id' => job.job_id,
-            'messaging.active_job.provider_job_id' => job.provider_job_id,
-            'messaging.active_job.priority' => job.priority
-          }
-
-          otel_attributes['net.transport'] = 'inproc' if TEST_ADAPTERS.include?(job.class.queue_adapter_name)
-          otel_attributes.compact!
-
-          otel_attributes
-        end
-
-        def tracer
-          OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')
+          { span: span, ctx_tokens: tokens }
         end
       end
     end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -51,6 +51,11 @@ module OpenTelemetry
     module ActiveJob
 
       class GenericSubscriber < ::ActiveSupport::Subscriber
+        attach_to :active_job
+
+        # The methods below are the events the Subscriber is interested in.
+        def enqueue(...); end
+        def perform(...);end
 
         def start(name, id, payload)
           begin
@@ -122,11 +127,6 @@ module OpenTelemetry
       class EnqueueSubscriber < GenericSubscriber
         TEST_ADAPTERS = %w[async inline]
 
-        attach_to :active_job
-
-        # The methods below are the events the Subscriber is interested in.
-        def enqueue(...); end
-
         def on_start(name, _id, payload)
           span = tracer.start_span("#{payload.fetch(:job).queue_name} publish",
           kind: :producer,
@@ -139,11 +139,6 @@ module OpenTelemetry
 
       class PerformSubscriber < GenericSubscriber
         TEST_ADAPTERS = %w[async inline]
-
-        attach_to :active_job
-
-        # The methods below are the events the Subscriber is interested in.
-        def perform(...);end
 
         def on_start(name, _id, payload)
           tokens = []

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'active_support/subscriber'
+
+module OpenTelemetry
+  module Instrumentation
+    module ActiveJob
+      module Patches
+        # Module to prepend to ActiveJob::Core for context propagation.
+        module Base
+          def self.prepended(base)
+            base.class_eval do
+              attr_accessor :__otel_headers
+            end
+          end
+
+          def initialize(...)
+            @__otel_headers = {}
+            super
+          end
+
+          def serialize
+            message = super
+
+            begin
+              message.merge!('__otel_headers' => serialize_arguments(@__otel_headers))
+            rescue StandardError => error
+              OpenTelemetry.handle_error(exception: error)
+            end
+
+            message
+          end
+
+          def deserialize(job_data)
+            begin
+              @__otel_headers = deserialize_arguments(job_data.delete('__otel_headers') || []).to_h
+            rescue StandardError => error
+              OpenTelemetry.handle_error(exception: error)
+            end
+            super
+          end
+          ::ActiveJob::Base.prepend(self)
+        end
+      end
+    end
+  end
+end
+
+module OpenTelemetry
+  module Instrumentation
+    module ActiveJob
+      class EnqueueSubscriber < ::ActiveSupport::Subscriber
+        TEST_ADAPTERS = %w[async inline]
+
+        attach_to :active_job
+
+        # The methods below are the events the Subscriber is interested in.
+        def enqueue(...); end
+
+        def start(name, _id, payload)
+          begin
+            span = tracer.start_span("#{payload.fetch(:job).queue_name} publish",
+                                      kind: :producer,
+                                      attributes: job_attributes(payload.fetch(:job)))
+            tokens = [OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))]
+            OpenTelemetry.propagation.inject(payload.fetch(:job).__otel_headers) # This must be transmitted over the wire
+            payload.merge!(__otel: { span: span, ctx_tokens: tokens }) # The payload is _not_ transmitted over the wire
+
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+
+          super
+        end
+
+        def finish(_name, _id, payload)
+          begin
+            otel = payload.delete(:__otel)
+            span = otel.fetch(:span)
+            tokens = otel.fetch(:ctx_tokens)
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+
+          super
+
+        ensure
+          begin
+            span&.finish
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+          tokens&.reverse&.each do |token|
+            begin
+              OpenTelemetry::Context.detach(token)
+            rescue StandardError => error
+              OpenTelemetry.handle_error(exception: error)
+            end
+          end
+        end
+
+        private
+
+        def job_attributes(job)
+          otel_attributes = {
+            'code.namespace' => job.class.name,
+            'messaging.destination_kind' => 'queue',
+            'messaging.system' => job.class.queue_adapter_name,
+            'messaging.destination' => job.queue_name,
+            'messaging.message_id' => job.job_id,
+            'messaging.active_job.provider_job_id' => job.provider_job_id,
+            'messaging.active_job.priority' => job.priority
+          }
+
+          otel_attributes['net.transport'] = 'inproc' if TEST_ADAPTERS.include?(job.class.queue_adapter_name)
+          otel_attributes.compact!
+
+          otel_attributes
+        end
+
+        def tracer
+          OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')
+        end
+      end
+
+      class PerformSubscriber < ::ActiveSupport::Subscriber
+        TEST_ADAPTERS = %w[async inline]
+
+        attach_to :active_job
+
+        # The methods below are the events the Subscriber is interested in.
+        def perform(...);end
+
+        def start(name, _id, payload)
+          tokens = []
+          begin
+            parent_context = OpenTelemetry.propagation.extract(payload.fetch(:job).__otel_headers)
+            span_context = OpenTelemetry::Trace.current_span(parent_context).context
+
+            if span_context.valid?
+              tokens << OpenTelemetry::Context.attach(parent_context)
+              links = [OpenTelemetry::Trace::Link.new(span_context)]
+            end
+
+            span = tracer.start_span("#{payload.fetch(:job).queue_name} process", kind: :consumer, attributes: job_attributes(payload.fetch(:job)), links: links)
+            tokens << OpenTelemetry::Context.attach(
+              OpenTelemetry::Trace.context_with_span(span)
+            )
+            payload.merge!(__otel: { span: span, ctx_tokens: tokens })
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+
+          super
+        end
+
+        def finish(_name, _id, payload)
+          begin
+            otel = payload.delete(:__otel)
+            span = otel.fetch(:span)
+            tokens = otel.fetch(:ctx_tokens)
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+
+          super
+
+        ensure
+          begin
+            span&.finish
+          rescue StandardError => error
+            OpenTelemetry.handle_error(exception: error)
+          end
+          tokens&.reverse&.each do |token|
+            begin
+              OpenTelemetry::Context.detach(token)
+            rescue StandardError => error
+              OpenTelemetry.handle_error(exception: error)
+            end
+          end
+        end
+
+        private
+
+        def job_attributes(job)
+          otel_attributes = {
+            'code.namespace' => job.class.name,
+            'messaging.destination_kind' => 'queue',
+            'messaging.system' => job.class.queue_adapter_name,
+            'messaging.destination' => job.queue_name,
+            'messaging.message_id' => job.job_id,
+            'messaging.active_job.provider_job_id' => job.provider_job_id,
+            'messaging.active_job.priority' => job.priority
+          }
+
+          otel_attributes['net.transport'] = 'inproc' if TEST_ADAPTERS.include?(job.class.queue_adapter_name)
+          otel_attributes.compact!
+
+          otel_attributes
+        end
+
+        def tracer
+          OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -55,8 +55,8 @@ module OpenTelemetry
           @tracer = tracer
         end
 
-        def on_start(name, _id, payload, subscriber)
-          span = @tracer.start_span(name, attributes: subscriber.as_otel_semconv_attrs(payload.fetch(:job)))
+        def on_start(name, _id, payload, attribute_processor)
+          span = @tracer.start_span(name, attributes: attribute_processor.as_otel_semconv_attrs(payload.fetch(:job)))
           tokens = [OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))]
           OpenTelemetry.propagation.inject(payload.fetch(:job).__otel_headers) # This must be transmitted over the wire
           { span: span, ctx_tokens: tokens }
@@ -68,7 +68,7 @@ module OpenTelemetry
           @tracer = tracer
         end
 
-        def on_start(name, _id, payload, subscriber)
+        def on_start(name, _id, payload, attribute_processor)
           span = @tracer.start_span("#{payload.fetch(:job).queue_name} publish",
           kind: :producer,
           attributes: subscriber.as_otel_semconv_attrs(payload.fetch(:job)))
@@ -83,7 +83,7 @@ module OpenTelemetry
           @tracer = tracer
         end
 
-        def on_start(name, _id, payload, subscriber)
+        def on_start(name, _id, payload, attribute_processor)
           tokens = []
           parent_context = OpenTelemetry.propagation.extract(payload.fetch(:job).__otel_headers)
           span_context = OpenTelemetry::Trace.current_span(parent_context).context
@@ -96,7 +96,7 @@ module OpenTelemetry
           span = @tracer.start_span(
             "#{payload.fetch(:job).queue_name} process",
             kind: :consumer,
-            attributes: subscriber.as_otel_semconv_attrs(payload.fetch(:job)),
+            attributes: attribute_processor.as_otel_semconv_attrs(payload.fetch(:job)),
             links: links
           )
 

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -121,7 +121,7 @@ module OpenTelemetry
             links = [OpenTelemetry::Trace::Link.new(span_context)]
           end
 
-          span = @tracer.start_span(
+          span = @tracer.start_root_span(
             "#{payload.fetch(:job).queue_name} process",
             kind: :consumer,
             attributes: to_otel_semconv_attributes(payload.fetch(:job)),

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -96,20 +96,16 @@ module OpenTelemetry
       end
 
       class Subscriber < ::ActiveSupport::Subscriber
-        EVENT_HANDLERS = {
-          'enqueue.active_job' => EnqueueSubscriber.new(OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')),
-          'perform.active_job' => PerformSubscriber.new(OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')),
-        }
+        attr_reader :tracer
 
         def initialize(...)
           super
+          @tracer = OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')
           @handlers_by_pattern = {
-            'enqueue.active_job' => EnqueueSubscriber.new(OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')),
-            'perform.active_job' => PerformSubscriber.new(OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')),
+            'enqueue.active_job' => EnqueueSubscriber.new(@tracer),
+            'perform.active_job' => PerformSubscriber.new(@tracer),
           }
         end
-
-        attach_to :active_job
 
         # The methods below are the events the Subscriber is interested in.
         def enqueue(...); end
@@ -177,9 +173,7 @@ module OpenTelemetry
           otel_attributes
         end
 
-        def tracer
-          OpenTelemetry.tracer_provider.tracer('otel-active_job', '0.0.1')
-        end
+        attach_to :active_job
       end
     end
   end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -51,6 +51,8 @@ module OpenTelemetry
     module ActiveJob
 
       class GenericSubscriber < ::ActiveSupport::Subscriber
+        TEST_ADAPTERS = %w[async inline]
+
         attach_to :active_job
 
         # The methods below are the events the Subscriber is interested in.
@@ -125,7 +127,6 @@ module OpenTelemetry
       end
 
       class EnqueueSubscriber < GenericSubscriber
-        TEST_ADAPTERS = %w[async inline]
 
         def on_start(name, _id, payload)
           span = tracer.start_span("#{payload.fetch(:job).queue_name} publish",
@@ -138,8 +139,6 @@ module OpenTelemetry
       end
 
       class PerformSubscriber < GenericSubscriber
-        TEST_ADAPTERS = %w[async inline]
-
         def on_start(name, _id, payload)
           tokens = []
           parent_context = OpenTelemetry.propagation.extract(payload.fetch(:job).__otel_headers)

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -86,7 +86,7 @@ module OpenTelemetry
         end
       end
 
-      class GenericSubscriber < ::ActiveSupport::Subscriber
+      class Subscriber < ::ActiveSupport::Subscriber
         TEST_ADAPTERS = %w[async inline]
         EVENT_HANDLERS = {
           'enqueue.active_job' => EnqueueSubscriber.new,

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/subscriber.rb
@@ -151,9 +151,13 @@ module OpenTelemetry
         end
 
         # The methods below are the events the Subscriber is interested in.
+        def enqueue_at(...); end
         def enqueue(...); end
+        def enqueue_retry(...); end
         def perform_start(...); end
         def perform(...);end
+        def retry_stopped(...); end
+        def discard(...); end
 
         def start(name, id, payload)
           begin


### PR DESCRIPTION
This is a spike to see if we can rewrite the ActiveJob instrumentation using AS notifications.

Some things that stand out to me:

Each subscriber requires additional logic to handle context propagation, which makes code reuse a little when clunky creating spans:
- Egress (kind: consumer) spans must extract incoming context to continue the trace context or use links
  - This means keeping track of multiple context tokens and detaching them in reverse order
- Ingress (kind: producer) spans must use the implicit parent span from the current context and must inject the outbound context

- Not all events measure a block of code e.g. https://github.com/rails/rails/blob/a5f4aadcee42f9b4fa99468776c56b5b988c87cf/activejob/lib/active_job/instrumentation.rb#L31
- Exceptions are not documented as being included in `perform` events, which means we may not have access to them to set an error on the Ingress spans
  - Exceptions seem to be caught and recorded as part of other events: https://github.com/rails/rails/blob/a5f4aadcee42f9b4fa99468776c56b5b988c87cf/activejob/lib/active_job/exceptions.rb#L152
  - `retry_stopped`, `discard`, and `enqueue_retry` will provide errors but should these be mapped to internal spans?
  - Would others agree that if the job is stopped or discarded due to an error, we should record the error?
- There are no semantics around retries. I assume that means we do not need to track those?