### PR TITLE
feat: Allow filtering the http.target attribute

### DIFF
--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
@@ -26,7 +26,11 @@ module OpenTelemetry
           #   or `Regexp` in this array, the instrumentation will not record a
           #   `kind = :client` representing the request and will not propagate
           #   context in the request.
-          option :untraced_hosts, default: [], validate: :array
+          # filter_target: a callable object that takes a path `String` and returns
+          #   a `String` to be used as the http.target attribute. The default is to
+          #   use the request path as-is.
+          option :untraced_hosts, default: [],  validate: :array
+          option :filter_target,  default: nil, validate: :callable
 
           private
 

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -23,7 +23,7 @@ module OpenTelemetry
               attributes = {
                 OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => req.method,
                 OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => USE_SSL_TO_SCHEME[use_ssl?],
-                OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => req.path,
+                OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => filter_target(req.path),
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => @address,
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => @port
               }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
@@ -83,6 +83,14 @@ module OpenTelemetry
 
             def tracer
               Net::HTTP::Instrumentation.instance.tracer
+            end
+
+            def filter_target(path)
+              if (filter = Net::HTTP::Instrumentation.instance.config[:filter_target])
+                filter.call(path)
+              else
+                path
+              end
             end
 
             def untraced?


### PR DESCRIPTION
This adds a config option to the `Net::HTTP` instrumentation, `filter_target`. It is a callable that takes a string and returns a string. The intent is to support filtering the `http.target` attribute to redact secrets/tokens in params. One way to use this with Rails is:

```ruby
filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
KV_RE   = "[^&;=]+"
PAIR_RE = %r{(#{KV_RE})=(#{KV_RE})}

filter_target: proc do |path|
  url = URI(path)
  query = url.query
  if query.empty?
    path
  else
    query = query.gsub(PAIR_RE) { |_| filter.filter($1 => $2).first.join("=") }
    "#{url.path}?#{query}"
  end
rescue URI::InvalidURIError
    path
end

OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation.instance.install({filter_target: filter_target})
```
