### PR TITLE
feat!: obfuscation for mysql2, dalli and postgresql as default option for db_statement

### DIFF
--- a/instrumentation/dalli/README.md
+++ b/instrumentation/dalli/README.md
@@ -30,6 +30,22 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Dalli', {
+    # You may optionally set a value for 'peer.service', which
+    # will be included on all spans from this instrumentation:
+    peer_service: '',
+
+    # The obfuscation of query in the db.statement attribute is enabled by default.
+    # To disable, set db_statement to :include; to omit the query completely, set db_statement to :omit
+    db_statement: :include,
+  }
+end
+```
+
 ## How can I get involved?
 
 The `opentelemetry-instrumentation-dalli` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: %I[omit obfuscate include]
+        option :db_statement, default: :obfuscate, validate: %I[omit obfuscate include]
 
         private
 

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -28,7 +28,7 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
 
   describe 'tracing' do
     before do
-      instrumentation.install
+      instrumentation.install(db_statement: :include)
     end
 
     it 'accepts peer service name from config' do

--- a/instrumentation/mysql2/README.md
+++ b/instrumentation/mysql2/README.md
@@ -46,9 +46,9 @@ end
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Mysql2', {
-    # The obfuscation of SQL in the db.statement attribute is disabled by default.
-    # To enable, set db_statement to :obfuscate.
-    db_statement: :obfuscate,
+    # The obfuscation of SQL in the db.statement attribute is enabled by default.
+    # To disable, set db_statement to :include; to omit the query completely, set db_statement to :omit
+    db_statement: :include,
   }
 end
 ```

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: %I[omit include obfuscate]
+        option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
         option :span_name, default: :statement_type, validate: %I[statement_type db_name db_operation_and_name]
         option :obfuscation_limit, default: 2000, validate: :integer
 

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -22,7 +22,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Mysql2::Instrumentation.instance }
   let(:exporter) { EXPORTER }
   let(:span) { exporter.finished_spans.first }
-  let(:config) { {} }
+  let(:config) { { db_statement: :include } }
 
   before do
     exporter.reset

--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -50,9 +50,9 @@ OpenTelemetry::SDK.configure do |c|
     # will be included on all spans from this instrumentation:
     peer_service: 'postgres:readonly',
 
-    # By default, this instrumentation includes the executed SQL as the `db.statement`
+    # By default, this instrumentation obfuscate/sanitize the executed SQL as the `db.statement`
     # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
-    # setting this option to :omit or sanitize the attribute by setting to :obfuscate
+    # setting this option to :omit or disbale sanitization the attribute by setting to :include
     db_statement: :include,
   }
 end

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: %I[omit include obfuscate]
+        option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
         option :obfuscation_limit, default: 2000, validate: :integer
 
         private

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -52,7 +52,6 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
     let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
     let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
     let(:config) { { db_statement: :include } }
-    
     before do
       instrumentation.install(config)
     end

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -51,7 +51,8 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
     let(:user) { ENV.fetch('TEST_POSTGRES_USER', 'postgres') }
     let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
     let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
-
+    let(:config) { { db_statement: :include } }
+    
     before do
       instrumentation.install(config)
     end


### PR DESCRIPTION
## Description

Based on [opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/pull/3127) and [discussion](https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions/442), change the db.statement default sql to sanitized sql

## Test
Tested with basic test suite (e.g. `rake test`)