### PR TITLE
fix!: Drop DelayedJob ActiveRecord in Tests

### DIFF
--- a/instrumentation/delayed_job/Appraisals
+++ b/instrumentation/delayed_job/Appraisals
@@ -4,6 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'delayed_job-4.1' do
-  gem 'delayed_job', '~> 4.1.0'
+appraise 'delayed_job_4.1-rails-7.1' do
+  gem 'activejob', '~> 7.1.0'
+end
+
+appraise 'delayed_job_4.1-rails-7.0' do
+  gem 'activejob', '~> 7.0.0'
+end
+
+appraise 'delayed_job-4.1-rails-6.1' do
+  gem 'activejob', '~> 6.1.0'
 end

--- a/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
+++ b/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
@@ -56,7 +56,6 @@ module OpenTelemetry
             end
 
             def add_events(span, job)
-              span.add_event('created_at', timestamp: job.created_at)
               span.add_event('run_at', timestamp: job.run_at) if job.run_at
               span.add_event('locked_at', timestamp: job.locked_at) if job.locked_at
             end

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
-  spec.add_development_dependency 'delayed_job', '~> 4.1.0'
-  spec.add_development_dependency 'delayed_job_active_record'
+  spec.add_development_dependency 'delayed_job', '~> 4.1.7'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'delayed_job', '~> 4.1.7'
-  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'delayed_job', '~> 4.1.7'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -11,6 +11,7 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
   let(:exporter) { EXPORTER }
 
   before do
+    Delayed::Worker.backend.delete_all
     instrumentation.install
     exporter.reset
   end
@@ -48,14 +49,6 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
   end
 
   describe 'tracing' do
-    before do
-      TestHelper.setup_active_record
-    end
-
-    after do
-      TestHelper.teardown_active_record
-    end
-
     it 'before job' do
       _(exporter.finished_spans.size).must_equal 0
     end

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -11,7 +11,8 @@ Bundler.require(:default, :development, :test)
 # We are compensating for that here in this test... that is a smell
 # NoMethodError: undefined method `extract_options!' for [#<ActiveJobPayload:0x0000000108bf5d48>, {}]:Array
 # delayed_job-4.1.11/lib/delayed/backend/job_preparer.rb:7:in `initialize'0
-require 'active_support/core_ext/array'
+# require 'active_support/core_ext/array'
+require 'delayed_job'
 
 require 'opentelemetry-instrumentation-delayed_job'
 

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -30,7 +30,6 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 gem_dir = Gem::Specification.find_by_name('delayed_job').gem_dir
-require "#{gem_dir}/spec/delayed/serialization/test"
 require "#{gem_dir}/spec/delayed/backend/test"
 
 Delayed::Worker.backend = Delayed::Backend::Test::Job

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -7,8 +7,13 @@
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
+# These are dependencies that delayed job assumes are already loaded
+# We are compensating for that here in this test... that is a smell
+# NoMethodError: undefined method `extract_options!' for [#<ActiveJobPayload:0x0000000108bf5d48>, {}]:Array
+# delayed_job-4.1.11/lib/delayed/backend/job_preparer.rb:7:in `initialize'0
+require 'active_support/core_ext/array'
+
 require 'opentelemetry-instrumentation-delayed_job'
-require 'active_support/core_ext/kernel/reporting'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
@@ -24,31 +29,8 @@ OpenTelemetry::SDK.configure do |c|
   c.add_span_processor span_processor
 end
 
-ActiveRecord::Migration.verbose = false
+gem_dir = Gem::Specification.find_by_name('delayed_job').gem_dir
+require "#{gem_dir}/spec/delayed/serialization/test"
+require "#{gem_dir}/spec/delayed/backend/test"
 
-module TestHelper
-  extend self
-
-  def setup_active_record
-    ::ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
-    ::ActiveRecord::Schema.define do
-      create_table 'delayed_jobs', force: :cascade do |t|
-        t.integer 'priority', default: 0, null: false
-        t.integer 'attempts', default: 0, null: false
-        t.text 'handler', null: false
-        t.text 'last_error'
-        t.datetime 'run_at'
-        t.datetime 'locked_at'
-        t.datetime 'failed_at'
-        t.string 'locked_by'
-        t.string 'queue'
-        t.datetime 'created_at'
-        t.datetime 'updated_at'
-      end
-    end
-  end
-
-  def teardown_active_record
-    ::ActiveRecord::Base.connection.close
-  end
-end
+Delayed::Worker.backend = Delayed::Backend::Test::Job

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -11,8 +11,7 @@ Bundler.require(:default, :development, :test)
 # We are compensating for that here in this test... that is a smell
 # NoMethodError: undefined method `extract_options!' for [#<ActiveJobPayload:0x0000000108bf5d48>, {}]:Array
 # delayed_job-4.1.11/lib/delayed/backend/job_preparer.rb:7:in `initialize'0
-# require 'active_support/core_ext/array'
-require 'delayed_job'
+require 'active_support/core_ext/array/extract_options'
 
 require 'opentelemetry-instrumentation-delayed_job'
 


### PR DESCRIPTION
The DelayedJob tests suite relied on the ActiveRecord Backend gem for testing, however incompatabilities with ActiveRecord/Rails 7.1 means would result in failures in the test suite.

It is not the responsibility of OTel Ruby Instrumentation to ensure compatability of 3rd party gems or ensure our test suite to come up with workarounds for bugs.

For this reason I have rewritten the test suite to use the Test backend that Delayed Job used to test the upstream gem.

This does introduce one change, the `created_at` attribute, which is _specific_ to the ActiveRecord backend will _no longer_ be emitted. Users that need this event should pin to earlier versions of the gem.

There is a risk here that the upstream DelayedJob gem will no longer be included in future releases, but I think that is less likely than to run into incompatabilities with future Rails versions.

See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/686