### PR TITLE
fix: Remove dependence on activesupport

### DIFF
--- a/instrumentation/gruf/lib/opentelemetry/instrumentation/gruf/interceptors/client.rb
+++ b/instrumentation/gruf/lib/opentelemetry/instrumentation/gruf/interceptors/client.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       module Interceptors
         class Client < ::Gruf::Interceptors::ClientInterceptor
           def call(request_context:)
-            return yield if instrumentation_config.blank?
+            return yield if instrumentation_config.empty?
 
             service = request_context.method.split('/')[1]
             method = request_context.method_name

--- a/instrumentation/gruf/lib/opentelemetry/instrumentation/gruf/interceptors/server.rb
+++ b/instrumentation/gruf/lib/opentelemetry/instrumentation/gruf/interceptors/server.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       module Interceptors
         class Server < ::Gruf::Interceptors::ServerInterceptor
           def call
-            return yield if instrumentation_config.blank?
+            return yield if instrumentation_config.empty?
 
             method = request.method_name
 


### PR DESCRIPTION
Instrumentations must not use transitive dependencies used by the library.

In this case, relying on the gruf library to load specific ActiveSupport extensions leaves the instrumentation vulnerable to bugs.

For this reason I have changed the code to use Enumerable methods instead of ActiveSupport extensions.

See https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/686

cc: @AS-AlStar 