### PR TITLE
refactor: Default to Proxy Tracer in instrumentations

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -204,7 +204,7 @@ module OpenTelemetry
         @config = {}
         @installed = false
         @options = options
-        @tracer = OpenTelemetry::Trace::Tracer.new
+        @tracer = OpenTelemetry.tracer_provider.tracer(name, version)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -220,7 +220,6 @@ module OpenTelemetry
         return false unless installable?(config)
 
         instance_exec(@config, &@install_blk)
-        @tracer = OpenTelemetry.tracer_provider.tracer(name, version)
         @installed = true
       end
 


### PR DESCRIPTION
While working on https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677, I ran into an issue where the base instrumentation tracer was not being automatically upgraded after the SDK initialization was complete.

I am not sure why this was implemented this way but I figured other instrumentations would need a reference to a proxy tracer in the future.

https://github.com/open-telemetry/opentelemetry-ruby/pull/671