### PR TITLE
Update test reset code for GraphQL-Ruby 2.1.3

### DIFF
--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -97,8 +97,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
 
         after do
           # Reset various instance variables to clear state between tests
-          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
-          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
+          [GraphQL::Schema, SomeOtherGraphQLAppSchema, SomeGraphQLAppSchema].each(&:_reset_tracer_for_testing)
         end
 
         it 'traces the provided schemas' do

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -97,13 +97,11 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
 
         after do
           # Reset various instance variables to clear state between tests
-          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
-          SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
+          [GraphQL::Schema, SomeOtherGraphQLAppSchema, SomeGraphQLAppSchema].each(&:_reset_tracer_for_testing)
         end
 
         it 'traces the provided schemas' do
           SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
-
           _(spans.size).must_equal(8)
         end
 

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -25,7 +25,7 @@ module SchemaTestPatches
   # Reseting @graphql_definition is needed for tests running against version `1.9.x`
   # Other variables are used by ~> 2.0.19
   def _reset_tracer_for_testing
-    %w[own_tracers trace_modes trace_class tracers graphql_definition].each do |ivar|
+    %w[own_tracers trace_modes trace_class tracers graphql_definition own_trace_modes].each do |ivar|
       remove_instance_variable("@#{ivar}") if instance_variable_defined?("@#{ivar}")
     end
   end


### PR DESCRIPTION
I'm trying to address the test failures mentioned here: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/689#issuecomment-1760704528


(Actually, I tried once already, over in https://github.com/rmosolgo/graphql-ruby/pull/4663, but I missed some failures because I was only running one of the test files.)

