### PR TITLE
fix: Omit `nil` `net.peer.name` attributes

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -44,9 +44,9 @@ module OpenTelemetry
           def span_creation_attributes(http_method:, url:)
             instrumentation_attrs = {
               'http.method' => http_method,
-              'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url.to_s),
-              'net.peer.name' => url.host
+              'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url.to_s)
             }
+            instrumentation_attrs['net.peer.name'] = url.host if url.host
             config = Faraday::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
             instrumentation_attrs.merge!(

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -42,89 +42,114 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       instrumentation.install
     end
 
-    it 'has http 200 attributes' do
-      response = client.get('/success')
+    describe 'given a client with a base url' do
+      it 'has http 200 attributes' do
+        response = client.get('/success')
 
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'has http.status_code 404' do
-      response = client.get('/not_found')
-
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 404
-      _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'has http.status_code 500' do
-      response = client.get('/failure')
-
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 500
-      _(span.attributes['http.url']).must_equal 'http://example.com/failure'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'merges http client attributes' do
-      client_context_attrs = {
-        'test.attribute' => 'test.value', 'http.method' => 'OVERRIDE'
-      }
-      response = OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
-        client.get('/success')
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http://example.com/success'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
       end
 
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'OVERRIDE'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(span.attributes['test.attribute']).must_equal 'test.value'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
+      it 'has http.status_code 404' do
+        response = client.get('/not_found')
 
-    it 'accepts peer service name from config' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(peer_service: 'example:faraday')
-
-      client.get('/success')
-
-      _(span.attributes['peer.service']).must_equal 'example:faraday'
-    end
-
-    it 'prioritizes context attributes over config for peer service name' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(peer_service: 'example:faraday')
-
-      client_context_attrs = { 'peer.service' => 'example:custom' }
-      OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
-        client.get('/success')
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 404
+        _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
       end
 
-      _(span.attributes['peer.service']).must_equal 'example:custom'
+      it 'has http.status_code 500' do
+        response = client.get('/failure')
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 500
+        _(span.attributes['http.url']).must_equal 'http://example.com/failure'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
+
+      it 'merges http client attributes' do
+        client_context_attrs = {
+          'test.attribute' => 'test.value', 'http.method' => 'OVERRIDE'
+        }
+        response = OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
+          client.get('/success')
+        end
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'OVERRIDE'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http://example.com/success'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['test.attribute']).must_equal 'test.value'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
+
+      it 'accepts peer service name from config' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(peer_service: 'example:faraday')
+
+        client.get('/success')
+
+        _(span.attributes['peer.service']).must_equal 'example:faraday'
+      end
+
+      it 'prioritizes context attributes over config for peer service name' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(peer_service: 'example:faraday')
+
+        client_context_attrs = { 'peer.service' => 'example:custom' }
+        OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
+          client.get('/success')
+        end
+
+        _(span.attributes['peer.service']).must_equal 'example:custom'
+      end
+
+      it 'does not leak authentication credentials' do
+        client.run_request(:get, 'http://username:password@example.com/success', nil, {})
+
+        _(span.attributes['http.url']).must_equal 'http://example.com/success'
+      end
     end
 
-    it 'does not leak authentication credentials' do
-      client.run_request(:get, 'http://username:password@example.com/success', nil, {})
+    describe 'given a client without a base url' do
+      let(:client) do
+        Faraday.new do |builder|
+          builder.adapter(:test) do |stub|
+            stub.get('/success') { |_| [200, {}, 'OK'] }
+          end
+        end
+      end
 
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
+      it 'omits missing attributes' do
+        response = client.get('/success')
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http:/success'
+        _(span.attributes).wont_include('net.peer.name')
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Copied from https://github.com/open-telemetry/opentelemetry-ruby/pull/1280

> Faraday uses a base URL to derive the host name which is used by the tracer middleware as the span attribute value for `net.peer.name`.
> 
> Although it seems incorrect, Faraday does not require a base URL when it is initialized and is a commonly used when using Faraday test stubs.
> 
> When the base URL is absent, the `net.peer.name` is set to `nil` triggering and invalid attribute error report and creates a bit of noise for test cases.
> 
> This change omits the `net.peer.name` attribute when it is `nil` to suppress error reporting when the host is absent.

Also, we have an app calling itself by not setting a base URL so we are observing this error in runtime. 