### PR TITLE
ci: upgrade to latest stable version of toys

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.1"
       - name: Process release request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.1"
       - name: Update open releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.1"
       - name: Perform release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.1"
       - name: Open release pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.1"
       - name: Retry release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -1,7 +1,7 @@
-toys_version! "0.14.7"
+toys_version! "0.15.1"
 
 load_git remote: "https://github.com/dazuma/toys.git",
          path: ".toys/release",
          as: "release",
-         commit: "toys/v0.14.7",
+         commit: "toys/v0.15.1",
          update: 3600


### PR DESCRIPTION
This will fix issues with incompatible version usage in configs:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/6534421626/job/17741560442#step:5:10