### PR TITLE
fix: Remove dependency on ActiveSupport core extensions from Grape instrumentation

### DIFF
--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -96,7 +96,7 @@ module OpenTelemetry
             version = endpoint.routes.first.options[:version] || ''
             prefix = endpoint.routes.first.options[:prefix]&.to_s || ''
             parts = [prefix, version] + namespace.split('/') + endpoint.options[:path]
-            parts.reject { |p| p.blank? || p.eql?('/') }.join('/').prepend('/')
+            parts.reject { |p| p.nil? || p.empty? || p.eql?('/') }.join('/').prepend('/')
           end
 
           def formatter_type(formatter)


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/705

I checked if we are using any other core extensions apart from `blank?` using this as a reference: https://guides.rubyonrails.org/active_support_core_extensions.html

Also, instead of replacing directly with `empty?`, I added an extra check for `nil?`. We shouldn't get `nil` values here, but I added it as a safeguard in case there are any changes in the Grape gem that change this behaviour.

Another case that was covered by `blank?` but not by `empty?` is pure whitespace strings, but I decided not to add this since it would be very unlikely to have path with whitespace.