### PR TITLE
chore: Fix HTTPx attribute and changelog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,8 @@ instrumentation/grape/ @muripic @fbogsany @mwear @robertlaurin @dazuma @ericmust
 
 instrumentation/graphql/ @swalkinshaw @rmosolgo @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd
 
+instrumentation/httpx/ @HoneyryderChuck @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd
+
 instrumentation/mongo/ @johnnyshields @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd
 
 instrumentation/racecar/ @chrisholmes @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd

--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-instrumentation-httpx


### PR DESCRIPTION
The toys gem is unable to detect an initial release from a file without a header. Fixes:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/6762253625/job/18378001165 

