### PR TITLE
release: Release opentelemetry-instrumentation-httpx 0.1.0 (initial release)

### DIFF
--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ### v0.1.0 / 2023-11-06
 
-* (No significant changes)
+* Initial Release.

--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Release History: opentelemetry-instrumentation-httpx
+
+### v0.1.0 / 2023-11-06
+
+* (No significant changes)

--- a/instrumentation/httpx/lib/opentelemetry/instrumentation/httpx/version.rb
+++ b/instrumentation/httpx/lib/opentelemetry/instrumentation/httpx/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module HTTPX
-      VERSION = '0.0.0'
+      VERSION = '0.1.0'
     end
   end
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **opentelemetry-instrumentation-httpx 0.1.0** (initial release)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the     "release: pending" label is set. The release     script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## opentelemetry-instrumentation-httpx

### v0.1.0 / 2023-11-06

* Initial Release.
