### PR TITLE
Removal Sinatra 1.x Appraisal

### DIFF
--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -12,6 +12,19 @@ gem install opentelemetry-instrumentation-rack
 
 Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-rack` in your `Gemfile`.
 
+### Version Compatibility
+
+Older versions of Rack are not supported by the latest version of this instrumentation. If you are using an older version of Rack and need an earlier version of this instrumentation, then consider installing and pinning the compatible gem version, e.g.:
+
+```console
+gem opentelemetry-instrumentation-rack, "<version>"
+```
+
+| Rack Version | Instrumentation Version |
+| ------------ | ----------------------- |
+| `< 2.0`      | `= 0.22.1`              |
+| `>= 2.0`     | `~> 0.23`               |
+
 ## Usage
 
 To use the instrumentation, call `use` with the name of the instrumentation:

--- a/instrumentation/sinatra/Appraisals
+++ b/instrumentation/sinatra/Appraisals
@@ -11,7 +11,3 @@ end
 appraise 'sinatra-2.x' do
   gem 'sinatra', '~> 2.1'
 end
-
-appraise 'sinatra-1.x' do
-  gem 'sinatra', '~> 1.4'
-end

--- a/instrumentation/sinatra/README.md
+++ b/instrumentation/sinatra/README.md
@@ -10,7 +10,21 @@ Install the gem using:
 gem install opentelemetry-instrumentation-sinatra
 ```
 
+
 Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-sinatra` to your `Gemfile`.
+
+### Version Compatibility
+
+Older versions of Sinatra depend on older version of Rack, which are not supported by the latest version of Rack instrumentation. If you are using an older version of Sinatra and need an earlier version of Rack instrumentation, then consider installing and pinning the compatible gem version, e.g.:
+
+```console
+gem opentelemetry-instrumentation-rack, "<version>"
+```
+
+| Sinatra Version | Rack Instrumentation Version |
+| --------------- | ---------------------------- |
+| `< 2.0`         | `= 0.22.1`                   |
+| `>= 2.0`        | `~> 0.22`                    |
 
 ## Usage
 


### PR DESCRIPTION
Sinatra 1.x is not supported as it does not provide the Sinatra::Event API. It does not need to be appraised.

This should close #364.

This issue recommends documenting the last supported version for Sinatra 1.x, Given that the last release of Sinatra was January 2017, is this still something that is advised?

The gemspec references "sinatra", without a strict version requirement. I was going to update this but I noticed all the other instrumentation packages don't reference minimal versions for dependencies either.