### PR TITLE
release: Release opentelemetry-instrumentation-rdkafka 0.4.2

### DIFF
--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-instrumentation-rdkafka
 
+### v0.4.2 / 2023-11-23
+
+* FIXED: Retry Release of 0.4.1 [#730](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/730)
+
 ### v0.4.1 / 2023-11-22
 
 * FIXED: Get Rdkafka version from VERSION contant

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/version.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module Rdkafka
-      VERSION = '0.4.1'
+      VERSION = '0.4.2'
     end
   end
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **opentelemetry-instrumentation-rdkafka 0.4.2** (was 0.4.1)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the     "release: pending" label is set. The release     script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## opentelemetry-instrumentation-rdkafka

### v0.4.2 / 2022-11-23

* FIXED: Retry Release of 0.4.1 [#730](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/730)