### PR TITLE
fix: Force new version of the gem

### DIFF
--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
   spec.summary     = 'Instrumentation Base for the OpenTelemetry framework'
-  spec.description = 'Instrumentation Base for the OpenTelemetry framework'
+  spec.description = 'Provides abstract classes for instrumentation authors to use when creating gems'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
 


### PR DESCRIPTION
Intended to force the release of the base gem. The previous release is failing to install from rubygems. 

```console
vibora ~/github/opentelemetry-ruby-contrib(main|…) %
🤘 gem list -r opentelemetry-instrumentation-base --verbose

*** REMOTE GEMS ***

GET https://rubygems.org/latest_specs.4.8.gz
304 Not Modified
opentelemetry-instrumentation-base (0.22.3)

vibora ~/github/opentelemetry-ruby-contrib(main|…) %
🤘 gem install opentelemetry-instrumentation-base -v 0.22.3 --verbose
HEAD https://index.rubygems.org/
200 OK
GET https://index.rubygems.org/info/opentelemetry-instrumentation-base
200 OK
ERROR:  Could not find a valid gem 'opentelemetry-instrumentation-base' (= 0.22.3) in any repository
GET https://rubygems.org/latest_specs.4.8.gz
304 Not Modified
ERROR:  Possible alternatives: opentelemetry-instrumentation-base
vibora ~/github/opentelemetry-ruby-contrib(main|…) %
```