### PR TITLE
chore: Fix Rails 7.2 secrets deprecation warning

### DIFF
--- a/instrumentation/action_pack/example/trace_demonstration.ru
+++ b/instrumentation/action_pack/example/trace_demonstration.ru
@@ -23,7 +23,7 @@ require 'action_controller/railtie'
 class TraceRequestApp < Rails::Application
   config.root = __dir__
   config.hosts << 'example.org'
-  secrets.secret_key_base = 'secret_key_base'
+  credentials.secret_key_base = 'secret_key_base'
   config.eager_load = false
   config.logger = Logger.new($stdout)
   Rails.logger  = config.logger

--- a/instrumentation/action_view/example/trace_request_demonstration.ru
+++ b/instrumentation/action_view/example/trace_request_demonstration.ru
@@ -26,7 +26,7 @@ require 'action_view/railtie'
 class TraceRequestApp < Rails::Application
   config.root = __dir__
   config.hosts << 'example.org'
-  secrets.secret_key_base = 'secret_key_base'
+  credentials.secret_key_base = 'secret_key_base'
 
   config.eager_load = false
 

--- a/instrumentation/rails/example/trace_request_demonstration.ru
+++ b/instrumentation/rails/example/trace_request_demonstration.ru
@@ -23,7 +23,7 @@ require 'action_controller/railtie'
 class TraceRequestApp < Rails::Application
   config.root = __dir__
   config.hosts << 'example.org'
-  secrets.secret_key_base = 'secret_key_base'
+  credentials.secret_key_base = 'secret_key_base'
   config.eager_load = false
   config.logger = Logger.new($stdout)
   Rails.logger  = config.logger


### PR DESCRIPTION
While running the `trace_demonstration.ru` example in #703, I came across the following deprecation warning: 
```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor 
of `Rails.application.credentials` and will be removed in Rails 7.2.
```

This PR updates the references to use `credentials` instead of `secrets`.