### PR TITLE
chore(deps-dev): update rubocop to ~> 1.58.0 in multiple gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.57.1'
+gem 'rubocop', '~> 1.58.0'
 gem 'rubocop-performance', '~> 1.19.1'

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.57.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
+++ b/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sqlite3'

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -93,8 +93,8 @@ module OpenTelemetry
             return '' unless endpoint.routes
 
             namespace = endpoint.routes.first.namespace
-            version = endpoint.routes.first.options[:version] || ''
-            prefix = endpoint.routes.first.options[:prefix]&.to_s || ''
+            version = endpoint.routes.first.options[:version]&.to_s
+            prefix = endpoint.routes.first.options[:prefix]&.to_s
             parts = [prefix, version] + namespace.split('/') + endpoint.options[:path]
             parts.reject { |p| p.nil? || p.empty? || p.eql?('/') }.join('/').prepend('/')
           end

--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
+++ b/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/http/test/instrumentation/http/patches/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/client_test.rb
@@ -128,7 +128,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       let(:span_name_formatter) do
         # demonstrate simple addition of path and string to span name:
         lambda { |request_method, request_path|
-          return "HTTP #{request_method} #{request_path} miniswan"
+          "HTTP #{request_method} #{request_path} miniswan"
         }
       end
 

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
+++ b/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg', '>= 1.1.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg', '~> 1.1'
   spec.add_development_dependency 'que'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'racecar', '~> 2.7'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 2.1.0'
   spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
+++ b/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '>= 0.9.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rdkafka', '>= 0.12'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'redis', '~> 4.1'
   spec.add_development_dependency 'redis-client', '~> 0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'resque'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rest-client', '~> 2.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.19'

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/instrumentation.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/instrumentation.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
         end
 
         compatible do
-          (!gem_version.nil? && gem_version >= MINIMUM_VERSION)
+          !gem_version.nil? && gem_version >= MINIMUM_VERSION
         end
 
         private

--- a/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
+++ b/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'ruby-kafka'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'sidekiq'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sinatra'

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'trilogy', '>= 2.0', '< 3.0'

--- a/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
+++ b/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.57.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/propagator/xray/opentelemetry-propagator-xray.gemspec
+++ b/propagator/xray/opentelemetry-propagator-xray.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.57.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/resources/azure/opentelemetry-resource-detector-azure.gemspec
+++ b/resources/azure/opentelemetry-resource-detector-azure.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.55.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.19.1'

--- a/resources/container/opentelemetry-resource-detector-container.gemspec
+++ b/resources/container/opentelemetry-resource-detector-container.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.56.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
+++ b/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.55.1'
+  spec.add_development_dependency 'rubocop', '~> 1.58.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.19.1'


### PR DESCRIPTION
## Update gemspecs

When dependabot is piecemealing a monorepo of gems (#748, #749, #750. #751, #752. #753, #754), go Old School:

```bash
git ls-files \*.gemspec \
  | xargs \
    sed -i '' \
        -E "s/'rubocop', '~> [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'/'rubocop', '~> 1.54.1'/"
```

## Rubocop Appeasements

### Lint/RedundantSafeNavigation

```
Redundant safe navigation with default literal detected.
  prefix = endpoint.routes.first.options[:prefix]&.to_s || ''
                                                 ^^^^^^^^^^^^
```

OK. We can stop at safely navigating the string coercion without supplying a default because `paths.reject{}` below filters `nil`s.

### Style/RedundantReturn

```
Redundant return detected.
  return "HTTP #{request_method} #{request_path} miniswan"
  ^^^^^^
```

Sure.

### Style/RedundantParentheses

```
Don't use parentheses around a logical expression.
      (!gem_version.nil? && gem_version >= MINIMUM_VERSION)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

OK.