### PR TITLE
chore: let stalebot close issues after 30 days of being stale.

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,7 +18,7 @@ jobs:
         stale-issue-label: "stale"
         exempt-issue-labels: "keep"
         days-before-issue-stale: 30
-        days-before-issue-close: -1
+        days-before-issue-close: 30
         stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `keep` label to hold stale off permanently, or do nothing. If you do nothing this pull request will be closed eventually by the stale bot"
         stale-pr-label: "stale"
         exempt-pr-labels: "keep"


### PR DESCRIPTION
Previously Stalebot marked issues as stale, but never closed them.
This PR will cause Stalebot to also close the issues after 30 days of being stale (thus a total of 60 days of no activity on the issue).

Any wrongly closed issues can always be reopened, or a new issue referencing the old issue can be created.