### PR TITLE
fix: Backport Rack proxy event to middleware

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -77,6 +77,8 @@ module OpenTelemetry
               tracer.in_span(request_span_name,
                              attributes: request_span_attributes(env: env),
                              kind: request_span_kind) do |request_span|
+                request_start_time = OpenTelemetry::Instrumentation::Rack::Util::QueueTime.get_request_start(env)
+                request_span.add_event('http.proxy.request.started', timestamp: request_start_time) unless request_start_time.nil?
                 OpenTelemetry::Instrumentation::Rack.with_span(request_span) do
                   @app.call(env).tap do |status, headers, response|
                     set_attributes_after_request(request_span, status, headers, response)

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -25,6 +25,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
   let(:exporter) { EXPORTER }
   let(:finished_spans) { exporter.finished_spans }
   let(:first_span) { exporter.finished_spans.first }
+  let(:proxy_event) { first_span.events&.first }
 
   let(:default_config) { {} }
   let(:config) { default_config }
@@ -81,6 +82,15 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       it 'records the query path' do
         _(first_span.attributes['http.target']).must_equal '/endpoint?query=true'
         _(first_span.name).must_equal 'HTTP GET'
+      end
+    end
+
+    describe 'given request proxy headers' do
+      let(:env) { Hash('HTTP_X_REQUEST_START' => '1677723466') }
+
+      it 'records an event' do
+        _(proxy_event.name).must_equal 'http.proxy.request.started'
+        _(proxy_event.timestamp).must_equal 1_677_723_466_000_000_000
       end
     end
 


### PR DESCRIPTION
The Rack Event handler instrumentation adds a Span Event representing the time the request was enqueued. See https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/1fa08103b4bad30ff94e27ba013de390684cc029/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb#L263-L264

The older middleware-based instrumentation represents the same information (optionally enabled via `config[:record_frontend_span]`) as a `http_server.proxy` span as a "fake" parent span for the Rack server span. The Span Event approach is both more correct and more useful for analysis.

This PR "backports" the Span Event approach to the middleware instrumentation. Since this is done unconditionally in the Rack Event handler instrumentation, I've made it unconditional in the middleware as well. If the `config[:record_frontend_span]` option is enabled, this will duplicate information, but I would argue we should deprecate that config option (and the corresponding code).

Many thanks to @arielvalentin for writing great code ~that I can steal~ to inspire me.