### PR TITLE
chore: Add Tests for GraphQL C Parser

### DIFF
--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -24,6 +24,10 @@ appraise 'graphql-2.1' do
   gem 'graphql', '~> 2.1.8'
 end
 
+appraise 'graphql-2.2.0' do
+  gem 'graphql', '2.2.0'
+end
+
 appraise 'graphql-2.x' do
-  gem 'graphql', '>= 2.2', '< 3.0.0'
+  gem 'graphql', '>= 2.2.1', '< 3.0.0'
 end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -32,3 +32,11 @@ end
 appraise 'graphql-2.2.x' do
   gem 'graphql', '~> 2.2.1', '< 3.0.0'
 end
+
+appraise 'graphql-c_parser-latest' do
+  gem 'graphql-c_parser'
+end
+
+appraise 'graphql-latest' do
+  gem 'graphql'
+end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -4,18 +4,26 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'graphql-1.13' do
+# Max compatible version of 1.x
+appraise 'graphql-1.x' do
   gem 'graphql', '~> 1.13'
 end
 
-appraise 'graphql-2.0.17' do
-  gem 'graphql', '2.0.17'
-end
-
+# A bug was introduced in 2.0.18 that was fixed in 2.0.19
 appraise 'graphql-2.0.18' do
   gem 'graphql', '2.0.18'
 end
 
+# Max compatible version of 2.0.x
+appraise 'graphql-2.0' do
+  gem 'graphql', '~> 2.0.27'
+end
+
+# Max compatible version of 2.1.x
+appraise 'graphql-2.1' do
+  gem 'graphql', '~> 2.1.8'
+end
+
 appraise 'graphql-2.x' do
-  gem 'graphql', '>= 2.0.18', '< 3.0.0'
+  gem 'graphql', '>= 2.2', '< 3.0.0'
 end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -24,10 +24,11 @@ appraise 'graphql-2.1' do
   gem 'graphql', '~> 2.1.8'
 end
 
-appraise 'graphql-2.2.0' do
-  gem 'graphql', '2.2.0'
+appraise 'graphql-c_parser-2.2.x' do
+  gem 'graphql', '~> 2.2.0'
+  gem 'graphql-c_parser', '~> 1.0.7'
 end
 
-appraise 'graphql-2.x' do
-  gem 'graphql', '>= 2.2.1', '< 3.0.0'
+appraise 'graphql-2.2.x' do
+  gem 'graphql', '~> 2.2.1', '< 3.0.0'
 end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -25,7 +25,7 @@ appraise 'graphql-2.1' do
 end
 
 appraise 'graphql-c_parser-2.2.x' do
-  gem 'graphql', '~> 2.2.0'
+  gem 'graphql', '~> 2.2.1'
   gem 'graphql-c_parser', '~> 1.0.7'
 end
 

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -54,6 +54,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
           'graphql.execute_multiplex'
         ]
 
+        expected_spans.delete('graphql.lex') unless trace_lex_supported?
+
         expected_result = {
           'simpleField' => 'Hello.',
           'resolvedField' => { 'originalValue' => 'testing=1', 'uppercasedValue' => 'TESTING=1' }
@@ -103,7 +105,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
         it 'traces the provided schemas' do
           SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
 
-          _(spans.size).must_equal(8)
+          _(spans.select { |s| s.name.start_with?('graphql.') }).wont_be(:empty?)
         end
 
         it 'does not trace all schemas' do

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -53,6 +53,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
           'graphql.execute_query_lazy',
           'graphql.execute_multiplex'
         ]
+        expected_spans.delete('graphql.lex') unless trace_lex_supported?
 
         expected_result = {
           'simpleField' => 'Hello.',
@@ -102,7 +103,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
 
         it 'traces the provided schemas' do
           SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
-          _(spans.size).must_equal(8)
+          _(spans.select { |s| s.name.start_with?('graphql.') }).wont_be(:empty?)
         end
 
         it 'does not trace all schemas' do

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -125,3 +125,12 @@ end
 def gem_version
   Gem::Version.new(GraphQL::VERSION)
 end
+
+# When tracing, is the parser expected to call `lex` before `parse`
+def trace_lex_supported?
+  return @trace_lex_supported if defined?(@trace_lex_supported)
+
+  # In GraphQL 2.2, the default parser was changed such that `lex` is no longer called
+  @trace_lex_supported = Gem::Requirement.new('< 2.2').satisfied_by?(Gem::Version.new(GraphQL::VERSION)) \
+    || (defined?(GraphQL::CParser) == 'constant')
+end


### PR DESCRIPTION
Graphql 2.2 introduces an optional C implementation of the Parser as well as optimizations to the pure Ruby parser that result in changes to what is captured during instrumentation.

Users of the pure Ruby implementation will no longer see `graphql.lex` spans emitted as a part of their traces and will instead need to switch to using the C Parser in order to explicitly see time spent in the lexer. 

This PR introduces updates to the test suite to add coverage for the C Parser and changes to the Ruby implementation. 

There are no underlying changes in the instrumentation itself. 