### PR TITLE
Revert "ci: Use Org OTel Bot Token (#789)"

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -21,7 +21,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.3"
       - name: Process release request
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           toys release _onclosed --verbose \
             "--enable-releases=${{ secrets.ENABLE_RELEASES }}" \

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -22,7 +22,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.3"
       - name: Update open releases
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           toys release _onpush --verbose \
             < /dev/null

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -31,7 +31,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.3"
       - name: Perform release
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           toys release perform --yes --verbose \
             "--enable-releases=${{ secrets.ENABLE_RELEASES }}" \

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e
         id: release
-        with:
-          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
     outputs:
       paths_released: ${{ steps.release.outputs.paths_released }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -25,7 +25,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.3"
       - name: Open release pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           toys release request --yes --verbose \
             "--gems=${{ github.event.inputs.gems }}" \

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -28,7 +28,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.3"
       - name: Retry release
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           toys release retry --yes --verbose \
             "--enable-releases=${{ secrets.ENABLE_RELEASES }}" \

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/stale@v9
       name: Clean up stale issues and PRs
       with:
-        repo-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "👋 This issue has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `keep` label to hold stale off permanently, or do nothing. If you do nothing this issue will be closed eventually by the stale bot."
         stale-issue-label: "stale"
         exempt-issue-labels: "keep"


### PR DESCRIPTION
This reverts commit 586b0fb137d430e2b826f3814723dd61c8d82ff1.

It seems this is intended that the OTel Bot use forks when making changes. 