### PR TITLE
Trilogy: only set `db.instance.id` attribute if there is a value

### DIFF
--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -91,7 +91,7 @@ module OpenTelemetry
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_USER] = database_user if database_user
             attributes[::OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] unless config[:peer_service].nil?
-            attributes['db.instance.id'] = @connected_host if defined?(@connected_host) && @connected_host
+            attributes['db.instance.id'] = @connected_host unless @connected_host.nil?
 
             if sql
               case config[:db_statement]

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -91,7 +91,7 @@ module OpenTelemetry
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_NAME] = database_name if database_name
             attributes[::OpenTelemetry::SemanticConventions::Trace::DB_USER] = database_user if database_user
             attributes[::OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] unless config[:peer_service].nil?
-            attributes['db.instance.id'] = @connected_host if defined?(@connected_host)
+            attributes['db.instance.id'] = @connected_host if defined?(@connected_host) && @connected_host
 
             if sql
               case config[:db_statement]


### PR DESCRIPTION
It's possible for the `@connected_host` value to be ~unset~ `nil` because a query is made within trilogy to initially assign the `@connected_host`:

https://github.com/trilogy-libraries/trilogy/blob/3c3a3865a3896f3056b1d7c69c5244964b60937c/contrib/ruby/lib/trilogy.rb#L39-L50

This PR adds a presence check before assigning the attribute. 