### PR TITLE
ci: Add Tests For Ruby 3.3

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -66,18 +66,18 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1.144.1
+      uses: ruby/setup-ruby@v1.165.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
         bundler:  "latest"
         bundler-cache: true
-        cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
+        cache-version: "${{ inputs.ruby }}-${{ steps.setup.outputs.cache_key }}"
 
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1.144.1
+      uses: ruby/setup-ruby@v1.165.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"

--- a/.github/workflows/ci-contrib-canary.yml
+++ b/.github/workflows/ci-contrib-canary.yml
@@ -21,6 +21,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
+          ruby: "3.3"
+          latest: "true"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -74,6 +80,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-${{ matrix.gem }}"
+          ruby: "3.3"
+          latest: "true"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-propagator-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -63,6 +68,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/ci-instrumentation-canary.yml
+++ b/.github/workflows/ci-instrumentation-canary.yml
@@ -59,6 +59,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        # BLOCKED BY: https://github.com/bigcommerce/gruf/pull/197
+        if: "${{ matrix.gem != 'gruf' }}"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
+          latest: "true"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/ci-instrumentation-with-services-canary.yml
+++ b/.github/workflows/ci-instrumentation-with-services-canary.yml
@@ -29,6 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
+          latest: "true"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -69,6 +74,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -106,6 +116,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -159,6 +174,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -203,6 +223,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:
@@ -244,6 +269,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -50,6 +50,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: "Test Ruby 3.3"
+        # BLOCKED BY: https://github.com/bigcommerce/gruf/pull/197
+        if: "${{ matrix.gem != 'gruf' }}"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "3.3"
       - name: "Test Ruby 3.2"
         uses: ./.github/actions/test_gem
         with:

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+          - 3.3
           - 3.2
           - 3.1
           - 3.0
@@ -22,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: "Install Latest Gem Versions on ${{ matrix.ruby-version }}"

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -2,6 +2,12 @@
 
 # add more tests for excon
 
-appraise 'excon-0.71' do
-  gem 'excon', '~> 0.71.0'
+%w[0.71 0.109].each do |version|
+  appraise "excon-#{version}" do
+    gem 'excon', "~> #{version}.0"
+  end
+end
+
+appraise 'excon-latest' do
+  gem 'excon'
 end

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
-  spec.add_development_dependency 'excon', '~> 0.71.0'
+  spec.add_development_dependency 'excon'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -244,9 +244,9 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       _(span.attributes['net.peer.port']).must_equal(99_999)
 
       span_event = span.events.first
-
       _(span_event.name).must_equal 'exception'
-      _(span_event.attributes['exception.type']).must_equal(SocketError.name)
+      # Depending on the Ruby and Excon Version this will be a SocketError, Socket::ResolutionError or Resolv::ResolvError
+      _(span_event.attributes['exception.type']).must_match(/(SocketError|Resolv)/)
 
       assert_http_spans(host: 'invalid.com', target: '/example')
     end

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -246,7 +246,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       span_event = span.events.first
       _(span_event.name).must_equal 'exception'
       # Depending on the Ruby and Excon Version this will be a SocketError, Socket::ResolutionError or Resolv::ResolvError
-      _(span_event.attributes['exception.type']).must_match(/(SocketError|Resolv)/)
+      _(span_event.attributes['exception.type']).must_match(/(Socket|Resolv)/)
 
       assert_http_spans(host: 'invalid.com', target: '/example')
     end

--- a/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
@@ -54,7 +54,7 @@ describe OpenTelemetry::Instrumentation::GraphQL do
           OpenTelemetry::TestHelpers.with_test_logger do |log|
             instrumentation.install(config)
             _(log.string).must_match(
-              / Unable to patch schema Old::Truck: undefined method `trace_with' for Old::Truck:Class/
+              /undefined method `trace_with'.*Old::Truck/
             )
           end
         end

--- a/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/instrumentation_test.rb
@@ -90,7 +90,7 @@ describe OpenTelemetry::Instrumentation::GraphQL do
             instrumentation.install(config)
 
             _(log.string).must_match(
-              /Unable to patch schema Old::Truck: undefined method `use' for Old::Truck:Class/
+              /undefined method `use'.*Old::Truck/
             )
           end
         end


### PR DESCRIPTION
Ruby 3.3 is out so this PR adds actions to test against it. 

One this to note is that `bigcommerce/gruf` does not yet support Ruby 3.3. Once https://github.com/bigcommerce/gruf/pull/197 is merged I will update the test suite to include gruf again.