### PR TITLE
Add xuan-cao-swi to approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,22 +12,22 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/aws_sdk/ @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/aws_sdk/ @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/racecar/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/racecar/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/rspec/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/rspec/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/que/ @indrekj @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle
+instrumentation/que/ @indrekj @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Approvers ([@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open
 
 - [Josef Šimánek](https://github.com/simi)
 - [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
+- [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 


### PR DESCRIPTION
@xuan-cao-swi has made a number of contributions to opentelemetry-ruby and opentelemetry-ruby-contrib. We'd like to promote him to contrib approver. Here is a summary of his work:

Contrib:
- [PRs authored](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pulls?q=author%3Axuan-cao-swi++is%3Apr+)
- [PRs commented upon](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues?q=commenter%3Axuan-cao-swi+) 
- [Issues opened](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues?q=is%3Aissue+author%3Axuan-cao-swi+) 
- [Issues commented upon](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues?q=is%3Aissue+commenter%3Axuan-cao-swi+)


Core:
- [PRs authored](https://github.com/open-telemetry/opentelemetry-ruby/pulls?q=author%3Axuan-cao-swi++is%3Apr+)
- [PRs commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=commenter%3Axuan-cao-swi+) 
- [Issues opened](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+author%3Axuan-cao-swi+) 
- [Issues commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+commenter%3Axuan-cao-swi+)
