### PR TITLE
chore: add rackup to sinatra example Gemfile

### DIFF
--- a/instrumentation/sinatra/example/Gemfile
+++ b/instrumentation/sinatra/example/Gemfile
@@ -5,9 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source 'https://rubygems.org'
-gem 'puma'
 gem 'opentelemetry-api'
 gem 'opentelemetry-common'
 gem 'opentelemetry-instrumentation-sinatra'
 gem 'opentelemetry-sdk'
+gem 'puma'
+gem 'rackup'
 gem 'sinatra'


### PR DESCRIPTION
Sinatra 4 needs `rackup` as a dependency ( [Sinatra CHANGELOG](https://github.com/sinatra/sinatra/blob/main/CHANGELOG.md) ). This PR adds it to the instrumentations example Gemfile, so the example can start.