### PR TITLE
docs: relocate Resque config option comments to render in Yard docs

### DIFF
--- a/instrumentation/resque/lib/opentelemetry/instrumentation/resque.rb
+++ b/instrumentation/resque/lib/opentelemetry/instrumentation/resque.rb
@@ -9,7 +9,7 @@ require 'opentelemetry-instrumentation-base'
 
 module OpenTelemetry
   module Instrumentation
-    # Contains the OpenTelemetry instrumentation for the Resque gem
+    # (see OpenTelemetry::Instrumentation::Resque::Instrumentation)
     module Resque
     end
   end

--- a/instrumentation/resque/lib/opentelemetry/instrumentation/resque/instrumentation.rb
+++ b/instrumentation/resque/lib/opentelemetry/instrumentation/resque/instrumentation.rb
@@ -7,7 +7,61 @@
 module OpenTelemetry
   module Instrumentation
     module Resque
-      # The Instrumentation class contains logic to detect and install the Resque instrumentation
+      # The {OpenTelemetry::Instrumentation::Resque::Instrumentation} class contains logic to detect and install the Resque instrumentation
+      #
+      # Installation and configuration of this instrumentation is done within the
+      # {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry/SDK#configure-instance_method OpenTelemetry::SDK#configure}
+      # block, calling {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry%2FSDK%2FConfigurator:use use()}
+      # or {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry%2FSDK%2FConfigurator:use_all use_all()}.
+      #
+      # ## Configuration keys and options
+      #
+      # ### `:span_naming`
+      #
+      # Specifies how the span names are set. Can be one of:
+      #
+      # - `:queue` **(default)** - The job span name will appear as '<destination / queue name> <operation>',
+      #   for example `default process`.
+      # - `:job_class` - The job span name will appear as '<job class name> <operation>',
+      #   for example `SimpleJob process`.
+      #
+      # ### `:propagation_style`
+      #
+      # Specifies how the job's execution is traced and related to the trace where the job was enqueued.
+      #
+      # - `:link` **(default)** - The job will be represented by a separate trace from the span that enqueued the job.
+      #     - The initial span of the job trace will be associated with the span that enqueued the job, via a
+      #       {https://opentelemetry.io/docs/concepts/signals/traces/#span-links Span Link}.
+      # - `:child` - The job will be represented within the same logical trace, as a direct
+      #   child of the span that enqueued the job.
+      # - `:none` - The job will be represented by a separate trace from the span that enqueued the job.
+      #   There will be no explicit relationship between the job trace and the trace containing the span that
+      #   enqueued the job.
+      #
+      # ### `:force_flush`
+      #
+      # Specifies whether spans are forcibly flushed (exported out of process) upon every job completion.
+      #
+      #   - `:ask_the_job` **(default)** - Synchronously flush completed spans when a job completes if workers are
+      #     forked for each job.
+      #       - Determined by checking if {https://www.rubydoc.info/gems/resque/Resque%2FWorker:fork_per_job%3F Resque::Worker#fork_per_job?}
+      #         is true. Spans must be flushed and exported before a worker process terminates or no telemetry will be sent.
+      #   - `:always` - All completed spans will be synchronously flushed at the end of a job's execution.
+      #   - `:never` - Job completion will not affect the export of spans out of worker processes.
+      #       - Selecting this option will result in spans being lost if the worker process ends before
+      #         the spans are flushed. You might select this option if you wish to coordinate the timing for flushing
+      #         completed spans yourself.
+      #
+      # @example An explicit default configuration
+      #   OpenTelemetry::SDK.configure do |c|
+      #     c.use_all({
+      #       'OpenTelemetry::Instrumentation::Resque' => {
+      #         span_naming: :queue,
+      #         propagation_style: :link
+      #         force_flush: :ask_the_job,
+      #       },
+      #     })
+      #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         install do |_config|
           require_dependencies
@@ -17,30 +71,6 @@ module OpenTelemetry
         present do
           defined?(::Resque)
         end
-
-        ## Supported configuration keys for the install config hash:
-        #
-        # force_flush: controls if spans are forcibly flushed upon job completion
-        #   - :ask_the_job (default) - if `Resque::Worker#fork_per_job?` is set,
-        #     all completed spans will be synchronously flushed at the end of a
-        #     job's execution
-        #   - :always - all completed spans will be synchronously flushed at the
-        #     end of a job's execution
-        #   - :never - the job will not intervene with the processing of spans
-        #
-        # span_naming: when `:job_class`, the span names will be set to
-        #   '<job class name> <operation>'. When `:queue`, the span names
-        #   will be set to '<destination / queue name> <operation>'
-        #
-        # propagation_style: controls how the job's execution is traced and related
-        #   to the trace where the job was enqueued. Can be one of:
-        #   - :link (default) - the job will be executed in a separate trace. The
-        #     initial span of the execution trace will be linked to the span that
-        #     enqueued the job, via a Span Link.
-        #   - :child - the job will be executed in the same logical trace, as a direct
-        #     child of the span that enqueued the job.
-        #   - :none - the job's execution will not be explicitly linked to the span that
-        #     enqueued the job.
 
         option :force_flush,       default: :ask_the_job, validate: %I[ask_the_job always never]
         option :span_naming,       default: :queue,       validate: %I[job_class queue]


### PR DESCRIPTION
As formatted markdown comments on the class, the information is made visible in the Yard-generated docs without making the options appear to be class or instance variables. Possibly instrumentation READMEs could link in [the Usage section](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/f5f21c686aa8b463a2fb6edd39260cf2a7da7043/instrumentation/resque#usage) to the instrumentation's latest version at rubydoc.info (for example, [this here resque](https://rubydoc.info/gems/opentelemetry-instrumentation-resque/OpenTelemetry/Instrumentation/Resque)) to avoid repeating the details of config options in the README but still making the options discoverable from there.

Placing all this on the Instrumentation class is in contrast to the approach used in #824 where each option has a distinct comment.

### Advantages to class-level doc comment:

1. The option names do not [appear to be class or instance methods](https://rubydoc.info/gems/opentelemetry-instrumentation-resque/OpenTelemetry/Instrumentation/Resque/Instrumentation) on `Instrumentation` within the documentation.
2. The documentation can be included and rendered higher up the module namespace (on `OTel::Inst::Resque`) with [a single line](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/834/files#diff-6400ed026f380d2c28fbe78a9acd4a8de98145857314a47c768e2c7e48e2ca66R12) while the doc content still lives close(ish) to the option declarations.
3. Simpler than holding Yard macros the right way.

### Disadvantages to class-level doc comment:

1. The documentation is a little removed from the option declarations.

## Screenshots!

<img width="1415" alt="Screenshot 2024-01-24 at 3 02 07 PM" src="https://github.com/open-telemetry/opentelemetry-ruby-contrib/assets/517302/68f2c3ed-e4df-4941-90da-145239610e2a">


... and scroll down a bit ...

![Screenshot 2024-01-24 at 3 04 43 PM](https://github.com/open-telemetry/opentelemetry-ruby-contrib/assets/517302/bcdf0352-6398-4fe8-a502-bcfd46886f4e)
