### PR TITLE
chore: force initial release version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,6 @@
 {
+  "helpers/mysql": "0.0.0",
+  "helpers/sql_obfuscation": "0.0.0",
   "instrumentation/gruf": "0.1.1",
   "instrumentation/grape": "0.1.6",
   "instrumentation/racecar": "0.3.0",

--- a/helpers/mysql/lib/opentelemetry/helpers/mysql/version.rb
+++ b/helpers/mysql/lib/opentelemetry/helpers/mysql/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Helpers
     module MySQL
-      VERSION = '0.1.0'
+      VERSION = '0.0.0'
     end
   end
 end

--- a/helpers/sql-obfuscation/lib/opentelemetry/helpers/sql_obfuscation/version.rb
+++ b/helpers/sql-obfuscation/lib/opentelemetry/helpers/sql_obfuscation/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Helpers
     module SqlObfuscation
-      VERSION = '0.1.0'
+      VERSION = '0.0.0'
     end
   end
 end

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-helpers-mysql', '~> 0.1.0'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-helpers-mysql'
+  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.5'

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'activerecord'

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-helpers-mysql', '~> 0.1.0'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-helpers-mysql'
+  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
   spec.add_dependency 'opentelemetry-semantic_conventions', '>= 1.8.0'
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,14 @@
   "skip-github-release": false,
   "tag-separator": " ",
   "packages": {
+    "helpers/mysql": {
+      "package-name": "opentelemetry-helpers-mysql",
+      "version-file": "lib/opentelemetry/helpers/mysql/version.rb"
+    },
+    "helpers/sql_obfuscation": {
+      "package-name": "opentelemetry-helpers-sql-obfuscation",
+      "version-file": "lib/opentelemetry/helpers/sql_obfuscation/version.rb"
+    },
     "instrumentation/gruf": {
       "package-name": "opentelemetry-instrumentation-gruf",
       "version-file": "lib/opentelemetry/instrumentation/gruf/version.rb"


### PR DESCRIPTION
[The toys gem expects for initial releases to start with version `0.0.0`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/7817578724/job/21325809668#step:5:1116
):

```console
[2024-02-07 15:59:43  INFO]  exec: ["gh", "api", "repos/open-telemetry/opentelemetry-ruby-contrib/pulls?state=open&sort=created&direction=desc&per_page=20&head=open-telemetry:release/opentelemetry-helpers-mysql", "-H", "Accept: application/vnd.github.v3+json"]
[2024-02-07 15:59:43  INFO]  exec: ["git", "tag", "-l"]
[2024-02-07 15:59:43  INFO]  Could not find any previous releases for opentelemetry-helpers-mysql

NoMethodError: undefined method `<<' for nil:NilClass
     25: /opt/hostedtoolcache/Ruby/3.0.6/x64/bin/toys:25:in `<main>'
     24: /opt/hostedtoolcache/Ruby/3.0.6/x64/bin/toys:25:in `load'
     23: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-0.15.3/bin/toys:11:in `<top (required)>'
     22: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:454:in `run'
     21: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/errors.rb:132:in `capture_path'
     20: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:462:in `block in run'
     19: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:620:in `execute_tool'
     18: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:620:in `catch'
     17: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:621:in `block in execute_tool'
     16: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:676:in `block in make_executor'
     15: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/standard_middleware/show_help.rb:240:in `run'
     14: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:676:in `block in make_executor'
     13: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/standard_middleware/show_root_version.rb:69:in `run'
     12: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:676:in `block in make_executor'
     11: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/standard_middleware/handle_usage_errors.rb:40:in `run'
     10: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:637:in `block in build_executor'
      9: /opt/hostedtoolcache/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/toys-core-0.15.3/lib/toys/cli.rb:601:in `block in make_run_handler'
      8: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/request.rb:84:in `run'
      7: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/request.rb:101:in `populate_requester'
      6: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/request.rb:101:in `each'
      5: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/request.rb:108:in `block in populate_requester'
      4: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/.lib/release_requester.rb:282:in `gem_info'
      3: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/.lib/release_requester.rb:282:in `new'
      2: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/.lib/release_requester.rb:18:in `initialize'
      1: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/.lib/release_requester.rb:98:in `analyze_messages'
Error during tool execution!
    NoMethodError: undefined method `<<' for nil:NilClass
    in config file: /home/runner/.cache/toys/git/6aae6748a2d9c5a8e22c933d80ef9e54/6e8c4a1d77866a2e50bab87cd85dc849badc669d/.toys/release/request.rb:108
    while executing tool: "release request"
    with arguments: ["--yes", "--verbose", "--gems=", "--release-ref=refs/heads/main"]
```


