### PR TITLE
fix: add missing requires for sql-helpers to mysql, pg, and trilogy instrumentation

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry-helpers-mysql'
+require 'opentelemetry-helpers-sql-obfuscation'
+
 module OpenTelemetry
   module Instrumentation
     module Mysql2

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry-helpers-sql-obfuscation'
 require_relative '../constants'
 require_relative '../lru_cache'
 

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry-helpers-mysql'
+require 'opentelemetry-helpers-sql-obfuscation'
+
 module OpenTelemetry
   module Instrumentation
     module Trilogy


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/529 a couple of `require`s were missing. This PR adds those.

Fixes: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/858