### PR TITLE
feat!: Cache GraphQL attributes

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -90,8 +90,8 @@ module OpenTelemetry
             when 'execute_field'
               field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_attrs] ||= attr_cache do |field|
                 {
-                  'graphql.field.parent' => field.owner.graphql_name,
-                  'graphql.field.name' => field.graphql_name,
+                  'graphql.field.parent' => field.owner.graphql_name || "", # nil values are not permitted
+                  'graphql.field.name' => (field.graphql_name if field.graphql_name),
                   'graphql.lazy' => false
                 }.freeze
               end
@@ -99,8 +99,8 @@ module OpenTelemetry
             when 'execute_field_lazy'
               lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_lazy_attrs] ||= attr_cache do |field|
                 {
-                  'graphql.field.parent' => field.owner.graphql_name,
-                  'graphql.field.name' => field.graphql_name,
+                  'graphql.field.parent' => (field.owner.graphql_name if field.owner.graphql_name),
+                  'graphql.field.name' => (field.graphql_name if field.graphql_name),
                   'graphql.lazy' => true
                 }.freeze
               end
@@ -108,7 +108,7 @@ module OpenTelemetry
             when 'authorized', 'resolve_type'
               type_attrs_cache = data[:context].namespace(:otel_attrs)[:type_attrs] ||= attr_cache do |type|
                 {
-                  'graphql.type.name' => type.graphql_name,
+                  'graphql.type.name' => (type.graphql_name if type.graphql_name),
                   'graphql.lazy' => false
                 }.freeze
               end
@@ -116,18 +116,17 @@ module OpenTelemetry
             when 'authorized_lazy', 'resolve_type_lazy'
               type_lazy_attrs_cache = data[:context].namespace(:otel_attrs)[:type_lazy_attrs] ||= attr_cache do |type|
                 {
-                  'graphql.type.name' => type.graphql_name,
+                  'graphql.type.name' => (type.graphql_name if type.graphql_name),
                   'graphql.lazy' => true
-                }
+                }.freeze
               end
               type_lazy_attrs_cache[data[:type]]
             when 'execute_query'
-              attributes = {
-                'graphql.document' => data[:query].query_string,
-                'graphql.operation.type' => data[:query].selected_operation.operation_type
-              }
-              attributes['graphql.operation.name'] = data[:query].selected_operation_name if data[:query].selected_operation_name
-              attributes
+              {
+                'graphql.document' => (data[:query].query_string if data[:query].query_string),
+                'graphql.operation.type' => (data[:query].selected_operation.operation_type if data[:query].selected_operation && data[:query].selected_operation.operation_type),
+                'graphql.operation.name' => data[:query].selected_operation_name || "", # nil values are not permitted
+              }.freeze
             else
               {}
             end

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -89,44 +89,44 @@ module OpenTelemetry
             case key
             when 'execute_field'
               field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_attrs] ||= attr_cache do |field|
-                {
-                  'graphql.field.parent' => field.owner.graphql_name || "", # nil values are not permitted
-                  'graphql.field.name' => (field.graphql_name if field.graphql_name),
-                  'graphql.lazy' => false
-                }.freeze
+                attrs = {}
+                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
+                attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
+                attrs['graphql.lazy'] = false
+                attrs.freeze
               end
               field_attr_cache[data[:field]]
             when 'execute_field_lazy'
               lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_lazy_attrs] ||= attr_cache do |field|
-                {
-                  'graphql.field.parent' => (field.owner.graphql_name if field.owner.graphql_name),
-                  'graphql.field.name' => (field.graphql_name if field.graphql_name),
-                  'graphql.lazy' => true
-                }.freeze
+                attrs = {}
+                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
+                attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
+                attrs['graphql.lazy'] = true
+                attrs.freeze
               end
               lazy_field_attr_cache[data[:field]]
             when 'authorized', 'resolve_type'
               type_attrs_cache = data[:context].namespace(:otel_attrs)[:type_attrs] ||= attr_cache do |type|
-                {
-                  'graphql.type.name' => (type.graphql_name if type.graphql_name),
-                  'graphql.lazy' => false
-                }.freeze
+                attrs = {}
+                attrs['graphql.type.name'] = type.graphql_name if type.graphql_name
+                attrs['graphql.lazy'] = false
+                attrs.freeze
               end
               type_attrs_cache[data[:type]]
             when 'authorized_lazy', 'resolve_type_lazy'
               type_lazy_attrs_cache = data[:context].namespace(:otel_attrs)[:type_lazy_attrs] ||= attr_cache do |type|
-                {
-                  'graphql.type.name' => (type.graphql_name if type.graphql_name),
-                  'graphql.lazy' => true
-                }.freeze
+                attrs = {}
+                attrs['graphql.type.name'] = type.graphql_name if type.graphql_name
+                attrs['graphql.lazy'] = true
+                attrs.freeze
               end
               type_lazy_attrs_cache[data[:type]]
             when 'execute_query'
-              {
-                'graphql.document' => (data[:query].query_string if data[:query].query_string),
-                'graphql.operation.type' => (data[:query].selected_operation.operation_type if data[:query].selected_operation && data[:query].selected_operation.operation_type),
-                'graphql.operation.name' => data[:query].selected_operation_name || "", # nil values are not permitted
-              }.freeze
+              attrs = {}
+              attrs['graphql.document'] = data[:query].query_string if data[:query].query_string
+              attrs['graphql.operation.type'] = data[:query].selected_operation.operation_type if data[:query].selected_operation && data[:query].selected_operation.operation_type
+              attrs['graphql.operation.name'] = data[:query].selected_operation_name || "anonymous"
+              attrs.freeze
             else
               {}
             end

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -101,7 +101,7 @@ module OpenTelemetry
               field_unique_key = "execute_field.#{data[:owner]&.graphql_name}.#{data[:field].graphql_name}"
               lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[field_unique_key] ||= attr_cache do |field|
                 attrs = {}
-                attrs['graphql.field.parent'] = data[:owner].graphql_name if field.owner.graphql_name
+                attrs['graphql.field.parent'] = data[:owner].graphql_name if data[:owner].graphql_name
                 attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
                 attrs['graphql.lazy'] = true
                 attrs.freeze

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -88,18 +88,20 @@ module OpenTelemetry
           def attributes_for(key, data)
             case key
             when 'execute_field'
-              field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_attrs] ||= attr_cache do |field|
+              field_unique_key = "execute_field.#{data[:owner]&.graphql_name}.#{data[:field].graphql_name}"
+              field_attr_cache = data[:query].context.namespace(:otel_attrs)[field_unique_key] ||= attr_cache do |field|
                 attrs = {}
-                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
+                attrs['graphql.field.parent'] = data[:owner].graphql_name if data[:owner].graphql_name
                 attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
                 attrs['graphql.lazy'] = false
                 attrs.freeze
               end
               field_attr_cache[data[:field]]
             when 'execute_field_lazy'
-              lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_lazy_attrs] ||= attr_cache do |field|
+              field_unique_key = "execute_field.#{data[:owner]&.graphql_name}.#{data[:field].graphql_name}"
+              lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[field_unique_key] ||= attr_cache do |field|
                 attrs = {}
-                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
+                attrs['graphql.field.parent'] = data[:owner].graphql_name if field.owner.graphql_name
                 attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
                 attrs['graphql.lazy'] = true
                 attrs.freeze

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -124,8 +124,10 @@ module OpenTelemetry
             when 'execute_query'
               attrs = {}
               attrs['graphql.document'] = data[:query].query_string if data[:query].query_string
+              # rubocop:disable Style/SafeNavigation - using safe navigation creates more objects, we want to avoid this
               attrs['graphql.operation.type'] = data[:query].selected_operation.operation_type if data[:query].selected_operation && data[:query].selected_operation.operation_type
-              attrs['graphql.operation.name'] = data[:query].selected_operation_name || "anonymous"
+              # rubocop:enable Style/SafeNavigation
+              attrs['graphql.operation.name'] = data[:query].selected_operation_name || 'anonymous'
               attrs.freeze
             else
               {}

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -13,6 +13,8 @@ module OpenTelemetry
         # GraphQLTracer contains the OpenTelemetry tracer implementation compatible with
         # the GraphQL tracer API
         class GraphQLTracer < ::GraphQL::Tracing::PlatformTracing
+          DEFAULT_HASH = {}.freeze
+
           self.platform_keys = {
             'lex' => 'graphql.lex',
             'parse' => 'graphql.parse',
@@ -130,7 +132,7 @@ module OpenTelemetry
               attrs['graphql.operation.name'] = data[:query].selected_operation_name || 'anonymous'
               attrs.freeze
             else
-              {}
+              DEFAULT_HASH
             end
           end
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -88,20 +88,18 @@ module OpenTelemetry
           def attributes_for(key, data)
             case key
             when 'execute_field'
-              field_unique_key = "execute_field.#{data[:owner]&.graphql_name}.#{data[:field].graphql_name}"
-              field_attr_cache = data[:query].context.namespace(:otel_attrs)[field_unique_key] ||= attr_cache do |field|
+              field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_attrs] ||= attr_cache do |field|
                 attrs = {}
-                attrs['graphql.field.parent'] = data[:owner].graphql_name if data[:owner].graphql_name
+                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
                 attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
                 attrs['graphql.lazy'] = false
                 attrs.freeze
               end
               field_attr_cache[data[:field]]
             when 'execute_field_lazy'
-              field_unique_key = "execute_field.#{data[:owner]&.graphql_name}.#{data[:field].graphql_name}"
-              lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[field_unique_key] ||= attr_cache do |field|
+              lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_lazy_attrs] ||= attr_cache do |field|
                 attrs = {}
-                attrs['graphql.field.parent'] = data[:owner].graphql_name if data[:owner].graphql_name
+                attrs['graphql.field.parent'] = field.owner.graphql_name if field.owner.graphql_name
                 attrs['graphql.field.name'] = field.graphql_name if field.graphql_name
                 attrs['graphql.lazy'] = true
                 attrs.freeze

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -86,24 +86,59 @@ module OpenTelemetry
           end
 
           def attributes_for(key, data)
-            attributes = {}
             case key
-            when 'execute_field', 'execute_field_lazy'
-              attributes['graphql.field.parent'] = data[:owner]&.graphql_name # owner is the concrete type, not interface
-              attributes['graphql.field.name'] = data[:field]&.graphql_name
-              attributes['graphql.lazy'] = key == 'execute_field_lazy'
-            when 'authorized', 'authorized_lazy'
-              attributes['graphql.type.name'] = data[:type]&.graphql_name
-              attributes['graphql.lazy'] = key == 'authorized_lazy'
-            when 'resolve_type', 'resolve_type_lazy'
-              attributes['graphql.type.name'] = data[:type]&.graphql_name
-              attributes['graphql.lazy'] = key == 'resolve_type_lazy'
+            when 'execute_field'
+              field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_attrs] ||= attr_cache do |field|
+                {
+                  'graphql.field.parent' => field.owner.graphql_name,
+                  'graphql.field.name' => field.graphql_name,
+                  'graphql.lazy' => false
+                }.freeze
+              end
+              field_attr_cache[data[:field]]
+            when 'execute_field_lazy'
+              lazy_field_attr_cache = data[:query].context.namespace(:otel_attrs)[:execute_field_lazy_attrs] ||= attr_cache do |field|
+                {
+                  'graphql.field.parent' => field.owner.graphql_name,
+                  'graphql.field.name' => field.graphql_name,
+                  'graphql.lazy' => true
+                }.freeze
+              end
+              lazy_field_attr_cache[data[:field]]
+            when 'authorized', 'resolve_type'
+              type_attrs_cache = data[:context].namespace(:otel_attrs)[:type_attrs] ||= attr_cache do |type|
+                {
+                  'graphql.type.name' => type.graphql_name,
+                  'graphql.lazy' => false
+                }.freeze
+              end
+              type_attrs_cache[data[:type]]
+            when 'authorized_lazy', 'resolve_type_lazy'
+              type_lazy_attrs_cache = data[:context].namespace(:otel_attrs)[:type_lazy_attrs] ||= attr_cache do |type|
+                {
+                  'graphql.type.name' => type.graphql_name,
+                  'graphql.lazy' => true
+                }
+              end
+              type_lazy_attrs_cache[data[:type]]
             when 'execute_query'
+              attributes = {
+                'graphql.document' => data[:query].query_string,
+                'graphql.operation.type' => data[:query].selected_operation.operation_type
+              }
               attributes['graphql.operation.name'] = data[:query].selected_operation_name if data[:query].selected_operation_name
-              attributes['graphql.operation.type'] = data[:query].selected_operation.operation_type
-              attributes['graphql.document'] = data[:query].query_string
+              attributes
+            else
+              {}
             end
-            attributes
+          end
+
+          def attr_cache
+            cache_h = Hash.new do |h, k|
+              h[k] = yield(k)
+            end
+            cache_h.compare_by_identity
+            cache_h
           end
         end
       end

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -83,7 +83,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
       it 'omits nil attributes for execute_query' do
         expected_attributes = {
           'graphql.operation.type' => 'query',
-          'graphql.document' => '{ simpleField }'
+          'graphql.document' => '{ simpleField }',
+          'graphql.operation.name' => 'anonymous'
         }
 
         SomeGraphQLAppSchema.execute('{ simpleField }')

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -142,7 +142,7 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
         it 'includes attributes using platform types' do
           skip if uses_platform_interfaces?
           expected_attributes = {
-            'graphql.field.parent' => 'Car', # type name, not interface
+            'graphql.field.parent' => 'Vehicle', # interface name, not type
             'graphql.field.name' => 'model',
             'graphql.lazy' => false
           }


### PR DESCRIPTION
# What

Backporting [this](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/723) to `graphql-1.12.24`. 

Closes: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/865 
  - `graphql.field.parent` is now reporting the interface instead of the concrete class for `execute_field`. We've made this 
choice consciously in order to benefit from the very serious performance gains vs 100% accuracy. For v2, this goes back to reporting the concrete class so we always have the choice of upgrading. 
  - If the `graphql.operation.name` is `nil`, we are now setting the value to `anonymous`. This allows us to detect unowned queries. 

# Why

This will result in:
- a 97% reduction in total allocated memory for this gem (130896 -> 3616) 
- a 96% reduction in total objects allocated for this gem (786 -> 32)
- a 6% reduction overall in bytes used

```diff
- Total allocated: 2084536 bytes (18106 objects)
+ Total allocated: 1957424 bytes (17353 objects)
  Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
   1033984  opentelemetry-sdk-1.4.0
-   684008  graphql-1.12.24
+   684176  graphql-1.12.24
    194472  opentelemetry-api-1.2.4
-   130896  graphql/lib
     41176  other
+     3616  graphql/lib  ❗️

allocated objects by gem
-----------------------------------
      8624  opentelemetry-sdk-1.4.0
      5820  graphql-1.12.24
      2353  opentelemetry-api-1.2.4
-      786  graphql/lib
       523  other
+       32  graphql/lib ❗️


allocated objects by class
-----------------------------------
-      7465  Hash
+      6704  Hash
      2348  Array
      1594  String
-      1177  Proc
+      1185  Proc
```

<details><summary>otel_bench.rb</summary>

```ruby
require "bundler/inline"

gemfile(false) do
  source "https://rubygems.org"
  gem "graphql", "1.12.24"
  gem "opentelemetry-sdk"
  gem "opentelemetry-api"
  gem "opentelemetry-instrumentation-graphql", path: "~/projects/opentelemetry-ruby-contrib/instrumentation/graphql"
  gem "benchmark-ips"
  gem "memory_profiler"
  gem "stackprof"
end

class MySchema < GraphQL::Schema
  DATA = {
    "5" => {
      name: "Beatrix Potter",
    },
    "6" => {
      name: "J.R.R. Tolkien"
    },
    "10" => {
      title: "The Tale of Squirrel Nutkin",
      author_id: "5",
      recommended_book_ids: ["11", "12"],
    },
    "11" => {
      title: "The Tale of Ginger and Pickles",
      author_id: "5",
      recommended_book_ids: ["10", "12"],
    },
    "12" => {
      title: "The Tale of Mr. Tod",
      author_id: "5",
      recommended_book_ids: ["11", "10"],
    },
    "21" => {
      title: "The Hobbit",
      author_id: "6",
      recommended_book_ids: ["22", "23", "24", "25", "26", "27"],
    },
    "22" => {
      title: "The Fellowship of the Ring",
      author_id: "6",
      recommended_book_ids: ["21", "23", "24", "25", "26", "27"],
    },
    "23" => {
      title: "The Two Towers",
      author_id: "6",
      recommended_book_ids: ["22", "21", "24", "25", "26", "27"],
    },
    "24" => {
      title: "The Return of the King",
      author_id: "6",
      recommended_book_ids: ["22", "23", "21", "25", "26", "27"],
    },
    "25" => {
      title: "The Silmarillion",
      author_id: "6",
      recommended_book_ids: ["22", "23", "24", "21", "26", "27"],
    },
    "26" => {
      title: "The Adventures of Tom Bombadil",
      author_id: "6",
      recommended_book_ids: ["21", "22", "23", "24", "25", "27"]
    },
    "27" => {
      title: "Leaf by Niggle",
      author_id: "6",
      recommended_book_ids: ["21", "22", "23", "24", "25", "26"]
    }
  }

  module Node
    include GraphQL::Schema::Interface
    field :id, ID, null: true, description: "The id."
  end

  class Author < GraphQL::Schema::Object
    def self.authorized?(obj, ctx)
      -> { true }
    end
    implements Node
    field :name, String, null: true
    field :books, ["MySchema::Book"], null: true

    def books
      author_id = DATA.find { |(id, auth)| auth == object }.first
      DATA.each_value.select { |d| d[:author_id] == author_id }
    end
  end

  class Book < GraphQL::Schema::Object
    implements Node
    field :title, String, null: true
    field :author, Author, null: true
    field :recommended_books, [Book], null: true

    def author
      DATA[object[:author_id]]
    end

    def recommended_books
      object[:recommended_book_ids].map { |id| -> { DATA[id] } }
    end
  end

  class Query < GraphQL::Schema::Object
    field :node, Node, null: true do
      argument :id, ID, required: false
    end

    def node(id:)
      DATA[id]
    end
  end

  query(Query)

  orphan_types(Book, Author)

  def self.resolve_type(type, obj, ctx)
    if obj.key?(:name)
      Author
    elsif obj.key?(:title)
      Book
    else
      raise "Unknown object: #{obj.inspect}"
    end
  end

  lazy_resolve(Proc, :call)
end

OpenTelemetry::SDK.configure do |c|
  c.use 'OpenTelemetry::Instrumentation::GraphQL', {
    schemas: [MySchema],
    # enable_platform_field maps to the execute_field and execute_field_lazy keys
    enable_platform_field: true,
    # enable_platform_authorized maps to the authorized and authorized_lazy keys
    enable_platform_authorized: true,
    # enable_platform_resolve_type maps to the resolve_type and resolve_type_lazy keys
    enable_platform_resolve_type: true,
    legacy_tracing:true,
  }
end


# puts MySchema.to_definition

small_query_str = <<-GRAPHQL
query {
  node(id: "10") {
    __typename
    ... on Book {
      title
      author {
        __typename
        name
      }
      recommendedBooks {
        __typename
        title
      }
    }
  }
}
GRAPHQL

large_query_str = <<-GRAPHQL
{
  node(id: "6") {
    ... on Author {
      name
      books {
        title
        recommendedBooks {
          title
          author { name }
          recommendedBooks { title }
        }
      }
    }
  }
}
GRAPHQL

# pp MySchema.execute(small_query_str).to_h
# pp MySchema.execute(large_query_str).to_h

Benchmark.ips do |x|
  x.report("small query") { MySchema.execute(small_query_str) }
  x.report("large query") { MySchema.execute(large_query_str) }
end

query_str = large_query_str

puts "\n\n\n"

result = StackProf.run(mode: :wall, interval: 1) do
  MySchema.execute(query_str)
end
report = StackProf::Report.new(result)
File.open("tmp/otel_query2.dump", "wb+") { |f| report.print_dump(f) }
report.print_text

report = MemoryProfiler.report do
  MySchema.execute(query_str)
end
puts "\n\n\n"
report.pretty_print

```

</details>

I've had to add `legacy_tracing:true` before comparing the two benchmarks. 

I ran this on the main branch and then on my branch. 

For the main branch, I got a lot of lines of error related to [this issue](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/865) I filed earlier in the week: 

```
invalid span attribute value type NilClass for key 'graphql.field.parent' on span 'graphql.execute_field'
invalid span attribute value type NilClass for key 'graphql.field.parent' on span 'graphql.execute_field'
invalid span attribute value type NilClass for key 'graphql.field.parent' on span 'graphql.execute_field'
invalid span attribute value type NilClass for key 'graphql.field.parent' on span 'graphql.execute_field'
....
```

The fix was actually fairly straightforward: 

```ruby
attributes['graphql.field.parent'] = data[:owner]&.graphql_name # owner is the concrete type, not interface
```

becomes 

```ruby
attributes['graphql.field.parent'] = data[:owner]&.graphql_name || "" # owner is the concrete type, not interface
```