### PR TITLE
chore: drop dependency on ruby2_keywords

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -51,9 +51,6 @@ module OpenTelemetry
         end
 
         def require_dependencies
-          # Our patches depend on Ruby 2 Keyword Syntax compatability since it is decorating the existing AR API
-          # Once we migrate to ActiveSupport Notifications based instrumentation we can remove this require statement.
-          require 'ruby2_keywords' # rubocop:disable Lint/RedundantRequireStatement
           require_relative 'patches/querying'
           require_relative 'patches/persistence'
           require_relative 'patches/persistence_class_methods'

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
-  spec.add_dependency 'ruby2_keywords'
 
   spec.add_development_dependency 'activerecord', '>= 6.1'
   spec.add_development_dependency 'appraisal', '~> 2.5'


### PR DESCRIPTION
Now that Ruby below 2.7 is not supported (#389, https://github.com/open-telemetry/opentelemetry-ruby-contrib/commit/38b083aa41b93bcc8f900cd65bc922c97fe26e5d) this is not needed anymore