### PR TITLE
fix: instrumentation/active_record: add `:allow_retry` option to `find_by_sql` patch

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
           # Contains ActiveRecord::Querying to be patched
           module ClassMethods
-            def find_by_sql(sql, binds = [], preparable: nil, &block)
+            def find_by_sql(...)
               tracer.in_span("#{self}.find_by_sql") do
                 super
               end


### PR DESCRIPTION
Rails 7.2 (rails/rails@eabcff2) introduces the `:allow_retry` option for the `find_by_sql` method, so we need to add it to this patch to maintain compatibility. The patch doesn't use the method's args, so we can just use `(...)` to avoid this problem.

~To check the Rails version, I had to add rails as a development dependency. I added it in the gemspec and set the minimum version to 6.1 following the pattern I saw in the other libraries in this repo ([for example](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec#L37)).~