### PR TITLE
chore: Run release-please only on open-telemetry

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   prepare:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Process Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently, `release-please` attempts to run on forks of opentelemetry-ruby-contrib. The workflow fails with the message "GitHub Actions is not permitted to create or approve pull requests." `release-please` is not needed on forks.

This is also the policy for the toys-based `release-hook-on-push` workflow.

I took a quick look at the other workflows and think this is the only one that needs to be ignored on forks. However, the `conventional-commits` workflow might be another good candidate.