### PR TITLE
fix: allow ActiveRecord::Querying find_by_sql to accept any arguments

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
           # Contains ActiveRecord::Querying to be patched
           module ClassMethods
-            def find_by_sql(sql, binds = [], preparable: nil, &block)
+            def find_by_sql(...)
               tracer.in_span("#{self}.find_by_sql") do
                 super
               end


### PR DESCRIPTION
This PR updates the `find_by_sql` method to allow to receive any arguments. We started to notice the following error when upgrading our Rails version that had the following change: https://github.com/rails/rails/pull/51336
```
ArgumentError: unknown keyword: :allow_retry
    vendor/gems/3.3.0/ruby/3.3.0/gems/opentelemetry-instrumentation-active_record-0.7.0/lib/opentelemetry/instrumentation/active_record/patches/querying.rb:21:in `find_by_sql'
```