### PR TITLE
chore(deps-ci): upgrade conventional commit check

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Conventional Commits Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: dev-build-deploy/commit-me@v1.3.1
+      - uses: dev-build-deploy/commit-me@v1.4.0
         env:
           FORCE_COLOR: 3
         with:


### PR DESCRIPTION
### Fixes Conventional Commit checking in CI.

Dependabot creates PRs with a `chore(deps-dev):` prefix when it is updating development-only dependencies. The version of the GitHub Action we're using—`dev-build-deploy/commit-me@v1.3.1`[1]—to validate commit prefixes balks at the hyphen. `v1.4.0` includes an update[2] that recognizes scopes that contain hyphens.

[1] https://github.com/dev-build-deploy/commit-me/tree/v1.3.1
[2] https://github.com/dev-build-deploy/commit-me/commit/38d4cb09a1bf468012516a3bfbfad325f3435915