### PR TITLE
chore: Move @kaylareopelle to maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 Approvers ([@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-approvers)):
 
 - [Josef Šimánek](https://github.com/simi)
-- [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 - [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
@@ -39,6 +38,7 @@ Maintainers ([@open-telemetry/ruby-contrib-maintainers](https://github.com/orgs/
 - [Daniel Azuma](https://github.com/dazuma), Google
 - [Eric Mustin](https://github.com/ericmustin)
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify
+- [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 - [Matthew Wear](https://github.com/mwear), Lightstep
 - [Robb Kidd](https://github.com/robbkidd), Honeycomb
 - [Robert Laurin](https://github.com/robertlaurin), Shopify


### PR DESCRIPTION
I'm thrilled to be [joining the opentelemetry-ruby-contrib maintainer's team!](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1712247069428889) 🎉 

Here are links to some of my work:
* [Reviews](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pulls?q=is%3Apr+commenter%3Akaylareopelle+-author%3Akaylareopelle) 
* [Authored PRs](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pulls?q=is%3Apr+author%3Akaylareopelle+)