### PR TITLE
test: Temporary fix for missing OpenStruct

### DIFF
--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -9,6 +9,8 @@ Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
+# Mitigates https://github.com/rmosolgo/graphql-ruby/issues/4900
+require 'ostruct' if Gem::Requirement.new('< 2.0.0').satisfied_by?(Gem::Version.new(GraphQL::VERSION))
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new


### PR DESCRIPTION
It looks like a transitive dependency removed `require 'ostruct'`, which results in an `uninitialized Constant` error. 

It may be this change to `rake` that the GraphQL gem was dependent on: https://github.com/ruby/rake/commit/a27bb8e10786efa4776cc3ecfe12490e1ea106a7

This PR temporarily requires `OpenStruct` until the issue is fixed in the Gem: https://github.com/rmosolgo/graphql-ruby/issues/4900