### PR TITLE
fix: analyze span names in GraphQL instrumentation

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -89,11 +89,11 @@ module OpenTelemetry
           end
 
           def analyze_multiplex(multiplex:, &block)
-            tracer.in_span('graphql.analyze_query', &block)
+            tracer.in_span('graphql.analyze_multiplex', &block)
           end
 
           def analyze_query(query:, &block)
-            tracer.in_span('graphql.analyze_multiplex', &block)
+            tracer.in_span('graphql.analyze_query', &block)
           end
 
           def execute_query(query:, &block)

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -47,8 +47,8 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
           'graphql.lex',
           'graphql.parse',
           'graphql.validate',
-          'graphql.analyze_multiplex',
           'graphql.analyze_query',
+          'graphql.analyze_multiplex',
           'graphql.execute_query',
           'graphql.execute_query_lazy',
           'graphql.execute_multiplex'


### PR DESCRIPTION
Span names for `analyze_query` and `analyze_multiplex` were reversed and incorrect. This fixes them to be consistent with the trace hook that produces them.