### PR TITLE
Support ignoring queries in the pg instrumentation

### DIFF
--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -27,6 +27,7 @@ module OpenTelemetry
         option :peer_service, default: nil, validate: :string
         option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
         option :obfuscation_limit, default: 2000, validate: :integer
+        option :untraced_queries, default: [], validate: :array
 
         private
 


### PR DESCRIPTION
This PR adds support for ignoring queries sent to the `pg` instrumentation, similar to `untraced_hosts` for the `net_http`  instrumentation.

The motivation for the feature is to ignore some frequent but low-value queries, in our case, the `;` query which is used by ActiveRecord to check if a [connection is active](https://github.com/rails/rails/blob/a94938f10ce0f34c765028e518caed6527a31d11/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L338).