### PR TITLE
chore: include new baggage span processor in release automation

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -209,6 +209,10 @@ gems:
     directory: instrumentation/all
     version_constant: [OpenTelemetry, Instrumentation, All, VERSION]
 
+  - name: opentelemetry-processor-baggage
+    directory: processor/baggage
+    version_constant: [OpenTelemetry, Processor, Baggage, VERSION]
+
   - name: opentelemetry-propagator-ottrace
     directory: propagator/ottrace
     version_constant: [OpenTelemetry, Propagator, OTTrace, VERSION]


### PR DESCRIPTION
Follow up to #937 to make the gem releasable with our automation.