### PR TITLE
feat: add option for untraced commands

### DIFF
--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -52,8 +52,13 @@ OpenTelemetry::SDK.configure do |c|
 
     # By default, this instrumentation obfuscate/sanitize the executed SQL as the `db.statement`
     # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
-    # setting this option to :omit or disbale sanitization the attribute by setting to :include
+    # setting this option to :omit or disable sanitization the attribute by setting to :include
     db_statement: :include,
+
+    # Add certain commands that you do not want to produce spans within traces. This can
+    # be useful if you find something like PREPARE statements too noisy in your trace data.
+    # note: these must be uppercase to match the command.
+    untraced_commands: %w[PREPARE DEALLOCATE],
   }
 end
 ```

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -27,6 +27,7 @@ module OpenTelemetry
         option :peer_service, default: nil, validate: :string
         option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
         option :obfuscation_limit, default: 2000, validate: :integer
+        option :untraced_commands, default: [], validate: :array
 
         private
 

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -116,6 +116,14 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_i
       end
+
+      describe 'untraced commands' do
+        let(:config) { { untraced_commands: ['SELECT'] } }
+
+        it 'does not produce a span' do
+          _(span).must_be_nil
+        end
+      end
     end
 
     %i[exec_params async_exec_params sync_exec_params].each do |method|
@@ -129,6 +137,14 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_i
+      end
+
+      describe 'untraced commands' do
+        let(:config) { { untraced_commands: ['SELECT'] } }
+
+        it 'does not produce a span' do
+          _(span).must_be_nil
+        end
       end
     end
 
@@ -144,6 +160,14 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.postgresql.prepared_statement_name']).must_equal 'foo'
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_i
+      end
+
+      describe 'untraced commands' do
+        let(:config) { { untraced_commands: ['PREPARE'] } }
+
+        it 'does not produce a span' do
+          _(span).must_be_nil
+        end
       end
     end
 
@@ -161,6 +185,14 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(last_span.attributes['net.peer.name']).must_equal host.to_s
         _(last_span.attributes['net.peer.port']).must_equal port.to_i
       end
+
+      describe 'untraced commands' do
+        let(:config) { { untraced_commands: ['EXECUTE'] } }
+
+        it 'does not produce a span' do
+          _(span).must_be_nil
+        end
+      end
     end
 
     %i[exec query sync_exec async_exec].each do |method|
@@ -174,6 +206,14 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.operation']).must_equal 'SELECT'
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_i
+      end
+
+      describe 'untraced commands' do
+        let(:config) { { untraced_commands: ['SELECT'] } }
+
+        it 'does not produce a span' do
+          _(span).must_be_nil
+        end
       end
     end
 


### PR DESCRIPTION
solution to https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions/264

Adds the ability to not trace specified commands. This is in the same fashion that Rack supports with `:untraced_endpoints`, and net_http with `:untraced_hosts`