### PR TITLE
feat!: Add baggage key predicate func to baggage span processor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,12 @@ services:
     command: ./start_server.sh
     working_dir: /app/instrumentation/sinatra/example
 
+  processor-baggage-test:
+    <<: *base
+    working_dir: /app/processor/baggage
+    command: |
+      bash -c "bundle install && rake"
+
   mongo:
     image: mongo:4.4
     expose:

--- a/processor/baggage/README.md
+++ b/processor/baggage/README.md
@@ -62,19 +62,22 @@ end
 
 Alternatively, you can provide a custom baggage key predicate to select which baggage keys you want to copy.
 
-For example, to only copy baggage entries that start with `my-key`:
+For example, to only copy baggage entries that start with `myapp.`:
 
 ```ruby
+OUR_BAGGAGE_KEY_PREFIX = 'myapp.'.freeze
 OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
-  ->(baggage_key) { baggage_key.start_with?('my-key') }
+  # a constant here improves performance
+  ->(baggage_key) { baggage_key.start_with?(OUR_BAGGAGE_KEY_PREFIX) }
 )
 ```
 
-For example, to only copy baggage entries that match the regex `^key.+`:
+For example, to only copy baggage entries that match `myapp.`, `myapp1.` and `myapp42.`:
 
 ```ruby
+OUR_BAGGAGE_KEY_MATCHER = /\Amyapp\d*\./
 OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
-  ->(baggage_key) { baggage_key.match?('^key.+') }
+  ->(baggage_key) { OUR_BAGGAGE_KEY_MATCHER.match?(baggage_key) }
 )
 ```
 

--- a/processor/baggage/README.md
+++ b/processor/baggage/README.md
@@ -2,7 +2,7 @@
 
 This is an OpenTelemetry [span processor](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor) that reads key/values stored in [Baggage](https://opentelemetry.io/docs/specs/otel/baggage/api/) in the starting span's parent context and adds them as attributes to the span.
 
-Keys and values added to Baggage will appear on all subsequent child spans for a trace within this service *and* will be propagated to external services via propagation headers.
+Keys and values added to Baggage will appear on all subsequent child spans, not the current active span, for a trace within this service *and* will be propagated to external services via propagation headers.
 If the external services also have a Baggage span processor, the keys and values will appear in those child spans as well.
 
 ⚠️ Waning ⚠️

--- a/processor/baggage/README.md
+++ b/processor/baggage/README.md
@@ -57,6 +57,16 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+A predicate proc that determines what baggage entries are copied can be provided as a constructor parameter.
+
+For example, to only copy baggage entries that start with `my-key`:
+
+```ruby
+OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
+  keyfilter: ->(key) { key.start_with?('my-key') }
+)
+```
+
 ## How can I get involved?
 
 The `opentelemetry-processor-baggage` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.

--- a/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
+++ b/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
@@ -14,12 +14,14 @@ module OpenTelemetry
       ALLOW_ALL_BAGGAGE_KEYS = ->(_) { true }
 
       # The BaggageSpanProcessor reads key/values stored in Baggage in the
-      # starting span's parent context and adds them as attributes to the span.
+      # starting span's parent context and adds them as attributes to the span,
+      # if a key matches a provided predicate lambda.
       #
       # Keys and values added to Baggage will appear on all subsequent child spans
       # for a trace within this service *and* will be propagated to external services
       # via propagation headers. If the external services also have a Baggage span
-      # processor, the keys and values will appear in those child spans as well.
+      # processor, the keys and values will appear in those child spans as well provided
+      # that the keys match any predicate method configured there.
       #
       # ⚠️
       # To repeat: a consequence of adding data to Baggage is that the keys and
@@ -27,11 +29,15 @@ module OpenTelemetry
       # Do not put sensitive information in Baggage.
       # ⚠️
       #
-      # @example
+      # @example Adding the BaggageSpanProcessor to the SDK, only add attributes for keys that start with 'myapp.'
+      #   OUR_BAGGAGE_KEY_PREFIX = 'myapp.'.freeze
+      #
       #   OpenTelemetry::SDK.configure do |c|
       #     # Add the BaggageSpanProcessor to the collection of span processors
-      #     c.add_span_processor(OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
-      #       OpenTelemetry::Processor::Baggage::ALLOW_ALL_BAGGAGE_KEYS)
+      #     c.add_span_processor(
+      #       OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
+      #         ->(key) { key.start_with?(OUR_BAGGAGE_KEY_PREFIX) } # a constant here improves performance
+      #       )
       #     )
       #
       #     # Because the span processor list is no longer empty, the SDK will not use the
@@ -46,12 +52,24 @@ module OpenTelemetry
       #       )
       #     )
       #   end
+      #
+      # @example Allow all Baggage keys to be added to the span as attributes
+      #   OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
+      #     # This processor provides a convenience predicate that allows all keys to be added as attributes.
+      #     OpenTelemetry::Processor::Baggage::ALLOW_ALL_BAGGAGE_KEYS
+      #   )
       class BaggageSpanProcessor < OpenTelemetry::SDK::Trace::SpanProcessor
         # Create a new BaggageSpanProcessor that reads Baggage keys and values from the parent context
         # and adds them as attributes to the span.
         #
-        # @param [lambda] baggage_key_predicate A lambda that takes a baggage key and returns true if
+        # @param [lambda] baggage_key_predicate A lambda that takes a baggage key [String] and returns true if
         #  the key should be added to the span as an attribute, false otherwise.
+        #
+        # @example Only add attributes for keys that start with a specific prefix
+        #   OUR_BAGGAGE_KEY_PREFIX = 'myapp.'.freeze
+        #   OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
+        #     ->(key) { key.start_with?(OUR_BAGGAGE_KEY_PREFIX) } # a constant here improves performance
+        #   )
         def initialize(baggage_key_predicate)
           raise ArgumentError, 'baggage_key_predicate must respond to :call (lambda/Proc)' unless baggage_key_predicate.respond_to?(:call)
 

--- a/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
+++ b/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
       # Keys and values added to Baggage will appear on all subsequent child spans,
       # not the current active span, for a trace within this service *and* will be
       # propagated to external services via propagation headers.
-      # 
+      #
       # If the external services also have a Baggage span processor, the keys and
       # values will appear in those child spans as well.
       #

--- a/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
+++ b/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
@@ -53,6 +53,8 @@ module OpenTelemetry
         # @param [lambda] baggage_key_predicate A lambda that takes a baggage key and returns true if
         #  the key should be added to the span as an attribute, false otherwise.
         def initialize(baggage_key_predicate)
+          raise ArgumentError, 'baggage_key_predicate must respond to :call (lambda/Proc)' unless baggage_key_predicate.respond_to?(:call)
+
           @baggage_key_predicate = baggage_key_predicate
           super()
         end

--- a/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
+++ b/processor/baggage/lib/opentelemetry/processor/baggage/baggage_span_processor.rb
@@ -17,11 +17,12 @@ module OpenTelemetry
       # starting span's parent context and adds them as attributes to the span,
       # if a key matches a provided predicate lambda.
       #
-      # Keys and values added to Baggage will appear on all subsequent child spans
-      # for a trace within this service *and* will be propagated to external services
-      # via propagation headers. If the external services also have a Baggage span
-      # processor, the keys and values will appear in those child spans as well provided
-      # that the keys match any predicate method configured there.
+      # Keys and values added to Baggage will appear on all subsequent child spans,
+      # not the current active span, for a trace within this service *and* will be
+      # propagated to external services via propagation headers.
+      # 
+      # If the external services also have a Baggage span processor, the keys and
+      # values will appear in those child spans as well.
       #
       # ⚠️
       # To repeat: a consequence of adding data to Baggage is that the keys and

--- a/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
+++ b/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
@@ -39,6 +39,14 @@ describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
     end
   end
 
+  describe '#new' do
+    it 'requires a callable baggage_key_predicate' do
+      _(-> { OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new }).must_raise(ArgumentError)
+      err = _(-> { OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(:not_a_callable) }).must_raise(ArgumentError)
+      _(err.message).must_match(/must respond to :call/)
+    end
+  end
+
   describe '#on_start' do
     describe 'with the ALLOW_ALL_BAGGAGE_KEYS predicate' do
       it 'adds current baggage keys/values as attributes when a span starts' do

--- a/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
+++ b/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
@@ -50,8 +50,8 @@ describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
       end
     end
 
-    describe 'with a starts_with key predicate' do
-      let(:starts_with_processor) do
+    describe 'with a start_with? key predicate' do
+      let(:start_with_processor) do
         OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new(
           ->(baggage_key) { baggage_key.start_with?('a') }
         )
@@ -60,7 +60,7 @@ describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
       it 'only adds attributes that pass the keyfilter' do
         span.expect(:add_attributes, span, [{ 'a_key' => 'a_value' }])
 
-        starts_with_processor.on_start(span, context_with_baggage)
+        start_with_processor.on_start(span, context_with_baggage)
 
         span.verify
       end

--- a/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
+++ b/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
@@ -26,11 +26,16 @@ end
 describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
   let(:processor) { OpenTelemetry::Processor::Baggage::BaggageSpanProcessor.new }
   let(:span) { Minitest::Mock.new }
-  let(:context_with_baggage) { OpenTelemetry::Baggage.set_value('a_key', 'a_value') }
+  let(:context_with_baggage) do
+    OpenTelemetry::Baggage.build(context: OpenTelemetry::Context.empty) do |baggage|
+      baggage.set_value('a_key', 'a_value')
+      baggage.set_value('b_key', 'b_value')
+    end
+  end
 
   describe '#on_start' do
     it 'adds current baggage keys/values as attributes when a span starts' do
-      span.expect(:add_attributes, span, [{ 'a_key' => 'a_value' }])
+      span.expect(:add_attributes, span, [{ 'a_key' => 'a_value', 'b_key' => 'b_value' }])
 
       processor.on_start(span, context_with_baggage)
 
@@ -89,7 +94,7 @@ describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
 
       _(exporter.finished_spans.size).must_equal(1)
       _(exporter.finished_spans.first.name).must_equal('integration test span')
-      _(exporter.finished_spans.first.attributes).must_equal('a_key' => 'a_value')
+      _(exporter.finished_spans.first.attributes).must_equal('a_key' => 'a_value', 'b_key' => 'b_value')
     end
   end
 end


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #956 

## Short description of the changes
- Add baggage key lambda as constructor parameter to baggage span processor
- Add `ALLOW_ALL_BAGGAGE_KEYS` lambda that allows all keys
- Add unit test to verify behaviour
- Update README with examples of setting a filter