### PR TITLE
test: Add vitess to the propagators matrix

### DIFF
--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -61,6 +61,7 @@ jobs:
       matrix:
         gem:
           - ottrace
+          - vitess
           - xray
         os:
           - ubuntu-latest


### PR DESCRIPTION
The opentelemetry-propagators-vitess gem was not included in the CI. Now it will be tested along with the other propagators.