### PR TITLE
fix: Add net.peer.name to ethon

### DIFF
--- a/instrumentation/ethon/Appraisals
+++ b/instrumentation/ethon/Appraisals
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-appraise 'ethon-0.12' do
-  gem 'ethon', '~> 0.12.0'
+appraise 'ethon-0.16' do
+  gem 'ethon', '~> 0.16.0'
 end
 
-appraise 'ethon-0.11' do
-  gem 'ethon', '~> 0.11.0'
+appraise 'ethon-latest' do
+  gem 'ethon'
 end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -71,6 +71,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
               _(span.attributes['http.method']).must_equal 'N/A'
               _(span.attributes['http.status_code']).must_be_nil
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['net.peer.name']).must_equal 'example.com'
             end
           end
         end
@@ -275,8 +276,10 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             multi.perform
 
             _(exporter.finished_spans.size).must_equal 2
-            _(exporter.finished_spans[0].attributes['http.url']).must_equal nil
+            _(exporter.finished_spans[0].attributes['http.url']).must_be_nil
+            _(exporter.finished_spans[0].attributes['net.peer.name']).must_be_nil
             _(exporter.finished_spans[1].attributes['http.url']).must_equal 'test'
+            _(exporter.finished_spans[1].attributes['net.peer.name']).must_be_nil
           end
         end
       end


### PR DESCRIPTION
The ethon instrumentation did not include the `net.peer.name` attribute like other HTTP instrumentations and was not ported from ddtrace-rb: <https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/ethon/easy_patch.rb#L159>

This attribute is important to GitHub because we base the `peer.service` extracting the subdomain and host information from `net.peer.name`.

In order to avoid parsing the URL multiple times, I inlined the common gem `cleanse_url` function and plan to open a separate PR adding a feature to support returing URI objects instead of Strings.