### PR TITLE
feat: Add after_request hook to Rack tracer middleware

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -29,7 +29,8 @@ module OpenTelemetry
         option :untraced_requests,        default: nil,   validate: :callable
         option :response_propagators,     default: [],    validate: :array
         # This option is only valid for applications using Rack 2.0 or greater
-        option :use_rack_events,          default: true, validate: :boolean
+        option :use_rack_events,          default: true,  validate: :boolean
+        option :after_request,            default: nil,   validate: :callable
 
         # Temporary Helper for Sinatra and ActionPack middleware to use during installation
         #

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -151,7 +151,7 @@ module OpenTelemetry
             end
           end
 
-          def set_attributes_after_request(span, status, headers, _response)
+          def set_attributes_after_request(span, status, headers, response)
             span.status = OpenTelemetry::Trace::Status.error unless (100..499).cover?(status.to_i)
             span.set_attribute('http.status_code', status)
 
@@ -160,6 +160,10 @@ module OpenTelemetry
             # e.g., "/users/:userID?
 
             allowed_response_headers(headers).each { |k, v| span.set_attribute(k, v) }
+
+            return unless (implementation = config[:after_request])
+
+            implementation.call(span, status, headers, response)
           end
 
           def allowed_request_headers(env)

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_test.rb
@@ -33,6 +33,7 @@ describe OpenTelemetry::Instrumentation::Rack::Instrumentation do
       _(instrumentation.config[:untraced_requests]).must_be_nil
       _(instrumentation.config[:response_propagators]).must_be_empty
       _(instrumentation.config[:use_rack_events]).must_equal true
+      _(instrumentation.config[:after_request]).must_be_nil
     end
   end
 

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -281,6 +281,20 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
         _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
     end
+
+    describe 'config[:after_request]' do
+      describe 'when a callable is passed in' do
+        let(:after_request_callable) do
+          ->(span, _status, _headers, _response) { span.set_attribute('after_request.called', true) }
+        end
+
+        let(:config) { default_config.merge(after_request: after_request_callable) }
+
+        it 'ran the callable' do
+          _(first_span.attributes['after_request.called']).must_equal true
+        end
+      end
+    end
   end
 
   describe 'config[:quantization]' do


### PR DESCRIPTION
The intention here is to allow the user to be able to modify the span attributes using details about the response. This PR adds an `after_request` hook to the configuration options for the tracer middleware so that the user may supply a method which can interact with the span attributes.