### PR TITLE
feat: Harmonize HTTP client instrumentation

### DIFF
--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -41,7 +41,7 @@ module OpenTelemetry
                 message = return_code ? ::Ethon::Curl.easy_strerror(return_code) : 'unknown reason'
                 @otel_span.status = OpenTelemetry::Trace::Status.error("Request has failed: #{message}")
               else
-                @otel_span.set_attribute('http.status_code', response_code)
+                @otel_span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, response_code)
                 @otel_span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(response_code.to_i)
               end
             ensure
@@ -84,17 +84,17 @@ module OpenTelemetry
 
           def span_creation_attributes(method)
             instrumentation_attrs = {
-              'http.method' => method
+              OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => method
             }
 
             uri = _otel_cleanse_uri(url)
             if uri
-              instrumentation_attrs['http.url'] = uri.to_s
-              instrumentation_attrs['net.peer.name'] = uri.host if uri.host
+              instrumentation_attrs[OpenTelemetry::SemanticConventions::Trace::HTTP_URL] = uri.to_s
+              instrumentation_attrs[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME] = uri.host if uri.host
             end
 
             config = Ethon::Instrumentation.instance.config
-            instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
+            instrumentation_attrs[OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] if config[:peer_service]
             instrumentation_attrs.merge!(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
             )

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -69,9 +69,15 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
               _(span.name).must_equal 'HTTP N/A'
               _(span.attributes['http.method']).must_equal 'N/A'
+              _(span.attributes['http.request.method']).must_equal 'N/A'
+              _(span.attributes['http.response.status_code']).must_be_nil
               _(span.attributes['http.status_code']).must_be_nil
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
               _(span.attributes['net.peer.name']).must_equal 'example.com'
+              _(span.attributes['server.address']).must_equal 'example.com'
+              _(span.attributes['server.port']).must_equal 80
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.attributes['url.scheme']).must_equal 'http'
             end
           end
         end
@@ -92,8 +98,11 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           stub_response(response_code: 200) do
             _(span.name).must_equal 'HTTP N/A'
             _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.request.method']).must_equal 'N/A'
+            _(span.attributes['http.response.status_code']).must_equal 200
             _(span.attributes['http.status_code']).must_equal 200
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(span.attributes['url.full']).must_equal 'http://example.com/test'
             _(easy.instance_eval { @otel_span }).must_be_nil
             _(
               easy.instance_eval { @otel_original_headers['traceparent'] }
@@ -105,8 +114,11 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           stub_response(response_code: 500) do
             _(span.name).must_equal 'HTTP N/A'
             _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.request.method']).must_equal 'N/A'
+            _(span.attributes['http.response.status_code']).must_equal 500
             _(span.attributes['http.status_code']).must_equal 500
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(span.attributes['url.full']).must_equal 'http://example.com/test'
             _(easy.instance_eval { @otel_span }).must_be_nil
             _(
               easy.instance_eval { @otel_original_headers['traceparent'] }
@@ -118,8 +130,11 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           stub_response(response_code: 0, return_code: :operation_timedout) do
             _(span.name).must_equal 'HTTP N/A'
             _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.request.method']).must_equal 'N/A'
+            _(span.attributes['http.response.status_code']).must_be_nil
             _(span.attributes['http.status_code']).must_be_nil
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(span.attributes['url.full']).must_equal 'http://example.com/test'
             _(span.status.code).must_equal(
               OpenTelemetry::Trace::Status::ERROR
             )
@@ -140,8 +155,10 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
             stub_response(response_code: 200) do
               _(span.attributes['http.method']).must_equal 'OVERRIDE'
+              _(span.attributes['http.request.method']).must_equal 'N/A'
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
               _(span.attributes['test.attribute']).must_equal 'test.value'
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
             end
           end
         end
@@ -278,8 +295,12 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(exporter.finished_spans.size).must_equal 2
             _(exporter.finished_spans[0].attributes['http.url']).must_be_nil
             _(exporter.finished_spans[0].attributes['net.peer.name']).must_be_nil
+            _(exporter.finished_spans[0].attributes['server.address']).must_be_nil
+            _(exporter.finished_spans[0].attributes['url.full']).must_be_nil
             _(exporter.finished_spans[1].attributes['http.url']).must_equal 'test'
             _(exporter.finished_spans[1].attributes['net.peer.name']).must_be_nil
+            _(exporter.finished_spans[1].attributes['server.address']).must_be_nil
+            _(exporter.finished_spans[1].attributes['url.full']).must_equal 'test'
           end
         end
       end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -140,8 +140,8 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
             stub_response(response_code: 200) do
               _(span.attributes['http.method']).must_equal 'OVERRIDE'
-              _(span.attributes['test.attribute']).must_equal 'test.value'
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['test.attribute']).must_equal 'test.value'
             end
           end
         end

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -27,10 +27,10 @@ module OpenTelemetry
             http_method = HTTP_METHODS_TO_UPPERCASE[datum[:method]]
 
             attributes = {
+              OpenTelemetry::SemanticConventions::Trace::HTTP_HOST => datum[:host],
               OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => http_method,
               OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => datum[:scheme],
               OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => datum[:path],
-              OpenTelemetry::SemanticConventions::Trace::HTTP_HOST => datum[:host],
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => datum[:hostname],
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => datum[:port]
             }

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/patches/socket.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/patches/socket.rb
@@ -23,7 +23,10 @@ module OpenTelemetry
               conn_port = @port
             end
 
-            attributes = { OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => conn_address, OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+            attributes = {
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => conn_address,
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port
+            }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             if is_a?(::Excon::SSLSocket) && @data[:proxy]
               span_name = 'HTTP CONNECT'

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/patches/socket.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/patches/socket.rb
@@ -25,7 +25,9 @@ module OpenTelemetry
 
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => conn_address,
-              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port,
+              'server.address' => conn_address,
+              'server.port' => conn_port
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             if is_a?(::Excon::SSLSocket) && @data[:proxy]

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -48,10 +48,10 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       assert_requested(
         :get,
@@ -71,10 +71,10 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 500
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.target']).must_equal '/failure'
       assert_requested(
         :get,
@@ -90,9 +90,9 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
+      _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
-      _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
@@ -119,10 +119,10 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'OVERRIDE'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'OVERRIDE'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['test.attribute']).must_equal 'test.value'
       assert_requested(
@@ -186,8 +186,8 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'GET'
     end
 
     it 'creates a span on connect for a non-ignored request' do
@@ -299,9 +299,9 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
   def assert_http_spans(scheme: 'http', host: 'localhost', target: '/', exception: nil)
     exporter.finished_spans[1..].each do |http_span|
       _(http_span.name).must_equal 'HTTP GET'
+      _(http_span.attributes['http.host']).must_equal host
       _(http_span.attributes['http.method']).must_equal 'GET'
       _(http_span.attributes['http.scheme']).must_equal scheme
-      _(http_span.attributes['http.host']).must_equal host
       _(http_span.attributes['http.target']).must_equal target
       _(http_span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -215,6 +215,8 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
     end
 
     it 'emits span on connect' do
+      port = nil
+
       TCPServer.open('localhost', 0) do |server|
         Thread.start do
           server.accept
@@ -231,6 +233,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       _(span.name).must_equal 'connect'
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil
+      _(span.attributes['net.peer.port']).must_equal(port)
 
       assert_http_spans(target: '/example', exception: 'Excon::Error::Timeout')
     end

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -47,12 +47,12 @@ module OpenTelemetry
 
           def span_creation_attributes(http_method:, url:, config:)
             instrumentation_attrs = {
-              'http.method' => http_method,
-              'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url.to_s),
+              OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => http_method,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => OpenTelemetry::Common::Utilities.cleanse_url(url.to_s),
               'faraday.adapter.name' => app.class.name
             }
-            instrumentation_attrs['net.peer.name'] = url.host if url.host
-            instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
+            instrumentation_attrs[OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME] = url.host if url.host
+            instrumentation_attrs[OpenTelemetry::SemanticConventions::Trace::PEER_SERVICE] = config[:peer_service] if config[:peer_service]
 
             instrumentation_attrs.merge!(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
@@ -67,7 +67,7 @@ module OpenTelemetry
           end
 
           def trace_response(span, status)
-            span.set_attribute('http.status_code', status)
+            span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, status)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(status.to_i)
           end
         end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -48,9 +48,15 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 200
         _(span.attributes['http.status_code']).must_equal 200
         _(span.attributes['http.url']).must_equal 'http://example.com/success'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http://example.com/success'
+        _(span.attributes['url.scheme']).must_equal 'http'
         _(response.env.request_headers['Traceparent']).must_equal(
           "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
         )
@@ -61,9 +67,15 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 404
         _(span.attributes['http.status_code']).must_equal 404
         _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http://example.com/not_found'
+        _(span.attributes['url.scheme']).must_equal 'http'
         _(response.env.request_headers['Traceparent']).must_equal(
           "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
         )
@@ -74,9 +86,15 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 500
         _(span.attributes['http.status_code']).must_equal 500
         _(span.attributes['http.url']).must_equal 'http://example.com/failure'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http://example.com/failure'
+        _(span.attributes['url.scheme']).must_equal 'http'
         _(response.env.request_headers['Traceparent']).must_equal(
           "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
         )
@@ -92,10 +110,16 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'OVERRIDE'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 200
         _(span.attributes['http.status_code']).must_equal 200
         _(span.attributes['http.url']).must_equal 'http://example.com/success'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
         _(span.attributes['test.attribute']).must_equal 'test.value'
+        _(span.attributes['url.full']).must_equal 'http://example.com/success'
+        _(span.attributes['url.scheme']).must_equal 'http'
         _(response.env.request_headers['Traceparent']).must_equal(
           "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
         )
@@ -153,6 +177,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
         client.run_request(:get, 'http://username:password@example.com/success', nil, {})
 
         _(span.attributes['http.url']).must_equal 'http://example.com/success'
+        _(span.attributes['url.full']).must_equal 'http://example.com/success'
       end
     end
 
@@ -170,8 +195,13 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 200
         _(span.attributes['http.status_code']).must_equal 200
         _(span.attributes['http.url']).must_equal 'http:/success'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http:/success'
+        _(span.attributes['url.scheme']).must_equal 'http'
         _(span.attributes).wont_include('net.peer.name')
         _(response.env.request_headers['Traceparent']).must_equal(
           "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
@@ -194,6 +224,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
           client.get('/not_found')
         end
 
+        _(span.attributes['http.response.status_code']).must_equal 404
         _(span.attributes['http.status_code']).must_equal 404
         _(span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
       end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
@@ -16,12 +16,12 @@ module OpenTelemetry
             span_name = create_request_span_name(request_method, uri.path)
 
             attributes = {
-              'http.method' => request_method,
-              'http.scheme' => uri.scheme,
-              'http.target' => uri.path,
-              'http.url' => "#{uri.scheme}://#{uri.host}",
-              'net.peer.name' => uri.host,
-              'net.peer.port' => uri.port
+              OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => request_method,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => uri.scheme,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => uri.path,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => "#{uri.scheme}://#{uri.host}",
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => uri.host,
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span(span_name, attributes: attributes, kind: :client) do |span|
@@ -42,7 +42,7 @@ module OpenTelemetry
             return unless response&.status
 
             status_code = response.status.to_i
-            span.set_attribute('http.status_code', status_code)
+            span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(status_code.to_i)
           end
 

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
@@ -17,11 +17,16 @@ module OpenTelemetry
 
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => request_method,
+              'http.request.method' => request_method,
               OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => uri.scheme,
               OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => uri.path,
               OpenTelemetry::SemanticConventions::Trace::HTTP_URL => "#{uri.scheme}://#{uri.host}",
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => uri.host,
-              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port,
+              'server.address' => uri.host,
+              'server.port' => uri.port,
+              'url.full' => OpenTelemetry::Common::Utilities.cleanse_url(uri.to_s),
+              'url.scheme' => uri.scheme
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span(span_name, attributes: attributes, kind: :client) do |span|
@@ -42,6 +47,7 @@ module OpenTelemetry
             return unless response&.status
 
             status_code = response.status.to_i
+            span.set_attribute('http.response.status_code', status_code)
             span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(status_code.to_i)
           end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
@@ -12,8 +12,8 @@ module OpenTelemetry
         module Connection
           def initialize(req, options)
             attributes = {
-              'net.peer.name' => req.uri.host,
-              'net.peer.port' => req.uri.port
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => req.uri.host,
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => req.uri.port
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span('HTTP CONNECT', attributes: attributes) do

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
@@ -13,7 +13,9 @@ module OpenTelemetry
           def initialize(req, options)
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => req.uri.host,
-              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => req.uri.port
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => req.uri.port,
+              'server.address' => req.uri.host,
+              'server.port' => req.uri.port
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span('HTTP CONNECT', attributes: attributes) do

--- a/instrumentation/http/test/instrumentation/http/patches/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/client_test.rb
@@ -47,11 +47,17 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       _(exporter.finished_spans.size).must_equal(1)
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',
@@ -65,11 +71,17 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP POST'
       _(span.attributes['http.method']).must_equal 'POST'
+      _(span.attributes['http.request.method']).must_equal 'POST'
+      _(span.attributes['http.response.status_code']).must_equal 500
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.target']).must_equal '/failure'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/failure'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :post,
         'http://example.com/failure',
@@ -85,11 +97,17 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_be_nil
       _(span.attributes['http.scheme']).must_equal 'https'
       _(span.attributes['http.status_code']).must_be_nil
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 443
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 443
+      _(span.attributes['url.full']).must_equal 'https://example.com/timeout'
+      _(span.attributes['url.scheme']).must_equal 'https'
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
@@ -111,12 +129,18 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
       _(span.attributes['peer.service']).must_equal 'foo'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',
@@ -140,12 +164,18 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
         _(exporter.finished_spans.size).must_equal 1
         _(span.name).must_equal 'HTTP GET /success miniswan'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 200
         _(span.attributes['http.scheme']).must_equal 'http'
         _(span.attributes['http.status_code']).must_equal 200
         _(span.attributes['http.target']).must_equal '/success'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
         _(span.attributes['net.peer.port']).must_equal 80
         _(span.attributes['peer.service']).must_equal 'foo'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http://example.com/success'
+        _(span.attributes['url.scheme']).must_equal 'http'
         assert_requested(
           :get,
           'http://example.com/success',
@@ -169,12 +199,18 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Client do
         _(exporter.finished_spans.size).must_equal 1
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.request.method']).must_equal 'GET'
+        _(span.attributes['http.response.status_code']).must_equal 200
         _(span.attributes['http.scheme']).must_equal 'http'
         _(span.attributes['http.status_code']).must_equal 200
         _(span.attributes['http.target']).must_equal '/success'
         _(span.attributes['net.peer.name']).must_equal 'example.com'
         _(span.attributes['net.peer.port']).must_equal 80
         _(span.attributes['peer.service']).must_equal 'foo'
+        _(span.attributes['server.address']).must_equal 'example.com'
+        _(span.attributes['server.port']).must_equal 80
+        _(span.attributes['url.full']).must_equal 'http://example.com/success'
+        _(span.attributes['url.scheme']).must_equal 'http'
         assert_requested(
           :get,
           'http://example.com/success',

--- a/instrumentation/http/test/instrumentation/http/patches/connection_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/connection_test.rb
@@ -24,6 +24,8 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Connection do
 
   describe '#connect' do
     it 'emits span on connect' do
+      port = nil
+
       WebMock.allow_net_connect!
       TCPServer.open('localhost', 0) do |server|
         Thread.start { server.accept }
@@ -38,6 +40,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Connection do
       _(span.name).must_equal 'HTTP CONNECT'
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil
+      _(span.attributes['net.peer.port']).must_equal(port)
     ensure
       WebMock.disable_net_connect!
     end

--- a/instrumentation/http/test/instrumentation/http/patches/connection_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/connection_test.rb
@@ -41,6 +41,9 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Connection do
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil
       _(span.attributes['net.peer.port']).must_equal(port)
+      _(span.attributes['server.address']).must_equal('localhost')
+      _(span.attributes['server.port']).wont_be_nil
+      _(span.attributes['server.port']).must_equal(port)
     ensure
       WebMock.disable_net_connect!
     end

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
@@ -18,12 +18,12 @@ module OpenTelemetry
             request_method = req.header.request_method
 
             attributes = {
-              'http.method' => request_method,
-              'http.scheme' => uri.scheme,
-              'http.target' => uri.path,
-              'http.url' => url,
-              'net.peer.name' => uri.host,
-              'net.peer.port' => uri.port
+              OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => request_method,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => uri.scheme,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => uri.path,
+              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url,
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => uri.host,
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
@@ -41,7 +41,7 @@ module OpenTelemetry
 
             status_code = response.status_code.to_i
 
-            span.set_attribute('http.status_code', status_code)
+            span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(status_code.to_i)
           end
 

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
@@ -19,11 +19,16 @@ module OpenTelemetry
 
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => request_method,
+              'http.request.method' => request_method,
               OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => uri.scheme,
               OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => uri.path,
               OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url,
               OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => uri.host,
-              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port
+              OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => uri.port,
+              'server.address' => uri.host,
+              'server.port' => uri.port,
+              'url.full' => OpenTelemetry::Common::Utilities.cleanse_url(uri.to_s),
+              'url.scheme' => uri.scheme
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
@@ -41,6 +46,7 @@ module OpenTelemetry
 
             status_code = response.status_code.to_i
 
+            span.set_attribute('http.response.status_code', status_code)
             span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, status_code)
             span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(status_code.to_i)
           end

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
@@ -15,7 +15,8 @@ module OpenTelemetry
             url = site.addr
 
             attributes = {
-              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url
+              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url,
+              'url.full' => url
             }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
             tracer.in_span('HTTP CONNECT', attributes: attributes) do
               super

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
             site = @proxy || @dest
             url = site.addr
 
-            attributes = { 'http.url' => url }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+            attributes = { OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
             tracer.in_span('HTTP CONNECT', attributes: attributes) do
               super
             end

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
@@ -14,7 +14,9 @@ module OpenTelemetry
             site = @proxy || @dest
             url = site.addr
 
-            attributes = { OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+            attributes = {
+              OpenTelemetry::SemanticConventions::Trace::HTTP_URL => url
+            }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
             tracer.in_span('HTTP CONNECT', attributes: attributes) do
               super
             end

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/client_test.rb
@@ -41,11 +41,17 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       _(exporter.finished_spans.size).must_equal(1)
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',
@@ -61,11 +67,17 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP POST'
       _(span.attributes['http.method']).must_equal 'POST'
+      _(span.attributes['http.request.method']).must_equal 'POST'
+      _(span.attributes['http.response.status_code']).must_equal 500
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.target']).must_equal '/failure'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/failure'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :post,
         'http://example.com/failure',
@@ -83,11 +95,17 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_be_nil
       _(span.attributes['http.scheme']).must_equal 'https'
       _(span.attributes['http.status_code']).must_be_nil
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 443
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 443
+      _(span.attributes['url.full']).must_equal 'https://example.com/timeout'
+      _(span.attributes['url.scheme']).must_equal 'https'
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
@@ -111,12 +129,18 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Client do
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 80
       _(span.attributes['peer.service']).must_equal 'foo'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/session_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/session_test.rb
@@ -39,6 +39,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Session do
       _(exporter.finished_spans.size).must_equal(2)
       _(span.name).must_equal 'HTTP CONNECT'
       _(span.attributes['http.url']).must_match(%r{http://localhost:})
+      _(span.attributes['url.full']).must_match(%r{http://localhost:})
     ensure
       WebMock.disable_net_connect!
     end

--- a/instrumentation/httpx/test/instrumentation/httpx/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/httpx/plugin_test.rb
@@ -6,8 +6,8 @@
 
 require 'test_helper'
 
-require_relative '../../lib/opentelemetry/instrumentation/httpx'
-require_relative '../../lib/opentelemetry/instrumentation/httpx/plugin'
+require_relative '../../../lib/opentelemetry/instrumentation/httpx'
+require_relative '../../../lib/opentelemetry/instrumentation/httpx/plugin'
 
 describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
   let(:instrumentation) { OpenTelemetry::Instrumentation::HTTPX::Instrumentation.instance }

--- a/instrumentation/httpx/test/instrumentation/httpx/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/httpx/plugin_test.rb
@@ -40,9 +40,15 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',
@@ -57,9 +63,15 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 500
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.target']).must_equal '/failure'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/failure'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/failure',
@@ -76,8 +88,13 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.target']).must_equal '/timeout'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
+      _(span.attributes['url.full']).must_equal 'http://example.com/timeout'
+      _(span.attributes['url.scheme']).must_equal 'http'
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
@@ -104,10 +121,16 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'OVERRIDE'
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['http.response.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
+      _(span.attributes['server.address']).must_equal 'example.com'
+      _(span.attributes['server.port']).must_equal 80
       _(span.attributes['test.attribute']).must_equal 'test.value'
+      _(span.attributes['url.full']).must_equal 'http://example.com/success'
+      _(span.attributes['url.scheme']).must_equal 'http'
       assert_requested(
         :get,
         'http://example.com/success',

--- a/instrumentation/httpx/test/instrumentation/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/plugin_test.rb
@@ -38,10 +38,10 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       assert_requested(
         :get,
@@ -55,10 +55,10 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 500
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.target']).must_equal '/failure'
       assert_requested(
         :get,
@@ -74,9 +74,9 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
+      _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
-      _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
@@ -102,10 +102,10 @@ describe OpenTelemetry::Instrumentation::HTTPX::Plugin do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'OVERRIDE'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.method']).must_equal 'OVERRIDE'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.target']).must_equal '/success'
       _(span.attributes['test.attribute']).must_equal 'test.value'
       assert_requested(

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -210,6 +210,8 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
 
   describe '#connect' do
     it 'emits span on connect' do
+      port = nil
+
       WebMock.allow_net_connect!
       TCPServer.open('localhost', 0) do |server|
         Thread.start { server.accept }
@@ -225,6 +227,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       _(span.name).must_equal 'connect'
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil
+      _(span.attributes['net.peer.port']).must_equal(port)
     ensure
       WebMock.disable_net_connect!
     end


### PR DESCRIPTION
This attempts to harmonize the HTTP client instrumentation by adopting the latest semantic conventions, version 1.26.0.

Each gem currently sets a slightly different set of attributes which makes it harder to create good dashboards in an environment where more than one HTTP client is used.

My change adopts the latest semantic conventions but doesn't retire what's already there. That seems like a better fit for the next major release which will allow a seamless migration.

Notably, this pull request makes the following [HTTP client span attributes](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client) available:

- `http.request.method`
- `http.response.status_code`
- `server.address`
- `server.port`
- `url.full`
- `url.scheme`

There are no constants available for these yet as [the opentelemetry-semantic_conventions gem](https://rubygems.org/gems/opentelemetry-semantic_conventions) was last updated in open-telemetry/opentelemetry-ruby@159044d74ce006cdfda8bb344b1f9c2267d7f040 to version 1.10.0.

See also [this summary of changes](https://opentelemetry.io/docs/specs/semconv/http/migration-guide/#summary-of-changes) and [the list of deprecated attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-deprecated-attributes).