### PR TITLE
test: Fix grape test suite

### DIFF
--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -15,4 +15,5 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-rack', path: '../rack'
+  gem 'builder'
 end


### PR DESCRIPTION
`builder` was removed as a dependency to `grape` but is used by active support in some versions.

See ruby-grape/grape#2443
See ruby-grape/grape#2445
Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1015