### PR TITLE
docs: add function doc for config_overrides_from_env

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -326,6 +326,18 @@ module OpenTelemetry
         ENV[var_name] != 'false'
       end
 
+      # Checks to see if the user has passed any environment variables that set options
+      # for instrumentation. By convention, the environment variable will be the name 
+      # of the instrumentation, uppercased, with '::' replaced by underscores, 
+      # OPENTELEMETRY shortened to OTEL_{LANG}, and _CONFIG_OPTS appended.
+      # For example, the environment variable name for OpenTelemetry::Instrumentation::Faraday
+      # will be OTEL_RUBY_INSTRUMENTATION_FARADAY_CONFIG_OPTS. A value of 'peer_service=new_service;'
+      # will override the options set from ::OpenTelemetry::SDK.configure do |c| ... end for Faraday.
+      #
+      # For an array option, simply separate the values with commas (e.g., option=a,b,c,d).
+      # For a boolean option, set the value to true or false (e.g., option=true).
+      # For integer, string, enum, set the value as a string (e.g., option=string).
+      # Callable options are not allowed to be set through environment variables.
       def config_overrides_from_env
         var_name = name.dup.tap do |n|
           n.upcase!

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -327,8 +327,8 @@ module OpenTelemetry
       end
 
       # Checks to see if the user has passed any environment variables that set options
-      # for instrumentation. By convention, the environment variable will be the name 
-      # of the instrumentation, uppercased, with '::' replaced by underscores, 
+      # for instrumentation. By convention, the environment variable will be the name
+      # of the instrumentation, uppercased, with '::' replaced by underscores,
       # OPENTELEMETRY shortened to OTEL_{LANG}, and _CONFIG_OPTS appended.
       # For example, the environment variable name for OpenTelemetry::Instrumentation::Faraday
       # will be OTEL_RUBY_INSTRUMENTATION_FARADAY_CONFIG_OPTS. A value of 'peer_service=new_service;'


### PR DESCRIPTION
Not sure if this is documented in some place, but adding the doc here for better clarity.

Should we add some example regarding the env var config options and also highlight the precedence (env > programmatic config) in opentelemetry.io?