### PR TITLE
feat: Extend Sidekiq instrumentation with common used attributes

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
               attributes = {
                 SemanticConventions::Trace::MESSAGING_SYSTEM => 'sidekiq',
                 'messaging.sidekiq.job_class' => job['wrapped']&.to_s || job['class'],
-                'messaging.sidekiq.retry' => job['retry'].to_s,
+                'messaging.sidekiq.retry' => job['retry'],
                 'messaging.sidekiq.args' => job['args'].join(', '),
                 SemanticConventions::Trace::MESSAGING_MESSAGE_ID => job['jid'],
                 SemanticConventions::Trace::MESSAGING_DESTINATION => job['queue'],

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -18,6 +18,8 @@ module OpenTelemetry
               attributes = {
                 SemanticConventions::Trace::MESSAGING_SYSTEM => 'sidekiq',
                 'messaging.sidekiq.job_class' => job['wrapped']&.to_s || job['class'],
+                'messaging.sidekiq.retry' => job['retry'].to_s,
+                'messaging.sidekiq.args' => job['args'].join(', '),
                 SemanticConventions::Trace::MESSAGING_MESSAGE_ID => job['jid'],
                 SemanticConventions::Trace::MESSAGING_DESTINATION => job['queue'],
                 SemanticConventions::Trace::MESSAGING_DESTINATION_KIND => 'queue'


### PR DESCRIPTION
## Contributions
This Pull Request adds two attributes to Sidekiq instrumentation: `retry` and `args`.

Neither of these tags are present on the [Semantic Convention for Messaging systems](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md).

## Use case

I am migrating one application that was using Open Tracing libraries. 
As can be [seen here](https://github.com/iaintshine/ruby-sidekiq-tracer/blob/f29955e129432f6e5e727d8f729920d9594a6c67/lib/sidekiq/tracer/commons.rb#L15C29-L15C51) the library adds these attributes. 

Now with the Otel Instrumentation I have noticed these missing span attributes. 
Thus, this PR adds it. It might be useful for other companies and engineers migrating their traces
infrastructure to Open Telemetry. 

I have tried to follow the same naming strategy for non Semantic Convention attributes as 
you are already using in this Sidekiq instrumentation ([example](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/d80a9f36b51aeddfd9d01da6964846ed21bcdcaf/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb#L20))