### PR TITLE
chore: fix base changelog

### DIFF
--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History: opentelemetry-instrumentation-base
 
+### v0.22.4 / 2024-06-18
+
+* FIXED: Relax otel common gem constraints
+* DOCS: Add function doc for config_overrides_from_env
+
 ### v0.22.3 / 2023-11-23
 
 * CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
@@ -57,8 +62,3 @@
 ### v0.17.0 / 2021-04-22
 
 * Initial release.
-
-### v0.22.4 / 2024-06-18
-
-* FIXED: Relax otel common gem constraints
-* DOCS: Add function doc for config_overrides_from_env


### PR DESCRIPTION
For whatever reason the release requester added the release notes to base in the [wrong place](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1025/files#diff-56e77db23a521227f2e9c998b52f3fd353ef19d60d294d6996159487efaf8e09). 

This change sets the release notes to the appropriate location to make the release script happy. 