### PR TITLE
fix: Include span kind in ActiveSupport Instrumentation helper

### DIFF
--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
@@ -20,14 +20,14 @@ module OpenTelemetry
         pattern,
         notification_payload_transform = nil,
         disallowed_notification_payload_keys = [],
-        kind = nil
+        kind: nil
       )
         subscriber = OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
           name: pattern,
           tracer: tracer,
           notification_payload_transform: notification_payload_transform,
           disallowed_notification_payload_keys: disallowed_notification_payload_keys,
-          kind: nil
+          kind: kind
         )
 
         subscriber_object = ::ActiveSupport::Notifications.subscribe(pattern, subscriber)

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -223,6 +223,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
       _(last_span).wont_be_nil
       _(last_span.name).must_equal('foo bar')
       _(last_span.attributes['extra']).must_equal('context')
+      _(last_span.kind).must_equal(:internal)
     end
 
     it 'finishes spans even when block subscribers blow up' do

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -260,5 +260,15 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
       _(obj.class).must_equal(ActiveSupport::Notifications::Fanout::Subscribers::Evented)
       _(last_span).must_be_nil
     end
+
+    it 'supports setting the span kind' do
+      OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, 'bar.foo', nil, [], kind: :client)
+      ActiveSupport::Notifications.instrument('bar.foo', extra: 'context')
+
+      _(last_span).wont_be_nil
+      _(last_span.name).must_equal('foo bar')
+      _(last_span.attributes['extra']).must_equal('context')
+      _(last_span.kind).must_equal(:client)
+    end
   end
 end


### PR DESCRIPTION
This change fixes a bug where the kind parameter was not passed along to the subscriber object