### PR TITLE
docs: Fix CHANGELOGs to reflect a past breaking change

### DIFF
--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### v0.6.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.5.2 / 2023-08-03
 

--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -57,11 +57,11 @@
 
 ### v0.50.1 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names (Resque)
+* BREAKING CHANGE: Align messaging instrumentation operation names (Resque)
 
 ### v0.50.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.40.0 / 2023-08-07
 

--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### v0.5.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.4.2 / 2023-08-03
 

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### v0.21.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.1 / 2023-06-05
 

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### v0.21.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.1 / 2023-06-05
 

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### v0.7.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.6.2 / 2023-08-07
 

--- a/instrumentation/racecar/CHANGELOG.md
+++ b/instrumentation/racecar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### v0.3.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.2.1 / 2023-06-05
 

--- a/instrumentation/rails/CHANGELOG.md
+++ b/instrumentation/rails/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### v0.28.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.27.1 / 2023-06-05
 

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### v0.4.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.3.2 / 2023-07-21
 

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v0.21.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.2 / 2023-08-09
 

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -22,8 +22,8 @@
 
 ### v0.25.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
-
+* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+*
 ### v0.24.4 / 2023-08-07
 
 * FIXED: Allow traces inside jobs while avoiding Redis noise


### PR DESCRIPTION
This was actually a breaking change, and despite `:fix!` being used in the commit, the release tooling failed to mark the change as breaking.

Refs: #648, #655