### PR TITLE
fix: register lambda span

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,11 +208,21 @@ merge. You'll probably get some feedback from these fine folks which helps to
 make the project that much better. Respond to the feedback and work with your
 reviewer(s) to resolve any issues.
 
+The some of the things the code owners are looking for include:
+* a signed [CNCF CLA][cncf-cla]
+* a passing CI build
+* adherence to the principles and features outlined in the
+  [instrumentation author's guide](.instrumentation/CONTRIBUTING.md)
+
 Reviewers are responsible for ensuring that each merged PR's commit message
 conforms to [conventional commits](https://conventionalcommits.org). This may
-mean editing the commit message when you merge the pull request. Alternately,
-the reviewer may ask the pull request submitter to amend the commit message of
-their initial commit.
+mean editing the commit message or the pull request title when you merge the
+pull request. Alternately, the reviewer may ask the pull request submitter
+to amend the commit message of their initial commit.
+
+In addition, when a change is complex or a reviewer is unfamiliar with the code,
+the reviewer may seek additional reviews from people more familiar with the
+change before merging a PR.
 
 ## Releases
 

--- a/instrumentation/aws_lambda/README.md
+++ b/instrumentation/aws_lambda/README.md
@@ -36,6 +36,7 @@ To run the example:
 	* `bundle install`
 2. Run the sample client script
 	* `ruby trace_demonstration.rb`
+	* or `bundle exec ruby trace_demonstration.rb`
 
 This will run SNS publish command, printing OpenTelemetry traces to the console as it goes.
 

--- a/instrumentation/aws_lambda/example/trace_demonstration.rb
+++ b/instrumentation/aws_lambda/example/trace_demonstration.rb
@@ -97,6 +97,6 @@ event = {
    "version" => "1.0"
 }
 
-context = MockLambdaContext.new(aws_request_id: "aws_request_id",invoked_function_arn: "invoked_function_arn",function_name: "function")
+context = MockLambdaContext.new(aws_request_id: "aws_request_id",invoked_function_arn: "arn:aws:lambda:us-west-2:123456789012:function:HelloWorld",function_name: "function")
 
 otel_wrapper(event: event, context: context) # you should see Success before the trace


### PR DESCRIPTION
## Description

The aws lambda span was not registered with context after start_span, which cause current_span can't detect it. User couldn't append attributes outside call_wrapped span. This PR attach the span to current context and detach it before finish.