### PR TITLE
fix: ActiveJob::Handlers.unsubscribe

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers.rb
@@ -64,7 +64,7 @@ module OpenTelemetry
         # Removes Event Handler Subscriptions for ActiveJob notifications
         # @note this method is not thread-safe and should not be used in a multi-threaded context
         def unsubscribe
-          @subscriptions&.each { |subscriber| ActiveSupport::Notifications.unsubscribe(subscriber) }
+          @subscriptions&.each { |subscriber| ::ActiveSupport::Notifications.unsubscribe(subscriber) }
           @subscriptions = nil
         end
       end

--- a/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers_test.rb
+++ b/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers_test.rb
@@ -50,4 +50,14 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Handlers do
       _(MixedArgsJob.perform_now('arg1', 'arg2', keyword2: :keyword2)).must_be_nil # Make sure this runs without raising an error
     end
   end
+
+  describe 'usage' do
+    it 'can unsubscribe' do
+      _(OpenTelemetry::Instrumentation::ActiveJob::Handlers.instance_variable_get(:@subscriptions)).wont_be_empty
+
+      OpenTelemetry::Instrumentation::ActiveJob::Handlers.unsubscribe
+
+      _(OpenTelemetry::Instrumentation::ActiveJob::Handlers.instance_variable_get(:@subscriptions)).must_be_nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1076

Added a basic unit test for good measure