### PR TITLE
feat(active-job)!: Normalize event messages

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers.rb
@@ -14,6 +14,8 @@ module OpenTelemetry
     module ActiveJob
       # Module that contains custom event handlers, which are used to generate spans per event
       module Handlers
+        EVENT_NAMESPACE = 'active_job'
+
         module_function
 
         # Subscribes Event Handlers to relevant ActiveJob notifications
@@ -57,7 +59,7 @@ module OpenTelemetry
           }
 
           @subscriptions = handlers_by_pattern.map do |key, handler|
-            ::ActiveSupport::Notifications.subscribe("#{key}.active_job", handler)
+            ::ActiveSupport::Notifications.subscribe("#{key}.#{EVENT_NAMESPACE}", handler)
           end
         end
 

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
@@ -10,6 +10,8 @@ module OpenTelemetry
       module Handlers
         # Handles `enqueue.active_job` and `enqueue_at.active_job` to generate egress spans
         class Enqueue < Default
+          EVENT_NAME = 'publish'
+
           # Overrides the `Default#start_span` method to create an egress span
           # and registers it with the current context
           #
@@ -19,21 +21,10 @@ module OpenTelemetry
           # @return [Hash] with the span and generated context tokens
           def start_span(name, _id, payload)
             job = payload.fetch(:job)
-            span = tracer.start_span(span_name(job), kind: :producer, attributes: @mapper.call(payload))
+            span_name = span_name(job, EVENT_NAME)
+            span = tracer.start_span(span_name, kind: :producer, attributes: @mapper.call(payload))
             OpenTelemetry.propagation.inject(job.__otel_headers) # This must be transmitted over the wire
             { span: span, ctx_token: OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span)) }
-          end
-
-          private
-
-          def span_name(job)
-            prefix = if @config[:span_naming] == :job_class
-                       job.class.name
-                     else
-                       job.queue_name
-                     end
-
-            "#{prefix} publish"
           end
         end
       end

--- a/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/discard_test.rb
+++ b/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/discard_test.rb
@@ -15,7 +15,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveJob::Handlers::Discard' do
   let(:spans) { exporter.finished_spans }
   let(:publish_span) { spans.find { |s| s.name == 'default publish' } }
   let(:process_span) { spans.find { |s| s.name == 'default process' } }
-  let(:discard_span) { spans.find { |s| s.name == 'discard.active_job' } }
+  let(:discard_span) { spans.find { |s| s.name == 'default discard' } }
 
   before do
     OpenTelemetry::Instrumentation::ActiveJob::Handlers.unsubscribe

--- a/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/retry_stopped_test.rb
+++ b/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/retry_stopped_test.rb
@@ -15,7 +15,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveJob::Handlers::RetryStopped' do
   let(:spans) { exporter.finished_spans }
   let(:publish_span) { spans.find { |s| s.name == 'default publish' } }
   let(:process_span) { spans.find { |s| s.name == 'default process' } }
-  let(:retry_span) { spans.find { |s| s.name == 'retry_stopped.active_job' } }
+  let(:retry_span) { spans.find { |s| s.name == 'default retry_stopped' } }
 
   before do
     OpenTelemetry::Instrumentation::ActiveJob::Handlers.unsubscribe


### PR DESCRIPTION
Designed to be merged after https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1079

Related to:
- https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648
- https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677

Currently, active job events are:
| Notification | Before | After |
| - | - | - |
| `enqueue.active_job` | `#{prefix} publish` | `#{prefix} publish` |
| `enqueue_at.active_job` | `#{prefix} publish` | `#{prefix} publish` |
| `enqueue_retry.active_job` | `enqueue_retry.active_job` | `#{prefix} enqueue_retry` |
| `perform.active_job` | `#{prefix} process` | `#{prefix} process` |
| `retry_stopped.active_job` | `retry_stopped.active_job` | `#{prefix} retry_stopped` |
| `discard.active_job` | `discard.active_job` | `#{prefix} discard` |

Prefix being the queue name or the job class, depending on config.

I think this is more consistent.

⚠️ Note that this is a BREAKING CHANGE with regards to the spans added in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677