### PR TITLE
fix: fix the issue of wrong log msg

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -304,7 +304,7 @@ module OpenTelemetry
           h[option_name] = option[:default]
         end
 
-        dropped_config_keys = user_config.keys - validated_config.keys
+        dropped_config_keys = user_config.keys - validated_config.keys - [:enabled]
         OpenTelemetry.logger.warn("Instrumentation #{name} ignored the following unknown configuration options #{dropped_config_keys}") unless dropped_config_keys.empty?
 
         validated_config


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1095

### Description

When user provides the `:enabled` in config option, the value will be passed into config_options, which is not part of instrumentation options so the [L308](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/opentelemetry-instrumentation-base/v0.22.5/instrumentation/base/lib/opentelemetry/instrumentation/base.rb#L308) will appear.