### PR TITLE
fix: Update `pg` support

### DIFF
--- a/instrumentation/pg/Appraisals
+++ b/instrumentation/pg/Appraisals
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-# 1.2.3 appears to be the most popular version at RubyGems.org
-appraise 'pg-1.2' do
-  gem 'pg', '~> 1.2.3'
+# Last release 1.4.6 (February 26, 2023)
+appraise 'pg-1.4' do
+  gem 'pg', '~> 1.4'
 end
 
-# 1.3.0 significantly changed connecting and the handling of connection strings
-appraise 'pg-1.3' do
-  gem 'pg', '~> 1.3.5'
+appraise 'pg-1.5' do
+  gem 'pg', '~> 1.5'
 end
 
 appraise 'pg-latest' do


### PR DESCRIPTION
Remove `pg` versions 1.2 and 1.3, add `pg` versions 1.4 and 1.5