### PR TITLE
fix(pg): update versions to be tested (includes drop support for pg 1.2)

### DIFF
--- a/instrumentation/pg/Appraisals
+++ b/instrumentation/pg/Appraisals
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# 1.2.3 appears to be the most popular version at RubyGems.org
-appraise 'pg-1.2' do
-  gem 'pg', '~> 1.2.3'
-end
-
-# 1.3.0 significantly changed connecting and the handling of connection strings
 appraise 'pg-1.3' do
   gem 'pg', '~> 1.3.5'
 end

--- a/instrumentation/pg/Appraisals
+++ b/instrumentation/pg/Appraisals
@@ -10,6 +10,10 @@ appraise 'pg-1.3' do
   gem 'pg', '~> 1.3.5'
 end
 
+appraise 'pg-1.4' do
+  gem 'pg', '~> 1.4.5'
+end
+
 appraise 'pg-latest' do
   gem 'pg'
 end


### PR DESCRIPTION
* drop pg-1.2
    * This addresses the specific pg error found in #1097.
    * pg 1.2.x does not work under Ruby >= 3.0.
    * We currently support and test only Ruby >= 3.0.
* add pg-1.4
    * This used to be latest! Now latest in 1.5. 

With thanks to @matthewtusker for raising the issue and helping to resolve!