### PR TITLE
test: Update Appraisals for Rails 7.2

### DIFF
--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+end

--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -16,6 +16,8 @@ appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
 
-appraise 'rails-7.2' do
-  gem 'rails', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'rails-7.2' do
+    gem 'rails', '~> 7.2.0'
+  end
 end

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+end

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -16,6 +16,8 @@ appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
 
-appraise 'rails-7.2' do
-  gem 'rails', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'rails-7.2' do
+    gem 'rails', '~> 7.2.0'
+  end
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -16,6 +16,8 @@ appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
 
-appraise 'rails-7.2' do
-  gem 'rails', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'rails-7.2' do
+    gem 'rails', '~> 7.2.0'
+  end
 end

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -16,6 +16,8 @@ appraise 'activerecord-7.1' do
   gem 'activerecord', '~> 7.1.0'
 end
 
-appraise 'activerecord-7.2' do
-  gem 'activerecord', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'activerecord-7.2' do
+    gem 'activerecord', '~> 7.2.0'
+  end
 end

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'activerecord-7.1' do
   gem 'activerecord', '~> 7.1.0'
 end
+
+appraise 'activerecord-7.2' do
+  gem 'activerecord', '~> 7.2.0'
+end

--- a/instrumentation/active_support/Appraisals
+++ b/instrumentation/active_support/Appraisals
@@ -16,6 +16,8 @@ appraise 'activesupport-7.1' do
   gem 'activesupport', '~> 7.1.0'
 end
 
-appraise 'activesupport-7.2' do
-  gem 'activesupport', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'activesupport-7.2' do
+    gem 'activesupport', '~> 7.2.0'
+  end
 end

--- a/instrumentation/active_support/Appraisals
+++ b/instrumentation/active_support/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'activesupport-7.1' do
   gem 'activesupport', '~> 7.1.0'
 end
+
+appraise 'activesupport-7.2' do
+  gem 'activesupport', '~> 7.2.0'
+end

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
-  spec.add_development_dependency 'activerecord', '< 7.2.0', '> 6.1.0'
+  spec.add_development_dependency 'activerecord', '> 6.1.0'
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
-  spec.add_development_dependency 'activerecord'
+  spec.add_development_dependency 'activerecord', '< 7.2.0', '> 6.1.0'
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'activerecord'
+  gem 'activerecord', '< 7.2.0', '> 6.1.0'
   gem 'pg'
   gem 'opentelemetry-helpers-sql-obfuscation', path: '../../helpers/sql-obfuscation'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -15,3 +15,7 @@ end
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -16,6 +16,8 @@ appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
 
-appraise 'rails-7.2' do
-  gem 'rails', '~> 7.2.0'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  appraise 'rails-7.2' do
+    gem 'rails', '~> 7.2.0'
+  end
 end


### PR DESCRIPTION
* Rails 7.2.0 was released on August 9, 2024. Add appraisals for the new version.
* pg was installing activerecord 3.2, this sets a bottom limit of 6.1, the oldest supported version of Rails 
* que is not yet compatible with Rails 7.2, so set a constraint to install something between 6.1 and 7.1 (it will be compatible once https://github.com/que-rb/que/pull/423 is merged)

Resolves #1113 

(I had this prefixed to `chore`, but switched it to `test`, not sure if one is preferred over the other)