### PR TITLE
fix(active-job): Prefix ::ActiveSupport when installing the instrumentation

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
@@ -71,7 +71,7 @@ module OpenTelemetry
         def patch_activejob
           Handlers.subscribe
 
-          ActiveSupport.on_load(:active_job) do
+          ::ActiveSupport.on_load(:active_job) do
             ::ActiveJob::Base.prepend(Patches::Base) unless ::ActiveJob::Base <= Patches::Base
           end
         end


### PR DESCRIPTION
Otherwise, `ActiveSupport` ends up resolving to `OpenTelemetry::Instrumentation::ActiveSupport`.

`OpenTelemetry::Instrumentation::Registry#install_instrumentation` rescues the exception, so the prepend ends up being (somewhat) silently dropped.

This results in the patch not being adding, which causes `OpenTelemetry.propagation.inject(job.__otel_headers)` to raise, dropping the span