### PR TITLE
fix: use ActiveSupport from top-level namespace

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -42,7 +42,7 @@ module OpenTelemetry
         end
 
         def patch_activerecord
-          ActiveSupport.on_load(:active_record) do
+          ::ActiveSupport.on_load(:active_record) do
             # Modules to prepend to ActiveRecord::Base are grouped by the source
             # module that they are defined in as they are included into ActiveRecord::Base
             # Example: Patches::PersistenceClassMethods refers to https://github.com/rails/rails/blob/v6.1.0/activerecord/lib/active_record/persistence.rb#L10


### PR DESCRIPTION
## Description
Came across an error when ActiveRecord Instrumentation is being installed in a Rails app.

## Proposed change
Use `::ActiveSupport` to look for constant in the top-level namespace.

### Error:
``` 
OpenTelemetry error: Instrumentation: OpenTelemetry::Instrumentation::ActiveRecord unhandled exception during install:
...
undefined method `on_load' for OpenTelemetry::Instrumentation::ActiveSupport:Module
...
ActiveSupport.on_load(:active_record) do
             ^^^^^^^^
```