### PR TITLE
🔬 Metrics Prototype: Conditions everywhere edition

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -214,9 +214,7 @@ module OpenTelemetry
         # We need the API as a dependency to call metrics
         # But, we can check for the SDK before we do any metrics-y things
         # might be able to shore this up to run only on init to preven re-eval
-        result = defined?(OpenTelemetry::Metrics) && @config[:send_metrics]
-        puts "***** metrics_enabled? result = #{result.inspect}"
-        result
+        defined?(OpenTelemetry::Metrics) && @config[:send_metrics]
       end
 
       # Install instrumentation with the given config. The present? and compatible?

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -29,8 +29,8 @@ module OpenTelemetry
         option :untraced_requests,        default: nil,   validate: :callable
         option :response_propagators,     default: [],    validate: :array
         # This option is only valid for applications using Rack 2.0 or greater
-        option :use_rack_events,          default: true, validate: :boolean
-
+        option :use_rack_events,          default: true,  validate: :boolean
+        option :send_metrics,             default: false, validate: :boolean
         # Temporary Helper for Sinatra and ActionPack middleware to use during installation
         #
         # @example Default usage

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
@@ -158,6 +158,8 @@ module OpenTelemetry
             false
           end
 
+          # TODO: This one is long because I wanted to keep the stable semantic
+          # conventions, and (for now) emit attributes that matched the span
           def record_http_server_request_duration_metric(span)
             return unless metrics_enabled? && http_server_duration_histogram
 
@@ -169,7 +171,7 @@ module OpenTelemetry
             attrs = {}
             # pattern below goes
             # stable convention
-            # current span convention
+            # attribute that matches rack spans (old convention)
 
             # attrs['http.request.method']
             attrs['http.method'] = span.attributes['http.method']
@@ -298,14 +300,8 @@ module OpenTelemetry
           end
 
           def http_server_duration_histogram
-            # only want to make the view and the histogram once
-            # OpenTelemetry.meter_provider.add_view(
-            #   'http.server.request.duration',
-            #   aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new(
-            #     boundaries: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
-            #     )
-            #   )
-            # Meter might be nil if metrics API isn't installed or isn't configured to send data
+            # Only want to make the histogram once
+            # Need to implement advice so we can update the buckets to match seconds instead of ms
             return @http_server_duration_histogram if defined?(@http_server_duration_histogram)
 
             @http_server_duration_histogram = nil unless meter

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
@@ -163,7 +163,7 @@ module OpenTelemetry
 
             # find span duration
             # end - start / a billion to convert nanoseconds to seconds
-            duration = (span.end_timestamp - span.start_timestamp) / (10**9)
+            duration = (span.end_timestamp - span.start_timestamp) / Float(10**9)
             # Create attributes
             #
             attrs = {}

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
@@ -160,9 +160,10 @@ module OpenTelemetry
 
           def record_http_server_request_duration_metric(span)
             return unless metrics_enabled? && http_server_duration_histogram
+
             # find span duration
             # end - start / a billion to convert nanoseconds to seconds
-            duration = (span.end_timestamp - span.start_timestamp) / 10**9
+            duration = (span.end_timestamp - span.start_timestamp) / (10**9)
             # Create attributes
             #
             attrs = {}
@@ -292,12 +293,18 @@ module OpenTelemetry
           def meter
             # warn if no meter?
             return @meter if defined?(@meter)
+
             @meter = metrics_enabled? ? OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.meter : nil
           end
 
           def http_server_duration_histogram
             # only want to make the view and the histogram once
-            # OpenTelemetry.meter_provider.add_view('http.server.request.duration', aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new(boundaries: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]))
+            # OpenTelemetry.meter_provider.add_view(
+            #   'http.server.request.duration',
+            #   aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new(
+            #     boundaries: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
+            #     )
+            #   )
             # Meter might be nil if metrics API isn't installed or isn't configured to send data
             return @http_server_duration_histogram if defined?(@http_server_duration_histogram)
 


### PR DESCRIPTION
A potential way to integrate metrics into the Instrumentation:
* If the OpenTelemetry::Metrics API is installed, go ahead and make things in base
* Check for a configuration option, `:send_metrics` to be `true` before generating telemetry
* Still very messy, do we like this general approach?