### PR TITLE
fix(active-job): Propagate context between enqueue and perform

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
@@ -23,8 +23,9 @@ module OpenTelemetry
             job = payload.fetch(:job)
             span_name = span_name(job, EVENT_NAME)
             span = tracer.start_span(span_name, kind: :producer, attributes: @mapper.call(payload))
+            token = OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))
             OpenTelemetry.propagation.inject(job.__otel_headers) # This must be transmitted over the wire
-            { span: span, ctx_token: OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span)) }
+            { span: span, ctx_token: token }
           end
         end
       end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
             # TODO: Refactor into a propagation strategy
             propagation_style = @config[:propagation_style]
             if propagation_style == :child
-              span = tracer.start_span(span_name, kind: :consumer, attributes: @mapper.call(payload))
+              span = tracer.start_span(span_name, with_parent: parent_context, kind: :consumer, attributes: @mapper.call(payload))
             else
               span_context = OpenTelemetry::Trace.current_span(parent_context).context
               links = [OpenTelemetry::Trace::Link.new(span_context)] if span_context.valid? && propagation_style == :link

--- a/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/perform_test.rb
+++ b/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/handlers/perform_test.rb
@@ -176,6 +176,18 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Handlers::Perform do
         _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
       end
 
+      it 'does not interfere with an outer span' do
+        instrumentation.tracer.in_span('outer span') do
+          TestJob.perform_later
+        end
+
+        _(publish_span.trace_id).wont_equal(process_span.trace_id)
+
+        _(process_span.total_recorded_links).must_equal(1)
+        _(process_span.links[0].span_context.trace_id).must_equal(publish_span.trace_id)
+        _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
+      end
+
       it 'propagates baggage' do
         ctx = OpenTelemetry::Baggage.set_value('testing_baggage', 'it_worked')
         OpenTelemetry::Context.with_current(ctx) do
@@ -189,6 +201,30 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Handlers::Perform do
         _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
 
         _(process_span.attributes['success']).must_equal(true)
+      end
+
+      describe 'with an async queue adapter' do
+        before do
+          begin
+            ActiveJob::Base.queue_adapter.shutdown
+          rescue StandardError
+            nil
+          end
+
+          singleton_class.include ActiveJob::TestHelper
+          ActiveJob::Base.queue_adapter = :test
+        end
+
+        it 'creates span links in separate traces' do
+          TestJob.perform_later
+          perform_enqueued_jobs
+
+          _(publish_span.trace_id).wont_equal(process_span.trace_id)
+
+          _(process_span.total_recorded_links).must_equal(1)
+          _(process_span.links[0].span_context.trace_id).must_equal(publish_span.trace_id)
+          _(process_span.links[0].span_context.span_id).must_equal(publish_span.span_id)
+        end
       end
     end
 
@@ -204,6 +240,17 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Handlers::Perform do
         _(process_span.parent_span_id).must_equal(publish_span.span_id)
       end
 
+      it 'does not interfere with an outer span' do
+        instrumentation.tracer.in_span('outer span') do
+          TestJob.perform_later
+        end
+
+        _(process_span.total_recorded_links).must_equal(0)
+
+        _(publish_span.trace_id).must_equal(process_span.trace_id)
+        _(process_span.parent_span_id).must_equal(publish_span.span_id)
+      end
+
       it 'propagates baggage' do
         ctx = OpenTelemetry::Baggage.set_value('testing_baggage', 'it_worked')
         OpenTelemetry::Context.with_current(ctx) do
@@ -214,6 +261,29 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Handlers::Perform do
         _(publish_span.trace_id).must_equal(process_span.trace_id)
         _(process_span.parent_span_id).must_equal(publish_span.span_id)
         _(process_span.attributes['success']).must_equal(true)
+      end
+
+      describe 'with an async queue adapter' do
+        before do
+          begin
+            ActiveJob::Base.queue_adapter.shutdown
+          rescue StandardError
+            nil
+          end
+
+          singleton_class.include ActiveJob::TestHelper
+          ActiveJob::Base.queue_adapter = :test
+        end
+
+        it 'creates a parent/child relationship' do
+          TestJob.perform_later
+          perform_enqueued_jobs
+
+          _(process_span.total_recorded_links).must_equal(0)
+
+          _(publish_span.trace_id).must_equal(process_span.trace_id)
+          _(process_span.parent_span_id).must_equal(publish_span.span_id)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1131

This fixes two issues:
1. Sets the current context before injecting for propagation
2. Specify `with_parent: parent_context` when performing

Those cases were not caught by tests because they were using the "async immediate" queue adapter, which executes within the same thread. It was working by accident. 

Added tests that match the report at https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1131