### PR TITLE
fix: ActionView Support Legacy Formats

### DIFF
--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view.rb
@@ -9,7 +9,7 @@ require 'opentelemetry-instrumentation-base'
 
 module OpenTelemetry
   module Instrumentation
-    # Contains the OpenTelemetry instrumentation for the ActionView gem
+    # (see OpenTelemetry::Instrumentation::ActionView::Instrumentation)
     module ActionView
     end
   end

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
@@ -7,7 +7,42 @@
 module OpenTelemetry
   module Instrumentation
     module ActionView
-      # The Instrumentation class contains logic to detect and install the ActionView instrumentation
+      # The {OpenTelemetry::Instrumentation::ActionView::Instrumentation} class contains logic to detect and install the ActionView instrumentation
+      #
+      # Installation and configuration of this instrumentation is done within the
+      # {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry/SDK#configure-instance_method OpenTelemetry::SDK#configure}
+      # block, calling {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry%2FSDK%2FConfigurator:use use()}
+      # or {https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry%2FSDK%2FConfigurator:use_all use_all()}.
+      #
+      # ## Configuration keys and options
+      #
+      # ### `:disallowed_notification_payload_keys`
+      #
+      # Specifies an array of keys that should be excluded from the notification payload as span attributes.
+      #
+      # ### `:notification_payload_transform`
+      #
+      # - `proc` **default** `nil`
+      #
+      # Specifies custom proc used to extract span attributes form the notification payload.
+      # Use this to rename keys, extract nested values, or perform any other custom logic.
+      #
+      # ### `:legacy_span_names`
+      #
+      # - `boolean`  **default** `false`
+      #
+      # Specifies whether spans names should use the legacy format where the subscription was reverse ordered and white space separated. (Ex. `action_view render_template`)
+      # If set to `true`, the span name will match the name of the notification itself. (Ex. `render_template.action_view`)
+      #
+      # @example An explicit default configuration
+      #   OpenTelemetry::SDK.configure do |c|
+      #     c.use_all({
+      #       'OpenTelemetry::Instrumentation::ActionView' => {
+      #         disallowed_notification_payload_keys: [],
+      #         legacy_span_names: true,
+      #       },
+      #     })
+      #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('6.1.0')
         install do |_config|
@@ -24,6 +59,7 @@ module OpenTelemetry
 
         option :disallowed_notification_payload_keys, default: [],  validate: :array
         option :notification_payload_transform,       default: nil, validate: :callable
+        option :legacy_span_names,                    default: false, validate: :boolean
 
         private
 

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
@@ -19,13 +19,16 @@ module OpenTelemetry
         config.after_initialize do
           ::OpenTelemetry::Instrumentation::ActiveSupport::Instrumentation.instance.install({})
 
+          instance = ::OpenTelemetry::Instrumentation::ActionView::Instrumentation.instance
+          span_name_formatter = instance.config[:legacy_span_names] ? ::OpenTelemetry::Instrumentation::ActiveSupport::LEGACY_NAME_FORMATTER : nil
+
           SUBSCRIPTIONS.each do |subscription_name|
-            config = ActionView::Instrumentation.instance.config
             ::OpenTelemetry::Instrumentation::ActiveSupport.subscribe(
-              ActionView::Instrumentation.instance.tracer,
+              instance.tracer,
               subscription_name,
-              config[:notification_payload_transform],
-              config[:disallowed_notification_payload_keys]
+              instance.config[:notification_payload_transform],
+              instance.config[:disallowed_notification_payload_keys],
+              span_name_formatter: span_name_formatter
             )
           end
         end

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.1'
+  spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.6'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.22.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.5'


### PR DESCRIPTION
This restores the functionality that was reverted 94c3c3bfafa4e78a7e153d38b5e43767144892bb.

I had originally introduced this functionality in this PR: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1039

cc: @mrsimo