### PR TITLE
Fix mistake in inline docs for `legacy_span_names` option

### DIFF
--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
       # - `boolean`  **default** `false`
       #
       # Specifies whether spans names should use the legacy format where the subscription was reverse ordered and white space separated. (Ex. `action_view render_template`)
-      # If set to `true`, the span name will match the name of the notification itself. (Ex. `render_template.action_view`)
+      # If set to `false`, the span name will match the name of the notification itself. (Ex. `render_template.action_view`)
       #
       # @example An explicit default configuration
       #   OpenTelemetry::SDK.configure do |c|


### PR DESCRIPTION
This looks to me to be incorrect: the default is `false`, with the span name matching the name of the notification itself. Switching it to `true` makes it reverse ordered and white space separated.