### PR TITLE
feat: Replace logging exporter with debug exporter

### DIFF
--- a/otelcol-config.yml
+++ b/otelcol-config.yml
@@ -8,7 +8,7 @@ exporters:
     endpoint: "jaeger:14250"
     tls:
       insecure: true
-  logging:
+  debug:
 
 processors:
   batch:
@@ -18,4 +18,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, jaeger]
+      exporters: [debug, jaeger]


### PR DESCRIPTION
The logging exporter for the collector was deprecated a year ago, and will be removed soon. The debug exporter is its replacement.