### PR TITLE
fix!: activerecord find_by_sql spans on Rails 7.0+

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -18,17 +18,11 @@ module OpenTelemetry
 
           # Contains ActiveRecord::Querying to be patched
           module ClassMethods
-            if ::ActiveRecord.version >= Gem::Version.new('7.0.0')
-              def _query_by_sql(...)
-                tracer.in_span("#{self} query") do
-                  super
-                end
-              end
-            else
-              def find_by_sql(...)
-                tracer.in_span("#{self} query") do
-                  super
-                end
+            method_name = ::ActiveRecord.version >= Gem::Version.new('7.0.0') ? :_query_by_sql : :find_by_sql
+
+            define_method(method_name) do |*args, **kwargs|
+              tracer.in_span("#{self} query") do
+                super(*args, **kwargs)
               end
             end
 

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -18,9 +18,17 @@ module OpenTelemetry
 
           # Contains ActiveRecord::Querying to be patched
           module ClassMethods
-            def find_by_sql(...)
-              tracer.in_span("#{self}.find_by_sql") do
-                super
+            if ::ActiveRecord.version >= Gem::Version.new('7.0.0')
+              def _query_by_sql(...)
+                tracer.in_span("#{self}.find_by_sql") do
+                  super
+                end
+              end
+            else
+              def find_by_sql(...)
+                tracer.in_span("#{self}.find_by_sql") do
+                  super
+                end
               end
             end
 

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -20,13 +20,13 @@ module OpenTelemetry
           module ClassMethods
             if ::ActiveRecord.version >= Gem::Version.new('7.0.0')
               def _query_by_sql(...)
-                tracer.in_span("#{self}.find_by_sql") do
+                tracer.in_span("#{self} query") do
                   super
                 end
               end
             else
               def find_by_sql(...)
-                tracer.in_span("#{self}.find_by_sql") do
+                tracer.in_span("#{self} query") do
                   super
                 end
               end

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
@@ -15,15 +15,15 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::Querying do
 
   before { exporter.reset }
 
-  describe 'find_by_sql' do
+  describe 'query' do
     it 'traces' do
       Account.create!
 
       User.find_by_sql('SELECT * FROM users')
       Account.first.users.to_a
 
-      user_find_spans = spans.select { |s| s.name == 'User.find_by_sql' }
-      account_find_span = spans.find { |s| s.name == 'Account.find_by_sql' }
+      user_find_spans = spans.select { |s| s.name == 'User query' }
+      account_find_span = spans.find { |s| s.name == 'Account query' }
 
       _(user_find_spans.length).must_equal(2)
       _(account_find_span).wont_be_nil

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
@@ -17,10 +17,16 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::Querying do
 
   describe 'find_by_sql' do
     it 'traces' do
-      User.find_by_sql('SELECT * FROM users')
+      Account.create!
 
-      find_span = spans.find { |s| s.name == 'User.find_by_sql' }
-      _(find_span).wont_be_nil
+      User.find_by_sql('SELECT * FROM users')
+      Account.first.users.to_a
+
+      user_find_spans = spans.select { |s| s.name == 'User.find_by_sql' }
+      account_find_span = spans.find { |s| s.name == 'Account.find_by_sql' }
+
+      _(user_find_spans.length).must_equal(2)
+      _(account_find_span).wont_be_nil
     end
   end
 end

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -60,7 +60,7 @@ migration_version = "#{segments[0]}.#{segments[1]}".to_f
 # Simple migration to create a table to test against
 class CreateUserTable < ActiveRecord::Migration[migration_version]
   def change
-    create_table :accounts do
+    create_table :accounts do |t|
       t.timestamps
     end
 

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -60,9 +60,7 @@ migration_version = "#{segments[0]}.#{segments[1]}".to_f
 # Simple migration to create a table to test against
 class CreateUserTable < ActiveRecord::Migration[migration_version]
   def change
-    create_table :accounts do |t|
-      t.timestamps
-    end
+    create_table :accounts, &:timestamps
 
     create_table :users do |t|
       t.string 'name'

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -34,8 +34,14 @@ ActiveRecord::Base.establish_connection(
   database: 'db/development.sqlite3'
 )
 
-# Create User model
+# Create ActiveRecord models
+class Account < ActiveRecord::Base
+  has_many :users
+end
+
 class User < ActiveRecord::Base
+  belongs_to :account
+
   validate :name_if_present
 
   scope :recently_created, -> { where('created_at > ?', Time.now - 3600) }
@@ -54,9 +60,14 @@ migration_version = "#{segments[0]}.#{segments[1]}".to_f
 # Simple migration to create a table to test against
 class CreateUserTable < ActiveRecord::Migration[migration_version]
   def change
+    create_table :accounts do
+      t.timestamps
+    end
+
     create_table :users do |t|
       t.string 'name'
       t.integer 'counter'
+      t.references 'account'
       t.timestamps
     end
 


### PR DESCRIPTION
For https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1183

From my tests, using `_query_by_sql` to instrument is compatible with 7.0, 7.1 and 7.2, and is mostly equivalent to `find_by_sql`, with that one calling `_query_by_sql` itself. I believe this would be enough to bring back the same behavior we had in 6.1.

I am a bit conflicted with the name of these spans, since `find_by_sql` isn't entirely true anymore. Should they be called `_query_by_sql` in that case instead? Feels weird using the name of a private method, though. Should we do a more generic `read` or `query`? Help on this would be appreciated 😸 

Thank you!!