### PR TITLE
chore: Update webmock to 3.24.0

### DIFF
--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/action_mailer/opentelemetry-instrumentation-action_mailer.gemspec
+++ b/instrumentation/action_mailer/opentelemetry-instrumentation-action_mailer.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/aws_lambda/opentelemetry-instrumentation-aws_lambda.gemspec
+++ b/instrumentation/aws_lambda/opentelemetry-instrumentation-aws_lambda.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.19.1'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
+++ b/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
+++ b/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rails' if spec.respond_to?(:metadata)

--- a/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
+++ b/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.19'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/resources/azure/opentelemetry-resource-detector-azure.gemspec
+++ b/resources/azure/opentelemetry-resource-detector-azure.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17'
-  spec.add_development_dependency 'webmock', '~> 3.23.0'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)

--- a/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
+++ b/resources/google_cloud_platform/opentelemetry-resource-detector-google_cloud_platform.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.17'
-  spec.add_development_dependency 'webmock', '~> 3.23.0'
+  spec.add_development_dependency 'webmock', '~> 3.24.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Update the `webmock` gem for all gems in the repo. We had a mixed version requirement, some had a minor version lock and others had a patch version lock. Happy to revert back to a minor constraint if everyone would prefer.

This will close the related dependabot PRs.