### PR TITLE
chore: Update instrumentation/aws_sdk CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 
 resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
-instrumentation/aws_sdk/ @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/aws_sdk/ @jterapin @alextwoods @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
 instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 


### PR DESCRIPTION
The wonderful @jterapin and @alextwoods are members of the team at AWS who own the AWS SDK for Ruby. They've contributed a few changes to the aws_sdk instrumentation for enhanced compatibility with v2 and v3.

This commit adds them to the codeowners list for the opentelemetry-instrumentation-aws_sdk gem.

* https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1150
* https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1186 