### PR TITLE
feat: Set span error only for 5xx response range

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb
@@ -43,7 +43,6 @@ module OpenTelemetry
           include ::Rack::Events::Abstract
 
           OTEL_TOKEN_AND_SPAN = 'otel.rack.token_and_span'
-          GOOD_HTTP_STATUSES = (100..499)
 
           # Creates a server span for this current request using the incoming parent context
           # and registers them as the {current_span}
@@ -208,7 +207,7 @@ module OpenTelemetry
           end
 
           def add_response_attributes(span, response)
-            span.status = OpenTelemetry::Trace::Status.error unless GOOD_HTTP_STATUSES.include?(response.status.to_i)
+            span.status = OpenTelemetry::Trace::Status.error if response.server_error?
             attributes = extract_response_attributes(response)
             span.add_attributes(attributes)
           rescue StandardError => e

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -152,7 +152,7 @@ module OpenTelemetry
           end
 
           def set_attributes_after_request(span, status, headers, _response)
-            span.status = OpenTelemetry::Trace::Status.error unless (100..499).cover?(status.to_i)
+            span.status = OpenTelemetry::Trace::Status.error if (500..599).cover?(status.to_i)
             span.set_attribute('http.status_code', status)
 
             # NOTE: if data is available, it would be good to do this:

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/event_handler_test.rb
@@ -105,6 +105,19 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler' do
       _(proxy_event).must_be_nil
     end
 
+    describe 'with a hijacked response' do
+      let(:service) do
+        lambda do |env|
+          env['rack.hijack?'] = true
+          [-1, {}, []]
+        end
+      end
+
+      it 'sets the span status to "unset"' do
+        _(rack_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
+      end
+    end
+
     describe 'when baggage is set' do
       let(:headers) do
         Hash(

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -72,6 +72,19 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
     end
 
+    describe 'with a hijacked response' do
+      let(:app) do
+        lambda do |env|
+          env['rack.hijack?'] = true
+          [-1, {}, []]
+        end
+      end
+
+      it 'sets the span status to "unset"' do
+        _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
+      end
+    end
+
     it 'has no parent' do
       _(first_span.parent_span_id).must_equal OpenTelemetry::Trace::INVALID_SPAN_ID
     end


### PR DESCRIPTION
👋 Hello!

I ran into a very specific problem with the Rack instrumentation. 

When a Rails Action Cable requests get traced by the Rack instrument, the [response code returned by Rails is -1](https://github.com/rails/rails/blob/094aeca1378fd901510959a956fc887df745f153/actioncable/lib/action_cable/connection/client_socket.rb#L71-L74) and the body is empty as defined in [Rack Hijacking spec](https://github.com/rack/rack/blob/main/SPEC.rdoc#hijacking-). 

In a nutshell, Rack hijacking exists to allow an app to take over the response streaming object to do special things like switching protocol to a web socket (just like Action Cable does).

This currently makes the Rack instrumentation add an error on the span because `-1` is (rightfully) outside the defined good http statues (100..499).

https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/c2ffafc85527a415bbe6d0fccece1130201634c1/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb#L46
https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/c2ffafc85527a415bbe6d0fccece1130201634c1/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/event_handler.rb#L210-L215

This change will simply ignore the response object when the env marked the request as hijacked, which I think is was a Rack user would expect in this case.

Special thanks to @arielvalentin for pointing me to the Rack detailed spec when I initially asked the question about this problem in Slack [just here](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1729277160681719).