### PR TITLE
test: Add Rails 7.2 to Appraisals

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -95,6 +95,7 @@ runs:
       run: |
         # 💎 Install dependencies and generate appraisals 💎
         bundle install --quiet --jobs=3 --retry=4
+        bundle exec appraisal clean
         bundle exec appraisal generate
       working-directory: "${{ steps.setup.outputs.gem_dir }}"
 
@@ -105,7 +106,7 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
-            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --full-index --quiet --jobs=3 --retry=4 && \
+            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
             echo "::endgroup::"

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -94,7 +94,6 @@ runs:
       shell: bash
       run: |
         # 💎 Install dependencies and generate appraisals 💎
-        bundle update --bundler
         bundle install --quiet --jobs=3 --retry=4
         bundle exec appraisal generate
       working-directory: "${{ steps.setup.outputs.gem_dir }}"

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -94,6 +94,7 @@ runs:
       shell: bash
       run: |
         # 💎 Install dependencies and generate appraisals 💎
+        bundle update --bundler
         bundle install --quiet --jobs=3 --retry=4
         bundle exec appraisal generate
       working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -105,7 +106,7 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
-            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
+            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --full-index --quiet --jobs=3 --retry=4 && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
             echo "::endgroup::"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # Appraisals
 instrumentation/**/gemfiles
+instrumentation/**/tmp/**/*
 
 # Sqlite file for tests
 instrumentation/active_record/db
@@ -26,3 +27,4 @@ instrumentation/active_record/db
 .ruby-version
 
 tags
+!**/*/.gitkeep

--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-end
-
-appraise 'rails-7.1' do
-  gem 'rails', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'rails-7.2' do
-    gem 'rails', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "action_mailer-#{version}" do
+    gem 'rails', "~> #{version}"
   end
+end
+
+appraise 'action_mailer-latest' do
+  gem 'action_mailer', "~> #{version}"
 end

--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -10,10 +10,6 @@
   end
 end
 
-appraise 'action_mailer-latest' do
-  gem 'rails'
-end
-
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
   %w[7.2.0].each do |version|
     appraise "action_mailer-#{version}" do

--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -11,5 +11,5 @@
 end
 
 appraise 'action_mailer-latest' do
-  gem 'action_mailer', "~> #{version}"
+  gem 'action_mailer'
 end

--- a/instrumentation/action_mailer/Appraisals
+++ b/instrumentation/action_mailer/Appraisals
@@ -4,12 +4,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "action_mailer-#{version}" do
     gem 'rails', "~> #{version}"
   end
 end
 
 appraise 'action_mailer-latest' do
-  gem 'action_mailer'
+  gem 'rails'
+end
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "action_mailer-#{version}" do
+      gem 'rails', "~> #{version}"
+    end
+  end
+
+  appraise 'action_mailer-latest' do
+    gem 'rails'
+  end
 end

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "rails-#{version}" do
     gem 'rails', "~> #{version}"
   end
 end
 
-appraise 'rails-latest' do
-  gem 'rails'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "rails-#{version}" do
+      gem 'rails', "~> #{version}"
+    end
+  end
+
+  appraise 'rails-latest' do
+    gem 'rails'
+  end
 end

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-end
-
-appraise 'rails-7.1' do
-  gem 'rails', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'rails-7.2' do
-    gem 'rails', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "rails-#{version}" do
+    gem 'rails', "~> #{version}"
   end
+end
+
+appraise 'rails-latest' do
+  gem 'rails'
 end

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
-  spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 1.68.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.22.0'

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -16,7 +16,7 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
   let(:span) { exporter.finished_spans.last }
-  let(:rails_app) { DEFAULT_RAILS_APP }
+  let(:rails_app) { AppConfig.initialize_app }
   let(:config) { {} }
 
   # Clear captured spans

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -22,8 +22,3 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::ActionPack'
   c.add_span_processor span_processor
 end
-
-# Create a globally available Rails app, this should be used in test unless
-# specifically testing behaviour with different initialization configs.
-DEFAULT_RAILS_APP = AppConfig.initialize_app
-Rails.application = DEFAULT_RAILS_APP

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -30,7 +30,7 @@ module AppConfig
     case Rails.version
     when /^6\.1/
       apply_rails_6_1_configs(new_app)
-    when /^7\./
+    when /^7|8\./
       apply_rails_7_configs(new_app)
     end
 

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-class Application < Rails::Application; end
 require 'action_controller/railtie'
+class Application < Rails::Application; end
 require_relative 'middlewares'
 require_relative 'controllers'
 require_relative 'routes'

--- a/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
+++ b/instrumentation/action_pack/test/test_helpers/controllers/example_controller.rb
@@ -20,6 +20,6 @@ class ExampleController < ActionController::Base
   end
 
   def internal_server_error
-    raise :internal_server_error
+    raise 'internal_server_error'
   end
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-end
-
-appraise 'rails-7.1' do
-  gem 'rails', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'rails-7.2' do
-    gem 'rails', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "action_view-#{version}" do
+    gem 'rails', "~> #{version}"
   end
+end
+
+appraise 'action_view-latest' do
+  gem 'action_view', "~> #{version}"
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -11,5 +11,5 @@
 end
 
 appraise 'action_view-latest' do
-  gem 'action_view', "~> #{version}"
+  gem 'action_view'
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "action_view-#{version}" do
     gem 'rails', "~> #{version}"
   end
 end
 
-appraise 'action_view-latest' do
-  gem 'action_view'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "rails-#{version}" do
+      gem 'rails', "~> #{version}"
+    end
+  end
+
+  appraise 'rails-latest' do
+    gem 'rails'
+  end
 end

--- a/instrumentation/active_job/Appraisals
+++ b/instrumentation/active_job/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
   appraise "activejob-#{version}" do
     gem 'activejob', "~> #{version}"
   end

--- a/instrumentation/active_job/Appraisals
+++ b/instrumentation/active_job/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "activejob-#{version}" do
     gem 'activejob', "~> #{version}"
   end
 end
 
-appraise 'activejob-latest' do
-  gem 'activejob'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "activejob-#{version}" do
+      gem 'acivejob', "~> #{version}"
+    end
+  end
+
+  appraise 'activejob-latest' do
+    gem 'activejob'
+  end
 end

--- a/instrumentation/active_job/Appraisals
+++ b/instrumentation/active_job/Appraisals
@@ -13,7 +13,7 @@ end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
   %w[7.2.0].each do |version|
     appraise "activejob-#{version}" do
-      gem 'acivejob', "~> #{version}"
+      gem 'activejob', "~> #{version}"
     end
   end
 

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'activerecord-6.1' do
-  gem 'activerecord', '~> 6.1.0'
-end
-
-appraise 'activerecord-7.0' do
-  gem 'activerecord', '~> 7.0.0'
-end
-
-appraise 'activerecord-7.1' do
-  gem 'activerecord', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'activerecord-7.2' do
-    gem 'activerecord', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "activerecord-#{version}" do
+    gem 'activerecord', "~> #{version}"
   end
+end
+
+appraise 'activerecord-latest' do
+  gem 'activerecord'
 end

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -6,6 +6,7 @@
 
 %w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "activerecord-#{version}" do
+    gem 'sqlite3', '~> 1.4'
     gem 'activerecord', "~> #{version}"
   end
 end
@@ -13,6 +14,7 @@ end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
   %w[7.2.0].each do |version|
     appraise "activerecord-#{version}" do
+      gem 'sqlite3', '~> 1.4'
       gem 'activerecord', "~> #{version}"
     end
   end

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -18,6 +18,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
   end
 
   appraise 'activerecord-latest' do
+    gem 'sqlite3', '>= 2.1'
     gem 'activerecord'
   end
 end

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "activerecord-#{version}" do
     gem 'activerecord', "~> #{version}"
   end
 end
 
-appraise 'activerecord-latest' do
-  gem 'activerecord'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "activerecord-#{version}" do
+      gem 'activerecord', "~> #{version}"
+    end
+  end
+
+  appraise 'activerecord-latest' do
+    gem 'activerecord'
+  end
 end

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -12,5 +12,4 @@ group :test do
   gem 'byebug'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'pry-byebug'
-  gem 'sqlite3', '~> 1.4'
 end

--- a/instrumentation/active_support/Appraisals
+++ b/instrumentation/active_support/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "activesupport-#{version}" do
     gem 'activesupport', "~> #{version}"
   end
 end
 
-appraise 'activesupport-latest' do
-  gem 'activesupport'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "activesupport-#{version}" do
+      gem 'activesupport', "~> #{version}"
+    end
+  end
+
+  appraise 'activesupport-latest' do
+    gem 'activesupport'
+  end
 end

--- a/instrumentation/active_support/Appraisals
+++ b/instrumentation/active_support/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'activesupport-6.1' do
-  gem 'activesupport', '~> 6.1.0'
-end
-
-appraise 'activesupport-7.0' do
-  gem 'activesupport', '~> 7.0.0'
-end
-
-appraise 'activesupport-7.1' do
-  gem 'activesupport', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'activesupport-7.2' do
-    gem 'activesupport', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "activesupport-#{version}" do
+    gem 'activesupport', "~> #{version}"
   end
+end
+
+appraise 'activesupport-latest' do
+  gem 'activesupport'
 end

--- a/instrumentation/delayed_job/Appraisals
+++ b/instrumentation/delayed_job/Appraisals
@@ -4,18 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'delayed_job_4.1-rails-latest' do
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "delayed_job_4.1-activejob-#{version}" do
+    gem 'delayed_job', '~> 4.1'
+    gem 'activejob', "~> #{version}"
+  end
+end
+
+appraise 'delayed_job-activejob-latest' do
+  gem 'delayed_job'
   gem 'activejob'
-end
-
-appraise 'delayed_job_4.1-rails-7.1' do
-  gem 'activejob', '~> 7.1.0'
-end
-
-appraise 'delayed_job_4.1-rails-7.0' do
-  gem 'activejob', '~> 7.0.0'
-end
-
-appraise 'delayed_job-4.1-rails-6.1' do
-  gem 'activejob', '~> 6.1.0'
 end

--- a/instrumentation/delayed_job/Appraisals
+++ b/instrumentation/delayed_job/Appraisals
@@ -4,14 +4,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "delayed_job_4.1-activejob-#{version}" do
     gem 'delayed_job', '~> 4.1'
     gem 'activejob', "~> #{version}"
   end
 end
 
-appraise 'delayed_job-activejob-latest' do
-  gem 'delayed_job'
-  gem 'activejob'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "delayed_job-4.1-activejob-#{version}" do
+      gem 'delayed_job', '~> 4.1'
+      gem 'activejob', "~> #{version}"
+    end
+  end
+
+  appraise 'delayed_job-latest' do
+    gem 'delayed_job'
+    gem 'activejob'
+  end
 end

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -9,6 +9,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'delayed_job', '~> 4.1'
   gem 'opentelemetry-instrumentation-base', path: '../base'
 end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,12 +4,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+%w[6.1.0 7.0.0 7.1.0].each do |version|
   appraise "rails-#{version}" do
     gem 'rails', "~> #{version}"
   end
 end
 
-appraise 'rails-latest' do
-  gem 'rails'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  %w[7.2.0].each do |version|
+    appraise "rails-#{version}" do
+      gem 'rails', "~> #{version}"
+    end
+  end
+
+  appraise 'rails-latest' do
+    gem 'rails'
+  end
 end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,20 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-end
-
-appraise 'rails-7.1' do
-  gem 'rails', '~> 7.1.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  appraise 'rails-7.2' do
-    gem 'rails', '~> 7.2.0'
+%w[6.1.0 7.0.0 7.1.0 7.2.0].each do |version|
+  appraise "rails-#{version}" do
+    gem 'rails', "~> #{version}"
   end
+end
+
+appraise 'rails-latest' do
+  gem 'rails'
 end

--- a/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -12,7 +12,7 @@ describe OpenTelemetry::Instrumentation::Rails do
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
   let(:span) { exporter.finished_spans.last }
-  let(:rails_app) { DEFAULT_RAILS_APP }
+  let(:rails_app) { AppConfig.initialize_app }
 
   # Clear captured spans
   before { exporter.reset }

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -23,8 +23,3 @@ OpenTelemetry::SDK.configure do |c|
   c.use_all
   c.add_span_processor span_processor
 end
-
-# Create a globally available Rails app, this should be used in test unless
-# specifically testing behaviour with different initialization configs.
-DEFAULT_RAILS_APP = AppConfig.initialize_app
-Rails.application = DEFAULT_RAILS_APP

--- a/instrumentation/rails/test/instrumentation/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/instrumentation/test_helpers/app_config.rb
@@ -4,8 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-class Application < Rails::Application; end
 require 'action_controller/railtie'
+class Application < Rails::Application; end
+
 require_relative 'middlewares'
 require_relative 'controllers'
 require_relative 'routes'
@@ -46,9 +47,7 @@ module AppConfig
   private
 
   def remove_rack_middleware(application)
-    application.middleware.delete(
-      OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
-    )
+    application.middleware.delete(Rack::Events)
   end
 
   def add_exceptions_app(application)

--- a/instrumentation/rails/test/instrumentation/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/instrumentation/test_helpers/app_config.rb
@@ -28,7 +28,7 @@ module AppConfig
     case Rails.version
     when /^6\.1/
       apply_rails_6_1_configs(new_app)
-    when /^7\./
+    when /^7|8\./
       apply_rails_7_configs(new_app)
     end
 

--- a/instrumentation/rails/test/instrumentation/test_helpers/controllers/example_controller.rb
+++ b/instrumentation/rails/test/instrumentation/test_helpers/controllers/example_controller.rb
@@ -12,6 +12,6 @@ class ExampleController < ActionController::Base
   end
 
   def internal_server_error
-    raise :internal_server_error
+    raise 'internal_server_error'
   end
 end

--- a/instrumentation/rails/test/instrumentation/test_helpers/routes.rb
+++ b/instrumentation/rails/test/instrumentation/test_helpers/routes.rb
@@ -6,7 +6,7 @@
 
 def draw_routes(rails_app)
   rails_app.routes.draw do
-    get '/ok', to: 'example#ok'
+    get 'ok', to: 'example#ok'
     get '/internal_server_error', to: 'example#internal_server_error'
   end
 end


### PR DESCRIPTION
Now that Rails 8 has been released, we need to make sure our appraisals are up to date to explicitly include Rails 7.2