### PR TITLE
test: Fix Sinatra Tests

### DIFF
--- a/instrumentation/sinatra/Appraisals
+++ b/instrumentation/sinatra/Appraisals
@@ -4,16 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'sinatra-4.x' do
-  gem 'sinatra', '~> 4.0'
-end
-
-appraise 'sinatra-3.x' do
-  gem 'sinatra', '~> 3.0'
-end
-
-appraise 'sinatra-2.x' do
-  gem 'sinatra', '~> 2.1'
+%w[4.1 3.0 2.1].each do |version|
+  appraise "sinatra-#{version}" do
+    gem 'sinatra', "~> #{version}"
+  end
 end
 
 appraise 'sinatra-latest' do

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
 
   let(:app_one) do
     Class.new(Sinatra::Application) do
+      set :raise_errors, false
       get '/endpoint' do
         '1'
       end
@@ -41,6 +42,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
 
   let(:app_two) do
     Class.new(Sinatra::Application) do
+      set :raise_errors, false
       get '/endpoint' do
         '2'
       end
@@ -165,7 +167,8 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         'http.method' => 'GET',
         'http.route' => '/error',
         'http.scheme' => 'http',
-        'http.target' => '/error'
+        'http.target' => '/error',
+        'http.status_code' => 500
       )
       _(exporter.finished_spans.flat_map(&:events).map(&:name)).must_equal(['exception'])
     end

--- a/instrumentation/sinatra/test/test_helper.rb
+++ b/instrumentation/sinatra/test/test_helper.rb
@@ -3,6 +3,7 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+ENV['APP_ENV'] = 'test'
 
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)


### PR DESCRIPTION
Sinatra 4.1 now includes a stricter host authorization check by default, which caused our tests to fail.

The host authorization is not enforced in development and test mode so this PR sets the Sinatra environment to run in `test` mode.

See: https://github.com/sinatra/sinatra/pull/2053

fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1252