### PR TITLE
fix: pass block argument in ActiveRecord `find_by_sql` patch

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -20,9 +20,9 @@ module OpenTelemetry
           module ClassMethods
             method_name = ::ActiveRecord.version >= Gem::Version.new('7.0.0') ? :_query_by_sql : :find_by_sql
 
-            define_method(method_name) do |*args, **kwargs|
+            define_method(method_name) do |*args, **kwargs, &block|
               tracer.in_span("#{self} query") do
-                super(*args, **kwargs)
+                super(*args, **kwargs, &block)
               end
             end
 

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/querying_test.rb
@@ -14,6 +14,11 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::Querying do
   let(:spans) { exporter.finished_spans }
 
   before { exporter.reset }
+  after do
+    ActiveRecord::Base.subclasses.each do |model|
+      model.connection.truncate(model.table_name)
+    end
+  end
 
   describe 'query' do
     it 'traces' do
@@ -27,6 +32,80 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::Querying do
 
       _(user_find_spans.length).must_equal(2)
       _(account_find_span).wont_be_nil
+    end
+
+    describe 'find_by_sql' do
+      it 'creates a span' do
+        Account.create!
+
+        Account.find_by_sql('SELECT * FROM accounts')
+
+        account_find_span = spans.find { |s| s.name == 'Account query' }
+        _(account_find_span).wont_be_nil
+        _(account_find_span.attributes).must_be_empty
+      end
+
+      describe 'given a block' do
+        it 'creates a span' do
+          account = Account.create!
+
+          record_ids = []
+
+          Account.find_by_sql('SELECT * FROM accounts') do |record|
+            record_ids << record.id
+          end
+
+          account_find_span = spans.find { |s| s.name == 'Account query' }
+          _(account_find_span).wont_be_nil
+          _(account_find_span.attributes).must_be_empty
+
+          _(record_ids).must_equal([account.id])
+        end
+      end
+    end
+
+    describe 'find_by' do
+      it 'creates a span' do
+        account = Account.create!
+        User.create!(account: account)
+
+        Account.find_by(id: account.id)
+
+        account_find_span = spans.find { |s| s.name == 'Account query' }
+        _(account_find_span).wont_be_nil
+        _(account_find_span.attributes).must_be_empty
+      end
+    end
+
+    describe 'find' do
+      it 'creates a span' do
+        account = Account.create!
+        User.create!(account: account)
+
+        Account.find(account.id)
+
+        account_find_span = spans.find { |s| s.name == 'Account query' }
+        _(account_find_span).wont_be_nil
+        _(account_find_span.attributes).must_be_empty
+      end
+
+      describe 'given a block' do
+        it 'creates a span' do
+          account = Account.create!
+          User.create!(account: account)
+
+          record_ids = []
+
+          Account.find(account.id) do |record|
+            record_ids << record.id
+          end
+
+          account_find_span = spans.find { |s| s.name == 'Account query' }
+          _(account_find_span).wont_be_nil
+          _(account_find_span.attributes).must_be_empty
+          _(record_ids).must_equal([account.id])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`find_by_sql` takes a block as its final argument, which is neither a positional nor a keyword argument, hence we need to pass it explicitly; before this PR, the block was not passed to the `super()` call and hence not executed, thus altering application behavior.

Fixes #1258.