### PR TITLE
ci: fix installation tests.

### DIFF
--- a/instrumentation/grpc/lib/opentelemetry/instrumentation/grpc/version.rb
+++ b/instrumentation/grpc/lib/opentelemetry/instrumentation/grpc/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module Grpc
-      VERSION = "0.1.3"
+      VERSION = '0.1.3'
     end
   end
 end


### PR DESCRIPTION
Related Slack message: https://cloud-native.slack.com/archives/C01NWKKMKMY/p1732803872121489

Installation tests CI fails because of the double quotes in the GRPC instrumentation.