### PR TITLE
ci: 202 is Accepted for a non-dead link.

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -6,5 +6,5 @@
   ],
   "timeout": "5s",
   "retryOn429": true,
-  "aliveStatusCodes": [200, 206, 429]
+  "aliveStatusCodes": [200, 202, 206, 429]
 }


### PR DESCRIPTION
The Markdown Link Check job occasionally checks a link on rubydoc.info which needs to be rendered. In that case a HTTP `202` is returned.
However that leads to an error, e.g. [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/12072279789/job/33665893727?pr=1272#step:4:692):

```
ERROR: 1 dead links found!
[✖] https://www.rubydoc.info/gems/opentelemetry-propagator-ottrace → Status: 202
```

A HTTP `202` should be `Accepted`.