### PR TITLE
feat: Enable support for `Regexp` patterns when subscribing to Active Support's instrumentation Events

### DIFF
--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
         span_name_formatter: nil
       )
         subscriber = OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
-          name: pattern,
+          pattern: pattern,
           tracer: tracer,
           notification_payload_transform: notification_payload_transform,
           disallowed_notification_payload_keys: disallowed_notification_payload_keys,
@@ -64,8 +64,8 @@ module OpenTelemetry
         ALWAYS_VALID_PAYLOAD_TYPES = [TrueClass, FalseClass, String, Numeric, Symbol].freeze
 
         # rubocop:disable Metrics/ParameterLists
-        def initialize(name:, tracer:, notification_payload_transform: nil, disallowed_notification_payload_keys: nil, kind: nil, span_name_formatter: nil)
-          @pattern = name
+        def initialize(pattern:, tracer:, notification_payload_transform: nil, disallowed_notification_payload_keys: nil, kind: nil, span_name_formatter: nil)
+          @pattern = pattern
           @tracer = tracer
           @notification_payload_transform = notification_payload_transform
           @disallowed_notification_payload_keys = Array(disallowed_notification_payload_keys)

--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
@@ -65,7 +65,7 @@ module OpenTelemetry
 
         # rubocop:disable Metrics/ParameterLists
         def initialize(name:, tracer:, notification_payload_transform: nil, disallowed_notification_payload_keys: nil, kind: nil, span_name_formatter: nil)
-          @name = name
+          @pattern = name
           @tracer = tracer
           @notification_payload_transform = notification_payload_transform
           @disallowed_notification_payload_keys = Array(disallowed_notification_payload_keys)

--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/span_subscriber.rb
@@ -75,7 +75,7 @@ module OpenTelemetry
         # rubocop:enable Metrics/ParameterLists
 
         def start(name, id, payload)
-          span = @tracer.start_span(span_name(name).dup.freeze, kind: @kind)
+          span = @tracer.start_span(safe_span_name_for(name), kind: @kind)
           token = OpenTelemetry::Context.attach(
             OpenTelemetry::Trace.context_with_span(span)
           )
@@ -135,15 +135,6 @@ module OpenTelemetry
             value.to_s
           else
             value
-          end
-        end
-
-        def span_name(name)
-          case @name
-          when Regexp
-            safe_span_name_for(name)
-          else
-            @span_name ||= safe_span_name_for(@name)
           end
         end
 

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -201,7 +201,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
 
   describe 'instrument' do
     after do
-      ActiveSupport::Notifications.notifier.all_listeners_for(notification_name).each do |listener|
+      ActiveSupport::Notifications.notifier.listeners_for(notification_name).each do |listener|
         ActiveSupport::Notifications.unsubscribe(listener)
       end
     end
@@ -396,6 +396,12 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
       end
 
       it 'finishes spans even when block subscribers blow up' do
+        # This scenario cannot be exercised reliably on Active Support < 7.0 since the #finish method
+        # will never be called by the notifier if another subscriber raises an error.
+        #
+        # See this PR for additional details: https://github.com/rails/rails/pull/43282
+        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new("7.0")
+
         ActiveSupport::Notifications.subscribe(notification_pattern) { raise 'boom' }
         OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
 
@@ -409,6 +415,12 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
       end
 
       it 'finishes spans even when complex subscribers blow up' do
+        # This scenario cannot be exercised reliably on Active Support < 7.0 since the #finish method
+        # will never be called by the notifier if another subscriber raises an error.
+        #
+        # See this PR for additional details: https://github.com/rails/rails/pull/43282
+        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new("7.0")
+
         ActiveSupport::Notifications.subscribe(notification_pattern, CrashingEndSubscriber.new)
         OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
 

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -15,7 +15,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
   let(:notification_name) { 'bar.foo' }
   let(:subscriber) do
     OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
-      name: notification_name,
+      pattern: notification_name,
       tracer: tracer,
       kind: span_kind
     )
@@ -37,7 +37,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
 
   it 'uses the provided tracer' do
     subscriber = OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
-      name: 'oh.hai',
+      pattern: 'oh.hai',
       tracer: OpenTelemetry.tracer_provider.tracer('foo')
     )
     span, = subscriber.start('oh.hai', 'abc', {})
@@ -111,7 +111,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
   describe 'instrumentation option - disallowed_notification_payload_keys' do
     let(:subscriber) do
       OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
-        name: notification_name,
+        pattern: notification_name,
         tracer: tracer,
         notification_payload_transform: nil,
         disallowed_notification_payload_keys: [:foo]
@@ -149,7 +149,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
     let(:transformer_proc) { ->(v) { v.transform_values { 'optimus prime' } } }
     let(:subscriber) do
       OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
-        name: notification_name,
+        pattern: notification_name,
         tracer: tracer,
         notification_payload_transform: transformer_proc,
         disallowed_notification_payload_keys: [:foo]

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -400,7 +400,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
         # will never be called by the notifier if another subscriber raises an error.
         #
         # See this PR for additional details: https://github.com/rails/rails/pull/43282
-        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new("7.0")
+        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new('7.0')
 
         ActiveSupport::Notifications.subscribe(notification_pattern) { raise 'boom' }
         OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
@@ -419,7 +419,7 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
         # will never be called by the notifier if another subscriber raises an error.
         #
         # See this PR for additional details: https://github.com/rails/rails/pull/43282
-        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new("7.0")
+        skip 'Notifications will be broken in this scenario on Active Support < 7.0' if ActiveSupport.version < Gem::Version.new('7.0')
 
         ActiveSupport::Notifications.subscribe(notification_pattern, CrashingEndSubscriber.new)
         OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -205,123 +205,226 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
   end
 
   describe 'instrument' do
-    before do
-      ActiveSupport::Notifications.unsubscribe(notification_name)
-    end
-
-    it 'does not trace an event by default' do
-      ActiveSupport::Notifications.subscribe(notification_name) do
-        # pass
-      end
-      ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-      _(last_span).must_be_nil
-    end
-
-    it 'traces an event when a span subscriber is used' do
-      OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
-      ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-      _(last_span).wont_be_nil
-      _(last_span.name).must_equal(notification_name)
-      _(last_span.attributes['extra']).must_equal('context')
-      _(last_span.kind).must_equal(:internal)
-    end
-
-    describe 'when using a custom span name formatter' do
-      describe 'when using the LEGACY_NAME_FORMATTER' do
-        let(:span_name_formatter) { OpenTelemetry::Instrumentation::ActiveSupport::LEGACY_NAME_FORMATTER }
-        it 'uses the user supplied formatter' do
-          OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: span_name_formatter)
-          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-          _(last_span).wont_be_nil
-          _(last_span.name).must_equal('foo bar')
-          _(last_span.attributes['extra']).must_equal('context')
-        end
-      end
-
-      describe 'when using a custom formatter' do
-        let(:span_name_formatter) { ->(name) { "custom.#{name}" } }
-
-        it 'uses the user supplied formatter' do
-          OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: span_name_formatter)
-          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-          _(last_span).wont_be_nil
-          _(last_span.name).must_equal('custom.bar.foo')
-          _(last_span.attributes['extra']).must_equal('context')
-        end
-      end
-
-      describe 'when using a invalid formatter' do
-        it 'defaults to the notification name' do
-          OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) {})
-          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-          _(last_span).wont_be_nil
-          _(last_span.name).must_equal(notification_name)
-          _(last_span.attributes['extra']).must_equal('context')
-        end
-      end
-
-      describe 'when using a unstable formatter' do
-        it 'defaults to the notification name' do
-          allow(OpenTelemetry).to receive(:handle_error).with(exception: RuntimeError, message: String)
-
-          OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
-          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-          _(last_span).wont_be_nil
-          _(last_span.name).must_equal(notification_name)
-          _(last_span.attributes['extra']).must_equal('context')
-        end
+    after do
+      ActiveSupport::Notifications.notifier.all_listeners_for(notification_name).each do |listener|
+        ActiveSupport::Notifications.unsubscribe(listener)
       end
     end
 
-    it 'finishes spans even when block subscribers blow up' do
-      ActiveSupport::Notifications.subscribe(notification_name) { raise 'boom' }
-      OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
-
-      expect do
+    describe 'when subscribing to events directly' do
+      it 'does not trace an event by default' do
+        ActiveSupport::Notifications.subscribe(notification_name) do
+          # pass
+        end
         ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-      end.must_raise RuntimeError
+        _(last_span).must_be_nil
+      end
 
-      _(last_span).wont_be_nil
-      _(last_span.name).must_equal(notification_name)
-      _(last_span.attributes['extra']).must_equal('context')
-    end
-
-    it 'finishes spans even when complex subscribers blow up' do
-      ActiveSupport::Notifications.subscribe(notification_name, CrashingEndSubscriber.new)
-      OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
-
-      expect do
+      it 'traces an event when a span subscriber is used' do
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
         ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-      end.must_raise RuntimeError
 
-      _(last_span).wont_be_nil
-      _(last_span.name).must_equal(notification_name)
-      _(last_span.attributes['extra']).must_equal('context')
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+        _(last_span.kind).must_equal(:internal)
+      end
+
+      describe 'when using a custom span name formatter' do
+        describe 'when using the LEGACY_NAME_FORMATTER' do
+          let(:span_name_formatter) { OpenTelemetry::Instrumentation::ActiveSupport::LEGACY_NAME_FORMATTER }
+          it 'uses the user supplied formatter' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: span_name_formatter)
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal('foo bar')
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a custom formatter' do
+          let(:span_name_formatter) { ->(name) { "custom.#{name}" } }
+
+          it 'uses the user supplied formatter' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: span_name_formatter)
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal('custom.bar.foo')
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a invalid formatter' do
+          it 'defaults to the notification name' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) {})
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal(notification_name)
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a unstable formatter' do
+          it 'defaults to the notification name' do
+            allow(OpenTelemetry).to receive(:handle_error).with(exception: RuntimeError, message: String)
+
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal(notification_name)
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+      end
+
+      it 'finishes spans even when block subscribers blow up' do
+        ActiveSupport::Notifications.subscribe(notification_name) { raise 'boom' }
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
+
+        expect do
+          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+        end.must_raise RuntimeError
+
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+      end
+
+      it 'finishes spans even when complex subscribers blow up' do
+        ActiveSupport::Notifications.subscribe(notification_name, CrashingEndSubscriber.new)
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
+
+        expect do
+          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+        end.must_raise RuntimeError
+
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+      end
+
+      it 'supports unsubscribe' do
+        obj = OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
+        ActiveSupport::Notifications.unsubscribe(obj)
+
+        ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+        _(obj.class).must_equal(ActiveSupport::Notifications::Fanout::Subscribers::Evented)
+        _(last_span).must_be_nil
+      end
+
+      it 'supports setting the span kind' do
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, 'bar.foo', nil, [], kind: :client)
+        ActiveSupport::Notifications.instrument('bar.foo', extra: 'context')
+
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal('bar.foo')
+        _(last_span.attributes['extra']).must_equal('context')
+        _(last_span.kind).must_equal(:client)
+      end
     end
 
-    it 'supports unsubscribe' do
-      obj = OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name)
-      ActiveSupport::Notifications.unsubscribe(obj)
+    describe 'when subscribing to events matching a regular expression' do
+      let(:notification_pattern) { /.*\.foo/ }
 
-      ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+      it 'does not trace an event by default' do
+        ActiveSupport::Notifications.subscribe(notification_pattern) do
+          # pass
+        end
+        ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+        _(last_span).must_be_nil
+      end
 
-      _(obj.class).must_equal(ActiveSupport::Notifications::Fanout::Subscribers::Evented)
-      _(last_span).must_be_nil
-    end
+      it 'traces an event when a span subscriber is used' do
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
+        ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
 
-    it 'supports setting the span kind' do
-      OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, 'bar.foo', nil, [], kind: :client)
-      ActiveSupport::Notifications.instrument('bar.foo', extra: 'context')
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+        _(last_span.kind).must_equal(:internal)
+      end
 
-      _(last_span).wont_be_nil
-      _(last_span.name).must_equal('bar.foo')
-      _(last_span.attributes['extra']).must_equal('context')
-      _(last_span.kind).must_equal(:client)
+      describe 'when using a custom span name formatter' do
+        describe 'when using the LEGACY_NAME_FORMATTER' do
+          let(:span_name_formatter) { OpenTelemetry::Instrumentation::ActiveSupport::LEGACY_NAME_FORMATTER }
+          it 'uses the user supplied formatter' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: span_name_formatter)
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal('foo bar')
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a custom formatter' do
+          let(:span_name_formatter) { ->(name) { "custom.#{name}" } }
+
+          it 'uses the user supplied formatter' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: span_name_formatter)
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal('custom.bar.foo')
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a invalid formatter' do
+          it 'defaults to the notification name' do
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: ->(_) {})
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal(notification_name)
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+
+        describe 'when using a unstable formatter' do
+          it 'defaults to the notification name' do
+            allow(OpenTelemetry).to receive(:handle_error).with(exception: RuntimeError, message: String)
+
+            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
+            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+
+            _(last_span).wont_be_nil
+            _(last_span.name).must_equal(notification_name)
+            _(last_span.attributes['extra']).must_equal('context')
+          end
+        end
+      end
+
+      it 'finishes spans even when block subscribers blow up' do
+        ActiveSupport::Notifications.subscribe(notification_pattern) { raise 'boom' }
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
+
+        expect do
+          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+        end.must_raise RuntimeError
+
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+      end
+
+      it 'finishes spans even when complex subscribers blow up' do
+        ActiveSupport::Notifications.subscribe(notification_pattern, CrashingEndSubscriber.new)
+        OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern)
+
+        expect do
+          ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
+        end.must_raise RuntimeError
+
+        _(last_span).wont_be_nil
+        _(last_span.name).must_equal(notification_name)
+        _(last_span.attributes['extra']).must_equal('context')
+      end
     end
   end
 end

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -35,11 +35,6 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
     instrumentation.install({})
   end
 
-  it 'memoizes the span name' do
-    span, = subscriber.start('oh.hai', 'abc', {})
-    _(span.name).must_equal(notification_name)
-  end
-
   it 'uses the provided tracer' do
     subscriber = OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber.new(
       name: 'oh.hai',


### PR DESCRIPTION
This PR aims to introduce support for `Regexp` patterns to the `OpenTelemetry::Instrumentation::ActiveSupport.subscribe` method.

This should be in line with [a similar feature available on `ActiveSupport::Notifications.subscribe`](https://guides.rubyonrails.org/active_support_instrumentation.html#subscribing-to-an-event).

With this update, users will be able to:
1. Subscribe to multiple events at once, if desired.
2. Use the `Regexp` pattern directly without having to resort to a custom `span_name_formatter` to work around crashes when processing the event name.
3. Process the incoming event name if `span_name_formatter` is set, since the `name` parameter in the initializer includes a reference to the `Regexp` pattern in this case.