### PR TITLE
test: loosen the koala pin to ~> 3.0

### DIFF
--- a/instrumentation/koala/Appraisals
+++ b/instrumentation/koala/Appraisals
@@ -4,6 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 appraise 'koala-3' do
-  gem 'koala', '~> 3.0.0'
+  gem 'koala', '~> 3.0'
   gem 'faraday', '< 2.0'
 end


### PR DESCRIPTION
The `~> 3.0.0` pin of the koala lib restricted the instrumentation to always be tested against a (7-year old) 3.0.x version. I think it's viable to loosen this restriction and enable testing against `3.x` version.

This change also resolves the issue of a failing pipeline, as version `3.0.0` is incompatible with the `faraday-multipart 1.1.0` dependency. For reference, here’s an example of the failure: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/12399050526/job/34613192801