### PR TITLE
fix: Update instrumentation pg to support merge statements

### DIFF
--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
@@ -40,9 +40,9 @@ module OpenTelemetry
           LISTEN
           LOAD
           LOCK
+          MERGE
           MOVE
           NOTIFY
-          PREPARE
           PREPARE
           REASSIGN
           REFRESH
@@ -53,7 +53,6 @@ module OpenTelemetry
           ROLLBACK
           SAVEPOINT
           SECURITY
-          SELECT
           SELECT
           SET
           SHOW

--- a/instrumentation/pg/test/fixtures/sql_table_name.json
+++ b/instrumentation/pg/test/fixtures/sql_table_name.json
@@ -57,6 +57,6 @@
     },
     {
       "name": "merge",
-      "sql": "MERGE into test_table using other_table on other_table.id = test_table.id WHEN matched then update set x = test_table.x + 1 when not matched then insert (id,x,status) values (other_table.id,other_table.x,other_table.status); "
+      "sql": "MERGE into test_table using other_table on other_table.id = test_table.id WHEN matched then update set x = test_table.x + 1 when not matched then insert (id,x,status) values (other_table.id,other_table.x,other_table.status)"
     }
 ]

--- a/instrumentation/pg/test/fixtures/sql_table_name.json
+++ b/instrumentation/pg/test/fixtures/sql_table_name.json
@@ -57,6 +57,6 @@
     },
     {
       "name": "merge",
-      "sql": "MERGE into test_table using other_table on other_table.id = test_table.id WHEN matched then update set x = test_table.x + 1 when not matched then insert (id,x,status) values (other_table.id,other_table.x,other_table.status)"
+      "sql": "MERGE INTO test_table AS t USING other_table AS o ON (o.id = t.id) WHEN MATCHED THEN UPDATE SET x = t.x + 1 WHEN NOT MATCHED THEN INSERT (id, x, status) VALUES (o.id, o.x, o.status)"
     }
 ]

--- a/instrumentation/pg/test/fixtures/sql_table_name.json
+++ b/instrumentation/pg/test/fixtures/sql_table_name.json
@@ -54,5 +54,9 @@
     {
       "name": "table_name_with_double_quotes",
       "sql": "SELECT columns FROM \"test_table\""
+    },
+    {
+      "name": "merge",
+      "sql": "MERGE into test_table using other_table on other_table.id = test_table.id WHEN matched then update set x = test_table.x + 1 when not matched then insert (id,x,status) values (other_table.id,other_table.x,other_table.status); "
     }
 ]


### PR DESCRIPTION
### Summary 

In postgres15+, the MERGE statement was added

https://www.postgresql.org/docs/current/sql-commands.html
https://www.postgresql.org/docs/current/sql-merge.html

we don't support it currently in our hard coded list of pg sql command constants(_which was contributed before `MERGE` was added, iiuc_), which results in missing `db.operation` attributes and `db.statement` attributes that look like `;` on pg spans for `merge` statements, which isn't very useful.

This PR adds `MERGE` to our constants list, and also cleans up some duplicate entries :)

### Notes

This was surfaced in cncf slack, i think my tests should pass but letting the ci do the work.

Hope everyone is doing well.



