### PR TITLE
Fix "unknown keyword: :label" ArgumentError in Rdkafka

### DIFF
--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/producer.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/patches/producer.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       module Patches
         # The Producer module contains the instrumentation patch the Producer#produce method
         module Producer
-          def produce(topic:, payload: nil, key: nil, partition: nil, partition_key: nil, timestamp: nil, headers: nil)
+          def produce(topic:, payload: nil, key: nil, partition: nil, partition_key: nil, timestamp: nil, headers: nil, label: nil)
             attributes = {
               'messaging.system' => 'kafka',
               'messaging.destination' => topic,


### PR DESCRIPTION
Support for adding a label to a kafka payload(within rdkafka) was added in v0.15.0. https://github.com/karafka/rdkafka-ruby/pull/381
This PR updates the method signature to allow `label` keyword argument.