### PR TITLE
feat: gradually add metrics capabilities to Instrumentation::Base

### DIFF
--- a/instrumentation/base/Appraisals
+++ b/instrumentation/base/Appraisals
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+appraise 'base' do # rubocop: disable Lint/EmptyBlock
+end
+
+appraise 'metrics-api' do
+  gem 'opentelemetry-metrics-api'
+end
+
+appraise 'metrics-sdk' do
+  gem 'opentelemetry-sdk'
+  gem 'opentelemetry-metrics-sdk'
+end

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -6,4 +6,6 @@
 
 source 'https://rubygems.org'
 
+gem 'opentelemetry-test-helpers', github: 'zvkemp/opentelemetry-ruby', ref: 'test-helpers-metrics'
+
 gemspec

--- a/instrumentation/base/lib/opentelemetry/instrumentation/metrics.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/metrics.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+begin
+  # mitigate potential load order issues by always requiring
+  # the metrics-api gem if it is in the bundle. This module is
+  # intended to function with or without it, but loading it after
+  # any of the definition queries have been made may cause false negatives.
+  require 'opentelemetry-metrics-api'
+rescue LoadError # rubocop: disable Lint/SuppressedException
+end
+
+module OpenTelemetry
+  module Instrumentation
+    # Extensions to Instrumentation::Base that handle metrics instruments.
+    # The goal here is to allow metrics to be added gradually to instrumentation libraries,
+    # without requiring that the metrics-sdk or metrics-api gems are present in the bundle
+    # (if they are not, or if the metrics-api gem does not meet the minimum version requirement,
+    # the no-op edition is installed.)
+    module Metrics
+      METER_TYPES = %i[
+        counter
+        observable_counter
+        histogram
+        gauge
+        observable_gauge
+        up_down_counter
+        observable_up_down_counter
+      ].freeze
+
+      def self.prepended(base)
+        base.prepend(Compatibility)
+        base.extend(Compatibility)
+        base.extend(Registration)
+
+        if base.metrics_compatible?
+          base.prepend(Extensions)
+        else
+          base.prepend(NoopExtensions)
+        end
+      end
+
+      # Methods to check whether the metrics API is defined
+      # and is a compatible version
+      module Compatibility
+        METRICS_API_MINIMUM_GEM_VERSION = Gem::Version.new('0.2.0')
+
+        def metrics_defined?
+          defined?(OpenTelemetry::Metrics)
+        end
+
+        def metrics_compatible?
+          metrics_defined? && Gem.loaded_specs['opentelemetry-metrics-api'].version >= METRICS_API_MINIMUM_GEM_VERSION
+        end
+
+        extend(self)
+      end
+
+      # class-level methods to declare and register metrics instruments.
+      # This can be extended even if metrics is not active or present.
+      module Registration
+        METER_TYPES.each do |instrument_kind|
+          define_method(instrument_kind) do |name, **opts, &block|
+            opts[:callback] ||= block if block
+            register_instrument(instrument_kind, name, **opts)
+          end
+        end
+
+        def register_instrument(kind, name, **opts)
+          key = [kind, name]
+          if instrument_configs.key?(key)
+            warn("Duplicate instrument configured for #{self}: #{key.inspect}")
+          else
+            instrument_configs[key] = opts
+          end
+        end
+
+        def instrument_configs
+          @instrument_configs ||= {}
+        end
+      end
+
+      # No-op instance methods for metrics instruments.
+      module NoopExtensions
+        METER_TYPES.each do |kind|
+          define_method(kind) { |*, **| } # rubocop: disable Lint/EmptyBlock
+        end
+
+        def with_meter; end
+
+        def metrics_enabled?
+          false
+        end
+      end
+
+      # Instance methods for metrics instruments.
+      module Extensions
+        %i[
+          counter
+          observable_counter
+          histogram
+          gauge
+          observable_gauge
+          up_down_counter
+          observable_up_down_counter
+        ].each do |kind|
+          define_method(kind) do |name|
+            get_metrics_instrument(kind, name)
+          end
+        end
+
+        # This is based on a variety of factors, and should be invalidated when @config changes.
+        # It should be explicitly set in `prepare_install` for now.
+        def metrics_enabled?
+          !!@metrics_enabled
+        end
+
+        # @api private
+        # ONLY yields if the meter is enabled.
+        def with_meter
+          yield @meter if metrics_enabled?
+        end
+
+        private
+
+        def compute_metrics_enabled
+          return false unless metrics_compatible?
+          return false if metrics_disabled_by_env_var?
+
+          !!@config[:metrics] || metrics_enabled_by_env_var?
+        end
+
+        # Checks if this instrumentation's metrics are enabled by env var.
+        # This follows the conventions as outlined above, using `_METRICS_ENABLED` as a suffix.
+        # Unlike INSTRUMENTATION_*_ENABLED variables, these are explicitly opt-in (i.e.
+        # if the variable is unset, and `metrics: true` is not in the instrumentation's config,
+        # the metrics will not be enabled)
+        def metrics_enabled_by_env_var?
+          ENV.key?(metrics_env_var_name) && ENV[metrics_env_var_name] != 'false'
+        end
+
+        def metrics_disabled_by_env_var?
+          ENV[metrics_env_var_name] == 'false'
+        end
+
+        def metrics_env_var_name
+          @metrics_env_var_name ||=
+            begin
+              var_name = name.dup
+              var_name.upcase!
+              var_name.gsub!('::', '_')
+              var_name.gsub!('OPENTELEMETRY_', 'OTEL_RUBY_')
+              var_name << '_METRICS_ENABLED'
+              var_name
+            end
+        end
+
+        def prepare_install
+          @metrics_enabled = compute_metrics_enabled
+          if metrics_defined?
+            @metrics_instruments = {}
+            @instrument_mutex = Mutex.new
+          end
+
+          @meter = OpenTelemetry.meter_provider.meter(name, version: version) if metrics_enabled?
+
+          super
+        end
+
+        def get_metrics_instrument(kind, name)
+          # TODO: we should probably return *something*
+          # if metrics is not enabled, but if the api is undefined,
+          # it's unclear exactly what would be suitable.
+          # For now, there are no public methods that call this
+          # if metrics isn't defined.
+          return unless metrics_defined?
+
+          @metrics_instruments.fetch([kind, name]) do |key|
+            @instrument_mutex.synchronize do
+              @metrics_instruments[key] ||= create_configured_instrument(kind, name)
+            end
+          end
+        end
+
+        def create_configured_instrument(kind, name)
+          config = self.class.instrument_configs[[kind, name]]
+
+          if config.nil?
+            Kernel.warn("unconfigured instrument requested: #{kind} of '#{name}'")
+            return
+          end
+
+          meter.public_send(:"create_#{kind}", name, **config)
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
   spec.add_dependency 'opentelemetry-registry', '~> 0.1'
 
+  spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/base/test/instrumentation/metrics_test.rb
+++ b/instrumentation/base/test/instrumentation/metrics_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Instrumentation::Metrics do
+  let(:instrumentation_with_metrics) do
+    Class.new(OpenTelemetry::Instrumentation::Base) do
+      instrumentation_name 'test_instrumentation'
+      instrumentation_version '0.1.1'
+
+      option :metrics, default: false, validate: :boolean
+
+      install { true }
+      present { true }
+
+      if defined?(OpenTelemetry::Metrics)
+        counter 'example.counter'
+        observable_counter 'example.observable_counter'
+        histogram 'example.histogram'
+        gauge 'example.gauge'
+        observable_gauge 'example.observable_gauge'
+        up_down_counter 'example.up_down_counter'
+        observable_up_down_counter 'example.observable_up_down_counter'
+      end
+
+      def example_counter
+        counter 'example.counter'
+      end
+
+      def example_observable_counter
+        observable_counter 'example.observable_counter'
+      end
+
+      def example_histogram
+        histogram 'example.histogram'
+      end
+
+      def example_gauge
+        gauge 'example.gauge'
+      end
+
+      def example_observable_gauge
+        observable_gauge 'example.observable_gauge'
+      end
+
+      def example_up_down_counter
+        up_down_counter 'example.up_down_counter'
+      end
+
+      def example_observable_up_down_counter
+        observable_up_down_counter 'example.observable_up_down_counter'
+      end
+    end
+  end
+
+  let(:config) { {} }
+  let(:instance) { instrumentation_with_metrics.instance }
+
+  before do
+    instance.install(config)
+  end
+
+  if defined?(OpenTelemetry::Metrics)
+    describe 'with the metrics api' do
+      it 'is disabled by default' do
+        _(instance.metrics_enabled?).must_equal false
+      end
+
+      it 'returns a no-op counter' do
+        counter = instance.example_counter
+        _(counter).must_be_kind_of(OpenTelemetry::Metrics::Instrument::Counter)
+      end
+
+      describe 'with the option enabled' do
+        let(:config) { { metrics: true } }
+
+        it 'will be enabled' do
+          _(instance.metrics_enabled?).must_equal true
+        end
+
+        it 'returns a counter', with_metrics_sdk: true do
+          counter = instance.example_counter
+
+          _(counter).must_be_kind_of(OpenTelemetry::SDK::Metrics::Instrument::Counter)
+        end
+      end
+    end
+  else
+    describe 'without the metrics api' do
+      it 'will not be enabled' do
+        _(instance.metrics_enabled?).must_equal false
+      end
+
+      it 'returns no instruments' do
+        counter = instance.example_counter
+        _(counter).must_be_nil
+      end
+
+      describe 'with the option enabled' do
+        let(:config) { { metrics: true } }
+
+        it 'will not be enabled' do
+          _(instance.metrics_enabled?).must_equal false
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/base/test/test_helper.rb
+++ b/instrumentation/base/test/test_helper.rb
@@ -12,3 +12,6 @@ require 'opentelemetry-instrumentation-base'
 require 'minitest/autorun'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
+
+OpenTelemetry::SDK.configure if defined?(OpenTelemetry::SDK)
+require 'opentelemetry/test_helpers/metrics'


### PR DESCRIPTION
Proposed implementation for adding **optional** metrics capabilities to existing instrumentation libraries.

See https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1377, https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1314, or https://github.com/zvkemp/opentelemetry-ruby-contrib/pull/1 (example of observables) for example implementations. (<- note that these PRs are based on top of this branch, so you may see some duplication between here and there)

Proposed api:

- Libraries with metrics must add a boolean option called `:metrics`.
- Each instrument is configured at compile/boot time — this prevents library authors from creating instruments which are identically named, but have different attributes, callbacks, or advisory parameters, which makes registering them quite difficult. The intention here is that they are declared once in the instrumentation, then subsequent lookups in the instrumentation _instance_ will spawn the instrument (if it has not been spawned already).
- All of the logic in base/metrics works in the absence of metrics-sdk or metrics-api, so library authors can add metrics to libraries without requiring users to use the metrics system at all. This means that any of the instrument-lookup instance methods may return nil (so this will need to be handled, e.g. via short-circuiting https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1377/files#diff-6732dfa68439092c8ae9c61ca4dfd067a76e48f9cb6e37768b12aedb5cfb7f50R20)

TODO:
- [ ] requires https://github.com/open-telemetry/opentelemetry-ruby/pull/1804
- [ ] [FIXME](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1324/files#diff-7379de806670e7a913ebbe1d8e27945a6367cc83c94d79e55434de15cdd16732R365) should instruments not declared in advance return a valid instrument anyway?
- [x] ensure instrument opts are forwarded correctly, or validate them when they are declared
- [x] dependency load order is very important here; if the Metrics API isn't loaded before Instrumentation::Base, the conditional definitions are not run. We either need to hook into `Kernel.require` and detect when Metrics is loaded (probably too perilous to really consider, as any instrumentations with conditional metrics will need to be re-evaluated at this time), or eagerly attempt to require the metrics-api gem when Instrumentation::Base is loaded.