### PR TITLE
fix: strict rdkafka support to v0.14

### DIFF
--- a/instrumentation/rdkafka/Appraisals
+++ b/instrumentation/rdkafka/Appraisals
@@ -4,12 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rdkafka-0.12.x' do
-  gem 'rdkafka', '~> 0.12.0'
-end
-
-appraise 'rdkafka-0.13.x' do
-  gem 'rdkafka', '~> 0.13.0'
+%w[0.12.0 0.13.0 0.14.0].each do |version|
+  appraise "rdkafka-#{version}" do
+    gem 'rdkafka', "~> #{version}"
+  end
 end
 
 appraise 'rdkafka-latest' do

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
@@ -10,7 +10,8 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the Rdkafka instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          Gem::Requirement.new('>= 0.10.0', '< 0.15.0').satisfied_by?(::Rdkafka::VERSION)
+          gem_version = Gem::Version(::Rdkafka::VERSION)
+          Gem::Requirement.new('>= 0.10.0', '< 0.15.0').satisfied_by?(gem_version)
         end
 
         install do |_config|

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the Rdkafka instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         compatible do
-          gem_version = Gem::Version(::Rdkafka::VERSION)
+          gem_version = Gem::Version.new(::Rdkafka::VERSION)
           Gem::Requirement.new('>= 0.10.0', '< 0.15.0').satisfied_by?(gem_version)
         end
 

--- a/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
+++ b/instrumentation/rdkafka/lib/opentelemetry/instrumentation/rdkafka/instrumentation.rb
@@ -9,10 +9,8 @@ module OpenTelemetry
     module Rdkafka
       # The Instrumentation class contains logic to detect and install the Rdkafka instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('0.10.0')
-
         compatible do
-          Gem::Version.new(::Rdkafka::VERSION) >= MINIMUM_VERSION
+          Gem::Requirement.new('>= 0.10.0', '< 0.15.0').satisfied_by?(::Rdkafka::VERSION)
         end
 
         install do |_config|

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/instrumentation_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/instrumentation_test.rb
@@ -22,6 +22,7 @@ describe OpenTelemetry::Instrumentation::Rdkafka do
 
   describe '#install' do
     it 'accepts argument' do
+      skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.compatible?
       _(instrumentation.install({})).must_equal(true)
       instrumentation.instance_variable_set(:@installed, false)
     end

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
@@ -33,6 +33,8 @@ unless ENV['OMIT_SERVICES']
 
     describe '#each' do
       it 'traces each call' do
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-trace-#{rand_hash}"
         config = { 'bootstrap.servers': "#{host}:#{port}" }
@@ -112,6 +114,8 @@ unless ENV['OMIT_SERVICES']
       end
 
       it 'encodes messages keys depending on input format' do
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-trace-#{rand_hash}"
         config = { 'bootstrap.servers': "#{host}:#{port}" }
@@ -164,6 +168,8 @@ unless ENV['OMIT_SERVICES']
 
     describe '#each_batch' do
       it 'traces each_batch call' do
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-batch-trace-#{rand_hash}"
         config = { 'bootstrap.servers': "#{host}:#{port}" }

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/consumer_test.rb
@@ -33,7 +33,7 @@ unless ENV['OMIT_SERVICES']
 
     describe '#each' do
       it 'traces each call' do
-        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.compatible?
 
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-trace-#{rand_hash}"
@@ -114,7 +114,7 @@ unless ENV['OMIT_SERVICES']
       end
 
       it 'encodes messages keys depending on input format' do
-        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.compatible?
 
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-trace-#{rand_hash}"
@@ -168,7 +168,7 @@ unless ENV['OMIT_SERVICES']
 
     describe '#each_batch' do
       it 'traces each_batch call' do
-        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.compatible?
 
         rand_hash = SecureRandom.hex(10)
         topic_name = "consumer-patch-batch-trace-#{rand_hash}"

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
@@ -32,7 +32,7 @@ unless ENV['OMIT_SERVICES']
 
     describe 'tracing' do
       it 'traces sync produce calls' do
-        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.compatible?
         topic_name = 'producer-patch-trace'
         config = { 'bootstrap.servers': "#{host}:#{port}" }
 

--- a/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
+++ b/instrumentation/rdkafka/test/opentelemetry/instrumentation/rdkafka/patches/producer_test.rb
@@ -32,6 +32,7 @@ unless ENV['OMIT_SERVICES']
 
     describe 'tracing' do
       it 'traces sync produce calls' do
+        skip "#{Rdkafka::VERSION} is not supported" unless instrumentation.installed?
         topic_name = 'producer-patch-trace'
         config = { 'bootstrap.servers': "#{host}:#{port}" }
 


### PR DESCRIPTION
Our instrumentation has been incompatible with rdkafka since v0.15 but we did not notice. 

As of v0.20 we are now seeing build failures. This PR ensures that we support a max version of 0.14
 
See https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1325