### PR TITLE
fix: resolve rubocop errors in instrumentation generators

### DIFF
--- a/.instrumentation_generator/templates/Appraisals
+++ b/.instrumentation_generator/templates/Appraisals
@@ -13,4 +13,3 @@
 # appraise 'rack-2.0' do
 #   gem 'rack', '2.0.8'
 # end
-

--- a/.instrumentation_generator/templates/lib/entrypoint.rb
+++ b/.instrumentation_generator/templates/lib/entrypoint.rb
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative './opentelemetry/instrumentation'
+require_relative 'opentelemetry/instrumentation'

--- a/.instrumentation_generator/templates/lib/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation.rb.tt
@@ -16,4 +16,4 @@ module OpenTelemetry
   end
 end
 
-require_relative './instrumentation/<%= instrumentation_name %>'
+require_relative 'instrumentation/<%= instrumentation_name %>'

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
@@ -15,5 +15,5 @@ module OpenTelemetry
   end
 end
 
-require_relative './<%= instrumentation_name %>/instrumentation'
-require_relative './<%= instrumentation_name %>/version'
+require_relative '<%= instrumentation_name %>/instrumentation'
+require_relative '<%= instrumentation_name %>/version'


### PR DESCRIPTION
closes: #1332 

This PR solves rubocop errors in the codes generated from `bin/instrumentation_generator`.

## Test

```
❯ bin/instrumentation_generator sample_package
❯ cd instrumentation/sample_package
❯ bundle install
❯ bundle exec rake rubocop
Running RuboCop...
Inspecting 11 files
...........
                                                                                                                                                                                                                                                                                                                     
11 files inspected, no offenses detected
                                                                                                                                                                                                                                                                                                                     
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)
                                                                                                                                                                                                                                                                                                                     
You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```