### PR TITLE
ci: Silence Kafka Logs

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -153,6 +153,7 @@ jobs:
         env:
           ZOOKEEPER_CLIENT_PORT: 2181
           ZOOKEEPER_TICK_TIME: 2000
+          ZOO_LOG4J_PROP: "ERROR,CONSOLE"
       kafka:
         image: confluentinc/cp-kafka:latest
         ports:
@@ -165,6 +166,7 @@ jobs:
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
           KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_LOG4J_LOGGERS: "org.apache.kafka=ERROR"
 
   instrumentation_redis:
     strategy:


### PR DESCRIPTION
They are a bit verbose and make it difficult to inspect test output when it is mixed in with service logs

Hopefully this will help us a bit