### PR TITLE
feat: Strip Rails `(.:format)` suffix from `http.route`

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
           # @return [Array<String, Hash>] the span name and attributes
           def to_span_name_and_attributes(payload)
             request = payload[:request]
-            http_route = request.route_uri_pattern if request.respond_to?(:route_uri_pattern)
+            http_route = request.route_uri_pattern.chomp('(.:format)') if request.respond_to?(:route_uri_pattern)
 
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE => String(payload[:controller]),
@@ -63,7 +63,7 @@ module OpenTelemetry
             attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET] = request.filtered_path if request.filtered_path != request.fullpath
 
             if @span_naming == :semconv
-              return ["#{request.method} #{http_route.gsub('(.:format)', '')}", attributes] if http_route
+              return ["#{request.method} #{http_route}", attributes] if http_route
 
               return ["#{request.method} /#{payload.dig(:params, :controller)}/#{payload.dig(:params, :action)}", attributes]
             end

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -58,6 +58,14 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.attributes['code.function']).must_equal 'ok'
   end
 
+  it 'strips (:format) from http.route' do
+    skip "Rails #{Rails.gem_version} does not define ActionDispatch::Request#route_uri_pattern" if Rails.gem_version < Gem::Version.new('7.1')
+
+    get 'items/1234'
+
+    _(span.attributes['http.route']).must_equal '/items/:id'
+  end
+
   it 'does not memoize data across requests' do
     get '/ok'
     get '/items/new'


### PR DESCRIPTION
In our OpenTelemetry spans, all `http.route` values end in `(.:format)`. This is unsightly and does not help when diagnosing an issue using traces. It also stands out as different from the `http.route` produced by other language's OTel SDKs, which only include parts of the URL path itself.

With this change, we strip this suffix from `http.route`, just like we are already doing for the span name. 