### PR TITLE
feat: remove tracestate, add lineage support to X-Ray propagator

### DIFF
--- a/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
+++ b/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
@@ -128,15 +128,15 @@ module OpenTelemetry
           lineageSubstrings = lineage.split(':')
           return false unless lineageSubstrings.length == 3
 
-          requestCounter = lineageSubstrings[0].to_i
-          hashedResourceId = lineageSubstrings[1]
-          loopCounter = lineageSubstrings[2].to_i
+          lineageCounter1 = lineageSubstrings[0].to_i
+          hashedString = lineageSubstrings[1]
+          lineageCounter2 = lineageSubstrings[2].to_i
 
-          hashedResourceId.match?(/\A[a-zA-Z0-9]{8}\z/) &&
-            requestCounter >= 0 &&
-            requestCounter <= 32767 &&
-            loopCounter >= 0 &&
-            loopCounter <= 255
+          hashedString.match?(/\A[a-zA-Z0-9]{8}\z/) &&
+            lineageCounter1 >= 0 &&
+            lineageCounter1 <= 32767 &&
+            lineageCounter2 >= 0 &&
+            lineageCounter2 <= 255
         end
       end
     end

--- a/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
+++ b/propagator/xray/lib/opentelemetry/propagator/xray/text_map_propagator.rb
@@ -85,6 +85,12 @@ module OpenTelemetry
 
           xray_value = "Root=#{xray_trace_id};Parent=#{parent_id};Sampled=#{sampling_state}"
 
+          # Add lineage to xray_value if present in baggage
+          baggage = OpenTelemetry::Baggage.values(context: context)
+          if baggage.key?('Lineage')
+            xray_value += ";Lineage=#{baggage['Lineage']}"
+          end
+
           setter.set(carrier, XRAY_CONTEXT_KEY, xray_value)
           nil
         end


### PR DESCRIPTION
Leaving this PR as a draft until Lambda has confirmed they are ready for this change across all OTel SDKs. Reviews are welcome in the meantime.

All of OpenTelemetry language SDKs are moving towards support for the Lambda Lineage attribute in the X-Ray trace header via W3C Baggage. See [this PR](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1671) for the equivalent Java solution. This PR updates X-Ray propagator to pass lineage into baggage and inject it into outgoing X-Ray trace header.

The X-Ray propagator in other languages uses a delimiter-based scanning approach to extracting incoming X-Ray trace headers ([see Java](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/1615862cee845f5ca5fbb2069eafb3e032a39b1c/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java#L191-L225)), whereas the Ruby uses regex matching. I updated the regex string to not only support the Lineage key, but also allow the keys to appear in any order as the other algorithms permit.

In addition, extraneous attributes in the X-Ray trace header are dropped instead of added to the span context's tracestate to match how the trace header is processed in the other language SDKs.