### PR TITLE
feat: Support including host name in faraday span names

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -28,6 +28,7 @@ module OpenTelemetry
 
         option :span_kind, default: :client, validate: %i[client internal]
         option :peer_service, default: nil, validate: :string
+        option :span_naming, default: :http_method, validate: %i[http_method host]
 
         private
 

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -121,6 +121,24 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
         _(span.attributes['peer.service']).must_equal 'example:faraday'
       end
 
+      it 'defaults to span naming by http method' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install
+
+        client.get('/success')
+
+        _(span.name).must_equal 'HTTP GET'
+      end
+
+      it 'allows including the host in the span name' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(span_naming: :host)
+
+        client.get('/success')
+
+        _(span.name).must_equal 'HTTP GET example.com'
+      end
+
       it 'defaults to span kind client' do
         instrumentation.instance_variable_set(:@installed, false)
         instrumentation.install


### PR DESCRIPTION
Faraday span names appear as just "HTTP \<METHOD\>" which doesn't provide a ton of context when visualizing the spans.

For some specific context about our use case:
We use Grafana span metrics to create alerts when any of our critical 3rd-party APIs we use have a high latency. But since those metrics don't include the `net.peer.name` attribute that were on the original span, we only really have the span name to filter down the metrics to what we're looking for.

Including the host name in the span name makes this process significantly easier for us and makes it much easier to identify _what_ API call was performed at a quick glance rather than having to click into the span's attributes each time 😄 