### PR TITLE
chore: gRPC intrumentation: plug in Dependabot, update Readme and Changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -201,3 +201,7 @@ updates:
   directory: "/resources/google_cloud_platform"
   schedule:
     interval: weekly
+- package-ecosystem: bundler
+  directory: "/instrumentation/grpc"
+  schedule:
+    interval: weekly

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### v0.1.3 / 2024-09-11
 
-* Fix error in handling of non-gRPC errors
-* Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
+* FIXED: Fix error in handling of non-gRPC errors
+* FIXED: Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
 
 ### v0.1.2 / 2024-06-26
 

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### v0.1.2 / 2024-06-26
 
-* Align span naming with spec
+* FIXED: Align span naming with spec
 
 ### v0.1.1 / 2024-06-26
 

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### v0.1.1 / 2024-06-26
 
-* Fix `uninitialized constant Interceptors` error
+* FIXED: Fix `uninitialized constant Interceptors` error
 
 ### v0.1.0 / 2024-06-18
 

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+# Release History: opentelemetry-instrumentation-grpc
 
 ### v0.2.0 / 2025-01-16
 
@@ -6,19 +6,19 @@
 
 * ADDED: Set minimum supported version to Ruby 3.1
 
-## [0.1.3] - 2024-09-11
+### v0.1.3 / 2024-09-11
 
-- Fix error in handling of non-gRPC errors
-- Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
+* Fix error in handling of non-gRPC errors
+* Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
 
-## [0.1.2] - 2024-06-26
+### v0.1.2 / 2024-06-26
 
-- Align span naming with spec
+* Align span naming with spec
 
-## [0.1.1] - 2024-06-26
+### v0.1.1 / 2024-06-26
 
-- Fix `uninitialized constant Interceptors` error
+* Fix `uninitialized constant Interceptors` error
 
-## [0.1.0] - 2024-06-18
+### v0.1.0 / 2024-06-18
 
-- Initial release
+* Initial release

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -1,28 +1,25 @@
-# OpenTelemetry::Instrumentation::Grpc
+# OpenTelemetry gRPC Instrumentation
 > [!CAUTION]
 > This gem is not ready for release by the open-telemetry org yet, but other versions are available on RubyGems
 
 [![Gem Version](https://badge.fury.io/rb/opentelemetry-instrumentation-grpc.svg)](https://badge.fury.io/rb/opentelemetry-instrumentation-grpc)
 [![GitHub Actions CI Status](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/actions/workflows/main.yml/badge.svg)](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/actions?query=branch%3Amain)
 
-OpenTelemetry instrumentation for users of the `grpc` gem
+OpenTelemetry instrumentation for users of the [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) gem.
 
 > [!WARNING]
 > Right now, the gem only instruments outbound requests to gRPC services
 
-## Installation
+## How do I get started?
 
-Install the gem and add to the application's Gemfile by executing:
+Install the gem using:
 
-```sh
-  $ bundle add opentelemetry-instrumentation-grpc
+```console
+gem install opentelemetry-instrumentation-grpc
 ```
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-grpc` to your `Gemfile`.
 
-```sh
-  $ gem install opentelemetry-instrumentation-grpc
-```
 
 ## Usage
 
@@ -46,6 +43,10 @@ instrumentation.
   end
 ```
 
+## Examples
+
+Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/grpc/example/trace_demonstration.rb)
+
 ## Development
 
 Integration tests rely on a real gRPC server that is started by relevant tests. The proto definition is located in `test/support/proto/ping.proto`. Making changes to the proto definition requires re-creating gRPC-generated code. To do this, run the following command:
@@ -54,14 +55,21 @@ Integration tests rely on a real gRPC server that is started by relevant tests. 
 bundle exec grpc_tools_ruby_protoc --ruby_out=. --grpc_out=. test/support/proto/ping.proto
 ```
 
-## Contributing
+## How can I get involved?
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/open-telemetry/opentelemetry-ruby-contrib. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/CODE_OF_CONDUCT.md).
+The `opentelemetry-instrumentation-sidekiq` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The `opentelemetry-instrumentation-sidekiq` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
 
-## Code of Conduct
-
-Everyone interacting in the OpenTelemetry::Instrumentation::Grpc project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/CODE_OF_CONDUCT.md).
+[sidekiq-home]: https://github.com/mperham/sidekiq
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[slack-channel]: https://cloud-native.slack.com/archives/C01NWKKMKMY
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -57,15 +57,15 @@ bundle exec grpc_tools_ruby_protoc --ruby_out=. --grpc_out=. test/support/proto/
 
 ## How can I get involved?
 
-The `opentelemetry-instrumentation-sidekiq` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+The `opentelemetry-instrumentation-grpc` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
 ## License
 
-The `opentelemetry-instrumentation-sidekiq` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+The `opentelemetry-instrumentation-grpc` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
 
-[sidekiq-home]: https://github.com/mperham/sidekiq
+[grpc-home]: https://github.com/grpc/grpc
 [bundler-home]: https://bundler.io
 [repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
 [license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE


### PR DESCRIPTION
In response to https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1261

This PR:
 - plugs-in dependabot
 - updates Readme to match the style with other instrumentations
 - updates Changelog for compatibility with toys