### PR TITLE
test: Fix Sidekiq NameError ActiveJob

### DIFF
--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
 
-  spec.add_development_dependency 'activejob', '>= 6.0'
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3'
+  spec.add_development_dependency 'rails', '>= 7.0'
   spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'rubocop', '~> 1.71.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.23.0'

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -8,10 +8,11 @@ require 'simplecov'
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
-require 'active_job'
-
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
+require 'rails'
+require 'active_job'
+require 'sidekiq/rails'
 require 'sidekiq/testing'
 
 if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')


### PR DESCRIPTION
Sidekiq v7.3.9 fixed a load ordering problem where it was requiring its ActiveJob Adapter too early:

https://github.com/sidekiq/sidekiq/commit/886e4349f1d6a9f82f2764e4a3e7c7cf4b9113ee

Our tests relied on this load ordering bug so the suite started failing:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/13447267345/job/37575230194

```console
  /opt/hostedtoolcache/Ruby/3.4.1/x64/lib/ruby/gems/3.4.0/gems/sidekiq-7.3.9/lib/active_job/queue_adapters/sidekiq_adapter.rb:71:in '<class:SidekiqAdapter>': uninitialized constant Sidekiq::ActiveJob (NameError)

        class JobWrapper < Sidekiq::ActiveJob::Wrapper
```

This change borrows from Sidekiq's test suite to ensure the Rails integration is loaded: https://github.com/sidekiq/sidekiq/blob/main/test/helper.rb#L75