### PR TITLE
ci: Run FOSSA scans only on main repo

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   fossa:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
New FOSSA scans will run on forks and fail. This update prevents those runs.