### PR TITLE
fix: ActiveStorage OTel API Constraints

### DIFF
--- a/instrumentation/active_storage/opentelemetry-instrumentation-active_storage.gemspec
+++ b/instrumentation/active_storage/opentelemetry-instrumentation-active_storage.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.4.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.7'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
 


### PR DESCRIPTION
All instrumentations must use pessemistic _minor_ version locking starting with OTel API version `1.0`.

We released the ActiveStorage instrumentation with a pessemistic _bug fix_ version dependency of OTel API 1.4.x, which is incorrect.

That results in dependency and installation errors: https://github.com/mastodon/mastodon/pull/33968

This change fixes the ActiveStorage instrumentation to use pessemstic minor version dependencies for the OTel API starting with `1.0`.

cc: @renchap