### PR TITLE
chore: bump rubocop and rubocop-performance gem versions 

### DIFF
--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.19.1'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'webmock', '~> 3.24'

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 13.0'
 gem 'rubocop', '~> 1.72.0'
-gem 'rubocop-performance', '~> 1.23.0'
+gem 'rubocop-performance', '~> 1.24.0'

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.72.0'
+gem 'rubocop', '~> 1.73.2'
 gem 'rubocop-performance', '~> 1.24.0'

--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'yard-doctest', '~> 0.1.6'

--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/helpers/sql-obfuscation/Gemfile
+++ b/helpers/sql-obfuscation/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'yard-doctest', '~> 0.1.6'

--- a/helpers/sql-obfuscation/Gemfile
+++ b/helpers/sql-obfuscation/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/helpers/sql/Gemfile
+++ b/helpers/sql/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/helpers/sql/Gemfile
+++ b/helpers/sql/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'active_model_serializers'

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.4'
   gem 'rake', '~> 13.2'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.4'
   gem 'rake', '~> 13.2'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 12.3.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 12.3.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.2'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.2'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
 

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0.1'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0.1'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/pg/Gemfile
+++ b/instrumentation/pg/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/pg/Gemfile
+++ b/instrumentation/pg/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'activerecord', '>= 7.0.0'

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'pg'

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem 'rake', '~> 13.0'
   gem 'rspec-mocks'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rspec-mocks'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-sdk-experimental', '~> 0.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rack-test', '~> 2.1.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.1.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'

--- a/instrumentation/resque/Gemfile
+++ b/instrumentation/resque/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/resque/Gemfile
+++ b/instrumentation/resque/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/restclient/Gemfile
+++ b/instrumentation/restclient/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/restclient/Gemfile
+++ b/instrumentation/restclient/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'rspec-mocks'

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'rails', '>= 7.0'

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.1'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.1'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'rspec-mocks'

--- a/processor/baggage/Gemfile
+++ b/processor/baggage/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/processor/baggage/Gemfile
+++ b/processor/baggage/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.0'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.0'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
 

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.72.2'
-  gem 'rubocop-performance', '~> 1.23.0'
+  gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.72.2'
+  gem 'rubocop', '~> 1.73.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'


### PR DESCRIPTION
Replaces the dependabot PRs (#1440, #1441) for these versions to cover all Gemfiles.

rubocop-performance from 1.23.0 to 1.24.0 
rubocop from 1.72.0 to. 1.73.2