### PR TITLE
chore: Update grpc example's require_relative order

### DIFF
--- a/instrumentation/grpc/example/trace_demonstration.rb
+++ b/instrumentation/grpc/example/trace_demonstration.rb
@@ -1,6 +1,3 @@
-require_relative './proto/example_api_services_pb'
-require_relative './example_impl'
-
 require 'bundler/inline'
 
 gemfile do
@@ -11,6 +8,9 @@ gemfile do
   gem 'opentelemetry-instrumentation-grpc', path: '../'
   gem 'opentelemetry-sdk'
 end
+
+require_relative 'proto/example_api_services_pb'
+require_relative 'example_impl'
 
 ENV['OTEL_TRACES_EXPORTER'] = 'console'
 OpenTelemetry::SDK.configure do |c|


### PR DESCRIPTION
Since we're using an inline gemfile, call require_relative after the grpc gem is available to avoid 'cannot load such file' errors.