### PR TITLE
chore: Add AWS resource detector to releases

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -241,6 +241,11 @@ gems:
     directory: propagator/xray
     version_constant: [OpenTelemetry, Propagator, XRay, VERSION]
 
+  - name: opentelemetry-resource-detector-aws
+    directory: resources/aws
+    version_rb_path: lib/opentelemetry/resource/detector/aws/version.rb
+    version_constant: [OpenTelemetry, Resource, Detector, AWS, VERSION]
+
   - name: opentelemetry-resource-detector-azure
     directory: resources/azure
     version_rb_path: lib/opentelemetry/resource/detector/azure/version.rb

--- a/resources/aws/.rubocop.yml
+++ b/resources/aws/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/resources/aws/.yardopts
+++ b/resources/aws/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Resource Detector AWS
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/resource/detector/**/*.rb
+./lib/opentelemetry/resource/detector.rb
+-
+README.md
+CHANGELOG.md

--- a/resources/aws/CHANGELOG.md
+++ b/resources/aws/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-resource-detector-aws


### PR DESCRIPTION
## What does this pull request do?
Adds AWS reource detector to releases.

## Related Issues
https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/34