### PR TITLE
feat: support meta protocol instrumentation

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -34,6 +34,7 @@ module OpenTelemetry
             ::Dalli::Server.prepend(Patches::Server)
           else
             ::Dalli::Protocol::Binary.prepend(Patches::Server)
+            ::Dalli::Protocol::Meta.prepend(Patches::Server) if defined?(::Dalli::Protocol::Meta)
           end
         end
       end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -8,7 +8,7 @@ module OpenTelemetry
   module Instrumentation
     module Dalli
       module Patches
-        # Module to prepend to Dalli::Server (or Dalli::Protocol::Binary in 3.0+) for instrumentation
+        # Module to prepend to Dalli::Server (or Dalli::Protocol::Binary/Meta in 3.0+) for instrumentation
         module Server
           def request(op, *args) # rubocop:disable Naming/MethodParameterName
             operation = Utils.opname(op, multi?)

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -15,7 +15,6 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
   let(:span) { exporter.finished_spans.first }
   let(:host) { ENV.fetch('TEST_MEMCACHED_HOST', '127.0.0.1') }
   let(:port) { ENV.fetch('TEST_MEMCACHED_PORT', 11_211).to_i }
-  let(:dalli) { Dalli::Client.new("#{host}:#{port}", {}) }
 
   before do
     exporter.reset
@@ -26,116 +25,123 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
     instrumentation.instance_variable_set(:@installed, false)
   end
 
-  describe 'tracing' do
-    before do
-      instrumentation.install(db_statement: :include)
-    end
+  [
+    ['binary protocol', { protocol: :binary }],
+    ['meta protocol', { protocol: :meta }]
+  ].each do |name, protocol|
+    describe "tracing with #{name}" do
+      let(:dalli) { Dalli::Client.new("#{host}:#{port}", protocol) }
 
-    it 'accepts peer service name from config' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(peer_service: 'readonly:memcached')
-      dalli.set('foo', 'bar')
-
-      _(span.attributes['peer.service']).must_equal 'readonly:memcached'
-    end
-
-    it 'before request' do
-      _(exporter.finished_spans.size).must_equal 0
-    end
-
-    it 'after dalli#set' do
-      dalli.set('foo', 'bar')
-
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'set'
-      _(span.attributes['db.system']).must_equal 'memcached'
-      _(span.attributes['db.statement']).must_equal 'set foo bar 0 0'
-      _(span.attributes['db.operation']).must_equal 'set'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
-    end
-
-    it 'after dalli#set' do
-      dalli.get('foo')
-
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'get'
-      _(span.attributes['db.system']).must_equal 'memcached'
-      _(span.attributes['db.statement']).must_equal 'get foo'
-      _(span.attributes['db.operation']).must_equal 'get'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
-    end
-
-    it 'after dalli#get_multi' do
-      dalli.get_multi('foo', 'bar')
-
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'getkq'
-      _(span.attributes['db.system']).must_equal 'memcached'
-      _(span.attributes['db.statement']).must_equal 'getkq foo bar'
-      _(span.attributes['db.operation']).must_equal 'getkq'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
-    end
-
-    it 'after error' do
-      dalli.set('foo', 'bar')
-      exporter.reset
-
-      dalli.instance_variable_get(:@ring).servers.first.stub(:write, ->(_bytes) { raise Dalli::NetworkError }) do
-        dalli.get_multi('foo', 'bar')
+      before do
+        instrumentation.install(db_statement: :include)
       end
 
-      if supports_retry_on_network_errors?
-        _(exporter.finished_spans.size).must_equal 2
-      else
+      it 'accepts peer service name from config' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(peer_service: 'readonly:memcached')
+        dalli.set('foo', 'bar')
+
+        _(span.attributes['peer.service']).must_equal 'readonly:memcached'
+      end
+
+      it 'before request' do
+        _(exporter.finished_spans.size).must_equal 0
+      end
+
+      it 'after dalli#set' do
+        dalli.set('foo', 'bar')
+
         _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'set'
+        _(span.attributes['db.system']).must_equal 'memcached'
+        _(span.attributes['db.statement']).must_equal 'set foo bar 0 0'
+        _(span.attributes['db.operation']).must_equal 'set'
+        _(span.attributes['net.peer.name']).must_equal host
+        _(span.attributes['net.peer.port']).must_equal port
       end
 
-      _(span.name).must_equal 'getkq'
-      _(span.attributes['db.system']).must_equal 'memcached'
-      _(span.attributes['db.statement']).must_equal 'getkq foo bar'
-      _(span.attributes['db.operation']).must_equal 'getkq'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
+      it 'after dalli#get' do
+        dalli.get('foo')
 
-      span_event = span.events.first
-      _(span_event.name).must_equal 'exception'
-      _(span_event.attributes['exception.type']).must_equal 'Dalli::NetworkError'
-      _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
-    end
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'get'
+        _(span.attributes['db.system']).must_equal 'memcached'
+        _(span.attributes['db.statement']).must_equal 'get foo'
+        _(span.attributes['db.operation']).must_equal 'get'
+        _(span.attributes['net.peer.name']).must_equal host
+        _(span.attributes['net.peer.port']).must_equal port
+      end
 
-    it 'omits db.statement' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(db_statement: :omit)
+      it 'after dalli#get_multi' do
+        dalli.get_multi('foo', 'bar')
 
-      dalli.set('foo', 'bar')
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'getkq'
+        _(span.attributes['db.system']).must_equal 'memcached'
+        _(span.attributes['db.statement']).must_equal 'getkq foo bar'
+        _(span.attributes['db.operation']).must_equal 'getkq'
+        _(span.attributes['net.peer.name']).must_equal host
+        _(span.attributes['net.peer.port']).must_equal port
+      end
 
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'set'
-      _(span.attributes).wont_include 'db.statement'
-    end
+      it 'after error' do
+        dalli.set('foo', 'bar')
+        exporter.reset
 
-    it 'obfuscates db.statement' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(db_statement: :obfuscate)
+        dalli.instance_variable_get(:@ring).servers.first.stub(:write, ->(_bytes) { raise Dalli::NetworkError }) do
+          dalli.get_multi('foo', 'bar')
+        end
 
-      dalli.set('foo', 'bar')
+        if supports_retry_on_network_errors?
+          _(exporter.finished_spans.size).must_equal 2
+        else
+          _(exporter.finished_spans.size).must_equal 1
+        end
 
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'set'
-      _(span.attributes['db.statement']).must_equal 'set ?'
-    end
+        _(span.name).must_equal 'getkq'
+        _(span.attributes['db.system']).must_equal 'memcached'
+        _(span.attributes['db.statement']).must_equal 'getkq foo bar'
+        _(span.attributes['db.operation']).must_equal 'getkq'
+        _(span.attributes['net.peer.name']).must_equal host
+        _(span.attributes['net.peer.port']).must_equal port
 
-    it 'supports gat' do
-      skip unless dalli.respond_to?(:gat)
+        span_event = span.events.first
+        _(span_event.name).must_equal 'exception'
+        _(span_event.attributes['exception.type']).must_equal 'Dalli::NetworkError'
+        _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
+      end
 
-      dalli.gat('foo')
+      it 'omits db.statement' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(db_statement: :omit)
 
-      _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'gat'
-      _(span.attributes['db.statement']).must_equal 'gat foo 0'
+        dalli.set('foo', 'bar')
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'set'
+        _(span.attributes).wont_include 'db.statement'
+      end
+
+      it 'obfuscates db.statement' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(db_statement: :obfuscate)
+
+        dalli.set('foo', 'bar')
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'set'
+        _(span.attributes['db.statement']).must_equal 'set ?'
+      end
+
+      it 'supports gat' do
+        skip unless dalli.respond_to?(:gat)
+
+        dalli.gat('foo')
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'gat'
+        _(span.attributes['db.statement']).must_equal 'gat foo 0'
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Dalli supports [Memcached's meta protocol](https://docs.memcached.org/protocols/meta/) as of [3.2.0](https://github.com/petergoldstein/dalli/blob/main/CHANGELOG.md#320). This PR adds support for instrumentation when clients are using the meta protocol.