### PR TITLE
chore: only prepend Dalli patch if binary protocol defined

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -33,7 +33,7 @@ module OpenTelemetry
           if Gem::Version.new(::Dalli::VERSION) < Gem::Version.new('3.0.0')
             ::Dalli::Server.prepend(Patches::Server)
           else
-            ::Dalli::Protocol::Binary.prepend(Patches::Server)
+            ::Dalli::Protocol::Binary.prepend(Patches::Server) if defined?(::Dalli::Protocol::Binary)
             ::Dalli::Protocol::Meta.prepend(Patches::Server) if defined?(::Dalli::Protocol::Meta)
           end
         end


### PR DESCRIPTION
## Description

Follow up to https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1480.

We removed the binary protocol from Shopify's fork of Dalli (https://github.com/Shopify/dalli/pull/13) since it is officially deprecated by Memcached (https://docs.memcached.org/protocols/#why-is-the-binary-protocol-deprecated). I know it's also on upstream Dalli's roadmap to remove it as well. So this PR just ensures that `::Dalli::Protocol::Binary` is defined before applying the patch.