### PR TITLE
chore: Reduce duplication in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,28 +12,28 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/active_storage/ @ymtdzzz @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/active_storage/ @ymtdzzz @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/aws_sdk/ @jterapin @alextwoods @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/aws_sdk/ @jterapin @alextwoods @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/racecar/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/racecar/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/rspec/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/rspec/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-instrumentation/que/ @indrekj @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+instrumentation/que/ @indrekj @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-processor/baggage/ @robbkidd @mikegoldsmith @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+processor/baggage/ @robbkidd @mikegoldsmith @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers
 
-sampler/xray/ @jj22ee @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+sampler/xray/ @jj22ee @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers


### PR DESCRIPTION
Based on [the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), the GitHub alias for the approver and maintainer teams should take care of this for us.

Is there a historical reason for listing out the names of all the individual approver/maintainers as well? 