### PR TITLE
chore: Address Style/RedundantParentheses

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/default.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/default.rb
@@ -60,7 +60,7 @@ module OpenTelemetry
             span = otel&.fetch(:span)
             token = otel&.fetch(:ctx_token)
 
-            on_exception((payload[:error] || payload[:exception_object]), span)
+            on_exception(payload[:error] || payload[:exception_object], span)
           rescue StandardError => e
             OpenTelemetry.handle_error(exception: e)
           ensure


### PR DESCRIPTION
Rubocop 1.75.3 came out on 22 April. Our Gemfile is set to install new patch versions automatically. This cop started failing after the update with the message: Don't use parentheses around a method argument.