### PR TITLE
chore: Add @michal-kazmierczak to grpc codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,8 @@ instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-t
 
 instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
+instrumentation/grpc/ @michal-kazmierczak @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
+
 instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
 
 instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi


### PR DESCRIPTION
@michal-kazmierczak was instrumental in improving the `opentelemetry-instrumentation-grpc` gem and getting it ready for release. Let's formally add him to the CODEOWNERS file.