### PR TITLE
chore: Add component owners workflow

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,0 +1,47 @@
+# Keep all in alphabetical order
+components:
+  instrumentation/active_storage/:
+    - ymtdzzz
+
+  instrumentation/aws_sdk/:
+    - alextwoods
+    - jterapin
+    - NathanielRN
+
+  instrumentation/grape/:
+    - muripic
+
+  instrumentation/graphql/:
+    - rmoslogo
+    - swalkinshaw
+
+  instrumentation/grpc/:
+    - michal-kazmierczak
+
+  instrumentation/httpx/:
+    - HoneyryderChuck
+
+  instrumentation/mongo/:
+    - johnnyshields
+
+  instrumentation/racecar/:
+    - chrisholmes
+
+  instrumentation/rspec/:
+    - chrisholmes
+
+  instrumentation/que/:
+    - indrekj
+
+  processor/baggage/:
+    - mikegoldsmith
+    - robbkidd
+
+  resources/container/:
+    - scbjans
+
+  sampler/xray/:
+    - jj22ee
+
+ignored-authors:
+  - dependabot

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,0 +1,18 @@
+name: Component Owners
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  run_self:
+    runs-on: ubuntu-latest
+    name: Auto Assign Owners
+    steps:
+      - uses: dyladan/component-owners@main
+        with:
+          config-file: .github/component_owners.yml
+          repo-token: ${{ github.token }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,27 +13,3 @@
 #
 
 * @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-resources/container/ @scbjans @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/active_storage/ @ymtdzzz @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/aws_sdk/ @jterapin @alextwoods @NathanielRN @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/grape/ @muripic @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/graphql/ @swalkinshaw @rmoslogo @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/httpx/ @HoneyryderChuck @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/mongo/ @johnnyshields @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/racecar/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/rspec/ @chrisholmes @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-instrumentation/que/ @indrekj @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-processor/baggage/ @robbkidd @mikegoldsmith @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi
-
-sampler/xray/ @jj22ee @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @simi @kaylareopelle @xuan-cao-swi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ process. Don't worry it's painless!
 
 ### Review and feedback
 
-PRs require a review from one or more of the [code owners](CODEOWNERS) before
+PRs require a review from one or more of the [code owners](CODEOWNERS) or [component owners](.github/component_owners.yml) before
 merge. You'll probably get some feedback from these fine folks which helps to
 make the project that much better. Respond to the feedback and work with your
 reviewer(s) to resolve any issues.


### PR DESCRIPTION
The CODEOWNERS file will only assign PRs to users with write access.

Since we want more support reviewing PRs from domain experts, integrate the component owners workflow used by other OpenTelemetry repositories.

Before this will work, all component owners need to become members of the OpenTelemetry GitHub organization.

This will be tracked in a separate issue.