### PR TITLE
feat: suppress internal spans with Faraday instrumentation

### DIFF
--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -19,7 +19,7 @@ To install the instrumentation, call `use` with the name of the instrumentation.
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Faraday'
-  suppress_internal_instrumentation: true
+  enable_internal_instrumentation: false
 end
 ```
 
@@ -33,8 +33,8 @@ end
 
 ### Configuration options
 This instrumentation offers the following configuration options: 
-* `suppress_internal_instrumentation` (default: `false`): When set to `true`, any spans with 
- span kind of `internal` are suppressed from traces.
+* `enable_internal_instrumentation` (default: `false`): When set to `true`, any spans with 
+ span kind of `internal` are included in traces.
 
 ## Examples
 

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -18,8 +18,9 @@ To install the instrumentation, call `use` with the name of the instrumentation.
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::Faraday'
-  enable_internal_instrumentation: false
+  c.use 'OpenTelemetry::Instrumentation::Faraday', {
+    enable_internal_instrumentation: false
+  }
 end
 ```
 

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -19,6 +19,7 @@ To install the instrumentation, call `use` with the name of the instrumentation.
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Faraday'
+  suppress_internal_instrumentation: true
 end
 ```
 
@@ -29,6 +30,11 @@ OpenTelemetry::SDK.configure do |c|
   c.use_all
 end
 ```
+
+### Configuration options
+This instrumentation offers the following configuration options: 
+* `suppress_internal_instrumentation` (default: `false`): When set to `true`, any spans with 
+ span kind of `internal` are suppressed from traces.
 
 ## Examples
 

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -28,7 +28,7 @@ module OpenTelemetry
 
         option :span_kind, default: :client, validate: %i[client internal]
         option :peer_service, default: nil, validate: :string
-        option :suppress_internal_instrumentation, default: false, validate: :boolean
+        option :enable_internal_instrumentation, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -28,6 +28,7 @@ module OpenTelemetry
 
         option :span_kind, default: :client, validate: %i[client internal]
         option :peer_service, default: nil, validate: :string
+        option :suppress_internal_instrumentation, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -40,7 +40,7 @@ module OpenTelemetry
               ) do |span|
                 OpenTelemetry.propagation.inject(env.request_headers)
 
-                if config[:suppress_internal_instrumentation]
+                if config[:enable_internal_instrumentation] == false
                   OpenTelemetry::Common::Utilities.untraced do
                     app.call(env).on_complete { |resp| trace_response(span, resp.status) }
                   end


### PR DESCRIPTION
Addresses #1502 for Faraday library instrumentation. Allow user to set `suppress_internal_instrumentation` flag when configuring Faraday instrumentation to suppress additional client spans generated from underlying Net::Http instrumentation.

Before merging, waiting for update on Github issue to see if internal span suppression can be made default behavior for both Faraday and AWS SDK.