### PR TITLE
refactor: update error handling to use OpenTelemetry.handle_error API

### DIFF
--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
@@ -59,7 +59,7 @@ module OpenTelemetry
               resource_attributes[RESOURCE::HOST_TYPE] = identity['instanceType']
               resource_attributes[RESOURCE::HOST_NAME] = hostname
             rescue StandardError => e
-              OpenTelemetry.logger.debug("EC2 resource detection failed: #{e.message}")
+              OpenTelemetry.handle_error(exception: e, message: 'EC2 resource detection failed')
               return OpenTelemetry::SDK::Resources::Resource.create({})
             end
 
@@ -133,7 +133,7 @@ module OpenTelemetry
                 http.request(request)
               end
             rescue StandardError => e
-              OpenTelemetry.logger.debug("EC2 metadata service request failed: #{e.message}")
+              OpenTelemetry.handle_error(exception: e, message: 'EC2 metadata service request failed')
               nil
             end
           end

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
@@ -68,7 +68,7 @@ module OpenTelemetry
               logs_attributes = get_logs_resource(container_metadata)
               resource_attributes.merge!(logs_attributes)
             rescue StandardError => e
-              OpenTelemetry.logger.debug("ECS resource detection failed: #{e.message}")
+              OpenTelemetry.handle_error(exception: e, message: 'ECS resource detection failed')
               return OpenTelemetry::SDK::Resources::Resource.create({})
             end
 
@@ -92,7 +92,7 @@ module OpenTelemetry
                 end
               end
             rescue Errno::ENOENT => e
-              OpenTelemetry.logger.debug("Failed to get container ID on ECS: #{e.message}")
+              OpenTelemetry.handle_error(exception: e, message: 'Failed to get container ID on ECS')
             end
 
             ''
@@ -139,7 +139,7 @@ module OpenTelemetry
                 log_attributes[RESOURCE::AWS_LOG_STREAM_NAMES] = [logs_stream_name].compact
                 log_attributes[RESOURCE::AWS_LOG_STREAM_ARNS] = [logs_stream_arn].compact
               else
-                OpenTelemetry.logger.debug("The metadata endpoint v4 has returned 'awslogs' as 'LogDriver', but there is no 'LogOptions' data")
+                OpenTelemetry.handle_error(message: 'The metadata endpoint v4 has returned \'awslogs\' as \'LogDriver\', but there is no \'LogOptions\' data')
               end
             end
 


### PR DESCRIPTION
## What does this pull request do?
Follow-up PR to update the error handling in the existing AWS resource detectors (EC2 and ECS) to use `OpenTelemetry.handle_error`. 

More context [here](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1477/files#r2053080063)