### PR TITLE
chore: Add GoogleCloudTraceContext propagator to releases

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -229,6 +229,10 @@ gems:
     directory: processor/baggage
     version_constant: [OpenTelemetry, Processor, Baggage, VERSION]
 
+  - name: opentelemetry-propagator-google_cloud_trace_context
+    directory: propagator/google_cloud_trace_context
+    version_constant: [OpenTelemetry, Propagator, GoogleCloudTraceContext, VERSION]
+
   - name: opentelemetry-propagator-ottrace
     directory: propagator/ottrace
     version_constant: [OpenTelemetry, Propagator, OTTrace, VERSION]


### PR DESCRIPTION
When I tried to release the initial version of this gem yesterday, the action failed. I think this may be why. 

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/14762192392 