### PR TITLE
fix: add missing semantic conventions require in AWS resource detectors

### DIFF
--- a/resources/aws/lib/opentelemetry-resource-detector-aws.rb
+++ b/resources/aws/lib/opentelemetry-resource-detector-aws.rb
@@ -4,4 +4,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/semantic_conventions/resource'
 require_relative 'opentelemetry/resource/detector'

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
@@ -7,6 +7,7 @@
 require 'net/http'
 require 'json'
 require 'opentelemetry/common'
+require 'opentelemetry/semantic_conventions/resource'
 
 module OpenTelemetry
   module Resource

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
@@ -8,6 +8,7 @@ require 'net/http'
 require 'json'
 require 'socket'
 require 'opentelemetry/common'
+require 'opentelemetry/semantic_conventions/resource'
 
 module OpenTelemetry
   module Resource

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/lambda.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/lambda.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/semantic_conventions/resource'
+
 module OpenTelemetry
   module Resource
     module Detector


### PR DESCRIPTION
## What does this pull request do?
Fixes an issue where AWS resource detectors (EC2, ECS, Lambda) were using `OpenTelemetry::SemanticConventions::Resource` without requiring the module that defines it. This caused "uninitialized constant" errors when using these detectors in production environments where the semantic conventions module wasn't already loaded.

This PR implements a dual strategy for dependency management:

1. Added explicit `require 'opentelemetry/semantic_conventions/resource'` statements to each AWS detector file to ensure proper dependency loading regardless of the runtime environment.
2. Maintained these individual requires while also adding the require statement to the top-level detector file.

This approach ensures that we are explicit about the following behavior:
- When the gem is required normally via `require 'opentelemetry-resource-detector-aws'`, all dependencies are loaded properly.
- When individual detectors are required directly (e.g., `require 'opentelemetry/resource/detector/aws/ec2'`), they still have all their necessary dependencies.

## Issues
https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1515