### PR TITLE
docs: Use AWS SDK v3 in example

### DIFF
--- a/instrumentation/aws_sdk/example/Gemfile
+++ b/instrumentation/aws_sdk/example/Gemfile
@@ -2,10 +2,10 @@
 
 source 'https://rubygems.org'
 
-gem 'aws-sdk-core', '~> 3'
-gem 'aws-sdk-sns', '~> 1'
+gem 'aws-sdk-core', '~> 3.203.0'
+gem 'aws-sdk-sns', '~> 1.83.0'
 gem 'opentelemetry-api'
-gem 'opentelemetry-instrumentation-aws_sdk'
+gem 'opentelemetry-instrumentation-aws_sdk', '~> 0.7.0'
 gem 'opentelemetry-sdk'
 # AWS SDK core needs an XML library
 gem 'rexml'

--- a/instrumentation/aws_sdk/example/Gemfile
+++ b/instrumentation/aws_sdk/example/Gemfile
@@ -2,7 +2,10 @@
 
 source 'https://rubygems.org'
 
-gem 'aws-sdk'
+gem 'aws-sdk-core', '~> 3'
+gem 'aws-sdk-sns', '~> 1'
 gem 'opentelemetry-api'
 gem 'opentelemetry-instrumentation-aws_sdk'
 gem 'opentelemetry-sdk'
+# AWS SDK core needs an XML library
+gem 'rexml'

--- a/instrumentation/aws_sdk/example/trace_demonstration.rb
+++ b/instrumentation/aws_sdk/example/trace_demonstration.rb
@@ -13,8 +13,10 @@ Bundler.require
 ENV['OTEL_TRACES_EXPORTER'] ||= 'console'
 
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::AwsSdk', suppress_internal_instrumentation: false
+  c.use 'OpenTelemetry::Instrumentation::AwsSdk'
 end
 
-sns = Aws::SNS::Client.new
+# For more examples and options, see also https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/observability.html 
+otel_provider = Aws::Telemetry::OTelProvider.new
+sns = Aws::SNS::Client.new(telemetry_provider: otel_provider)
 sns.publish message: 'ruby sending message to sns'


### PR DESCRIPTION
This PR updates the AWS SDK documentation example to use the SDK v3 as discussed in #1470

It pretty much now implement the suggested example in the README itself:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/51f6328426db28829f6ca1cddb916d5d94cddb6b/instrumentation/aws_sdk/README.md?plain=1#L47-L58

And I added the version restriction in the example Gemfile to avoid any confusion on the SDK version used. 

I also added `rexml`, because starting from Ruby 3.0 it isn't shipped with Ruby core, but [aws-sdk-core needs an XML parser](https://github.com/aws/aws-sdk-ruby/blob/9bca9ab73addfd600e833b5c2b6ef57df517952f/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb#L70-L73). It works on the AWS SDK CI without specifying rexml, because [webmock](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/51f6328426db28829f6ca1cddb916d5d94cddb6b/instrumentation/aws_sdk/Gemfile#L20) requires rexml, but we don't have this gem in the example.

If you run for example `AWS_ACCESS_KEY_ID=123 AWS_SECRET_ACCESS_KEY=qwer AWS_REGION=us-east-1 ruby trace_demonstration.rb` you will now get the example trace working :

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/0807b298-2fab-4696-b4b5-f8a19cb99d06" />
