### PR TITLE
fix: Account for `nil` routes

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
@@ -53,6 +53,9 @@ module OpenTelemetry
           # @return [Array<String, Hash>] the span name and attributes
           def to_span_name_and_attributes(payload)
             request = payload[:request]
+            # It seems that there are cases in Rails functional tests where it bypasses the routing system and the `action_dispatch.route_uri_pattern` header not being set.
+            # Our Test suite executes the routing system so we are unable to recreate this error case.
+            # https://github.com/rails/rails/blob/747f85f200e7bb2c1a31b4e26e5a5655e2dc0cdc/actionpack/lib/action_dispatch/http/request.rb#L160
             http_route = request.route_uri_pattern&.chomp('(.:format)') if request.respond_to?(:route_uri_pattern)
 
             attributes = {

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
           # @return [Array<String, Hash>] the span name and attributes
           def to_span_name_and_attributes(payload)
             request = payload[:request]
-            http_route = request.route_uri_pattern.chomp('(.:format)') if request.respond_to?(:route_uri_pattern)
+            http_route = request.route_uri_pattern&.chomp('(.:format)') if request.respond_to?(:route_uri_pattern)
 
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE => String(payload[:controller]),


### PR DESCRIPTION
It seems that there are cases in Rails functional tests where it bypasses the routing system and the `action_dispatch.route_uri_pattern` header not being set.

https://github.com/rails/rails/blob/747f85f200e7bb2c1a31b4e26e5a5655e2dc0cdc/actionpack/lib/action_dispatch/http/request.rb#L160

```console
  4) SessionsController POST #create when user is not found or not persisted redirects to no access path
     Failure/Error: post :create, params: { provider: 'github' }

     NoMethodError:
       undefined method 'chomp' for nil
     # /usr/local/bundle/gems/opentelemetry-instrumentation-action_pack-0.12.0/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb:56:in 'OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController#to_span_name_and_attributes'
     # /usr/local/bundle/gems/opentelemetry-instrumentation-action_pack-0.12.0/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb:26:in 'OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController#start'
     # ./spec/controllers/sessions_controller_spec.rb:28:in 'block (4 levels) in <top (required)>'
```

Our Test suite executes the routing system so we are unable to recreate this error case.

This change adds safe navigation navigation to avoid running into errors when running Functional Tests and the instrumentation is enabled.

```console
irb(main):003> route_uri_pattern.chomp('(.format)')
(irb):3:in '<main>': undefined method 'chomp' for nil (NoMethodError)
        from <internal:kernel>:168:in 'Kernel#loop'
        from /Users/arielvalentin/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/irb-1.15.2/exe/irb:9:in '<top (required)>'
        from /Users/arielvalentin/.rbenv/versions/3.4.1/bin/irb:25:in 'Kernel#load'
        from /Users/arielvalentin/.rbenv/versions/3.4.1/bin/irb:25:in '<main>'
irb(main):004> route_uri_pattern&.chomp('(.format)')
=> nil
```