### PR TITLE
test: Add less restrictive gem spec for mongo gem

### DIFF
--- a/instrumentation/mongo/Appraisals
+++ b/instrumentation/mongo/Appraisals
@@ -4,6 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'mongo-2.13' do
-  gem 'mongo', '~> 2.13.0'
+appraise 'mongo-2' do
+  gem 'mongo', '~> 2.13'
 end

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -380,7 +380,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       _(span.events[0].name).must_equal 'exception'
       _(span.events[0].timestamp).must_be_kind_of Integer
       _(span.events[0].attributes['exception.type']).must_equal 'CommandFailed'
-      _(span.events[0].attributes['exception.message']).must_equal 'ns not found (26)'
+      _(span.events[0].attributes['exception.message']).must_equal '[26:NamespaceNotFound]: ns not found'
     end
 
     describe 'that triggers #failed before #started' do
@@ -402,7 +402,8 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
         database: TestHelper.database,
         auth_mech: :plain,
         user: 'plain_user',
-        password: 'plain_pass'
+        password: 'plain_pass',
+        auth_source: '$external'
       }
     end
 


### PR DESCRIPTION
It looks like latest features (including jruby 10 enablement) will require the latest minor release of the mongo gem.

Specifically:

The latest mongo gem relaxes the range for the ruby-bson gem. This would allow the uptake of https://github.com/mongodb/bson-ruby/pull/353 if it is accepted.