### PR TITLE
refactor: change error level logging to debug level for resource dete…

### DIFF
--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ec2.rb
@@ -60,7 +60,7 @@ module OpenTelemetry
               resource_attributes[RESOURCE::HOST_TYPE] = identity['instanceType']
               resource_attributes[RESOURCE::HOST_NAME] = hostname
             rescue StandardError => e
-              OpenTelemetry.handle_error(exception: e, message: 'EC2 resource detection failed')
+              OpenTelemetry.logger.debug("EC2 resource detection failed: #{e.message}")
               return OpenTelemetry::SDK::Resources::Resource.create({})
             end
 
@@ -134,7 +134,7 @@ module OpenTelemetry
                 http.request(request)
               end
             rescue StandardError => e
-              OpenTelemetry.handle_error(exception: e, message: 'EC2 metadata service request failed')
+              OpenTelemetry.logger.debug("EC2 metadata service request failed: #{e.message}")
               nil
             end
           end

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
@@ -69,7 +69,7 @@ module OpenTelemetry
               logs_attributes = get_logs_resource(container_metadata)
               resource_attributes.merge!(logs_attributes)
             rescue StandardError => e
-              OpenTelemetry.handle_error(exception: e, message: 'ECS resource detection failed')
+              OpenTelemetry.logger.debug("ECS resource detection failed: #{e.message}")
               return OpenTelemetry::SDK::Resources::Resource.create({})
             end
 
@@ -93,7 +93,7 @@ module OpenTelemetry
                 end
               end
             rescue Errno::ENOENT => e
-              OpenTelemetry.handle_error(exception: e, message: 'Failed to get container ID on ECS')
+              OpenTelemetry.logger.debug("Failed to get container ID on ECS: #{e.message}")
             end
 
             ''
@@ -140,7 +140,7 @@ module OpenTelemetry
                 log_attributes[RESOURCE::AWS_LOG_STREAM_NAMES] = [logs_stream_name].compact
                 log_attributes[RESOURCE::AWS_LOG_STREAM_ARNS] = [logs_stream_arn].compact
               else
-                OpenTelemetry.handle_error(message: 'The metadata endpoint v4 has returned \'awslogs\' as \'LogDriver\', but there is no \'LogOptions\' data')
+                OpenTelemetry.logger.debug("The metadata endpoint v4 has returned 'awslogs' as 'LogDriver', but there is no 'LogOptions' data")
               end
             end
 

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/lambda.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/lambda.rb
@@ -35,7 +35,7 @@ module OpenTelemetry
               # Convert memory size to integer
               resource_attributes[RESOURCE::FAAS_MAX_MEMORY] = ENV['AWS_LAMBDA_FUNCTION_MEMORY_SIZE'].to_i if ENV['AWS_LAMBDA_FUNCTION_MEMORY_SIZE']
             rescue StandardError => e
-              OpenTelemetry.handle_error(exception: e, message: 'Lambda resource detection failed')
+              OpenTelemetry.logger.debug("Lambda resource detection failed: #{e.message}")
               return OpenTelemetry::SDK::Resources::Resource.create({})
             end
 


### PR DESCRIPTION
## What does this pull request do?
Updates existings AWS resource detectors to use debug level logging for resource detection failure per the [OTel spec](https://github.com/open-telemetry/opentelemetry-specification/blob/9eee5293f95b9fd74f6f1c280b97f87aaec872d7/specification/resource/sdk.md#L115-L118).

## Issues
https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1538