### PR TITLE
ci: fix markdownlint-check config

### DIFF
--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -12,9 +12,9 @@ jobs:
       # equivalent cli: markdownlint-cli2  "**/*.md" "#**/CHANGELOG.md"  --config .markdownlint.json
       - name: "Markdown Lint Check"
         uses: DavidAnson/markdownlint-cli2-action@v19
+        continue-on-error: true
         with:
           fix: false
           globs: |
             **/*.md
             !**/CHANGELOG.md
-          continue-on-error: true


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/15105985424/job/42454773761#step:3:1 showed a warning for the markdownlint-check action:

```
Markdown Lint Check
Unexpected input(s) 'continue-on-error', valid inputs are ['config', 'fix', 'globs', 'separator']
```

According to the [docs](https://github.com/marketplace/actions/markdownlint-cli2-action) the `continue-on-error` configuration should be unindented.

Corresponding PR in non-contrib: https://github.com/open-telemetry/opentelemetry-ruby/pull/1848