### PR TITLE
fix: compact Dalli attributes

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -15,9 +15,10 @@ module OpenTelemetry
             attributes = {
               'db.system' => 'memcached',
               'db.operation' => operation,
-              'net.peer.name' => hostname,
-              'net.peer.port' => port
+              'net.peer.name' => hostname
             }
+            attributes['net.peer.port'] = port if port
+
             if config[:db_statement] == :include
               attributes['db.statement'] = Utils.format_command(operation, args)
             elsif config[:db_statement] == :obfuscate

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -142,6 +142,24 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
         _(span.name).must_equal 'gat'
         _(span.attributes['db.statement']).must_equal 'gat foo 0'
       end
+
+      it 'supports unix domain socket' do
+        dalli.version
+        exporter.reset
+
+        server = dalli.instance_variable_get(:@ring).servers.first
+        server.stub(:hostname, '/tmp/memcached.sock') do
+          server.stub(:port, nil) do
+            dalli.set('foo', 'bar')
+
+            puts exporter.finished_spans
+            _(exporter.finished_spans.size).must_equal 1
+            _(span.name).must_equal 'set'
+            _(span.attributes).wont_include 'net.peer.port'
+            _(span.attributes['net.peer.name']).must_equal '/tmp/memcached.sock'
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Dalli supports connecting to Memcached over a [UNIX domain socket](https://github.com/petergoldstein/dalli/wiki/Server-Configuration#individual-server-configuration-strings) in which case the [`port` is nil](https://github.com/Shopify/dalli/blob/main/lib/dalli/protocol/server_config_parser.rb#L60-L65). This will raise `OpenTelemetry error: invalid span attribute value type NilClass for key 'net.peer.port' on span 'set' (OpenTelemetry::Error)` ([source](https://github.com/Shopify/opentelemetry-ruby-shopify/blob/main/opentelemetry-shopify/lib/opentelemetry/shopify.rb#L291-L301)).

This PR attempts to address this by compacting the `attributes`. I'm curious if folks think the test is digging too deep into Dalli internals. I just mainly wanted to avoid spinning up a separate Memcached server that is listening over a UNIX domain socket to test this. I'm all ears for other approaches too.