### PR TITLE
fix: action_pack always assuming sdk spans

### DIFF
--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -236,6 +236,12 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
       _(span.attributes['code.namespace']).must_equal 'ExceptionsController'
       _(span.attributes['code.function']).must_equal 'show'
     end
+
+    it 'does not raise with api/non recording spans' do
+      with_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF) do
+        get 'internal_server_error'
+      end
+    end
   end
 
   it 'sets filters `http.target`' do

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -24,3 +24,11 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::ActionPack'
   c.add_span_processor span_processor
 end
+
+def with_sampler(sampler)
+  previous_sampler = OpenTelemetry.tracer_provider.sampler
+  OpenTelemetry.tracer_provider.sampler = sampler
+  yield
+ensure
+  OpenTelemetry.tracer_provider.sampler = previous_sampler
+end


### PR DESCRIPTION
`span.name` is not a method on api/non recording spans. This small refactor changes the logic around renaming to stop relying on the presence of `span.name` for when the naming convention is `class_name`. 

Adds a small regression test to prevent this mistake from being re-introduced. 