### PR TITLE
chore: do not use latest cp-kafka image

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -157,7 +157,7 @@ jobs:
           ZOOKEEPER_CLIENT_PORT: 2181
           ZOOKEEPER_TICK_TIME: 2000
       kafka:
-        image: confluentinc/cp-kafka:latest
+        image: confluentinc/cp-kafka:7.9.1
         ports:
           - 9092:9092
           - 29092:29092

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,7 +226,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.9.1
     ports:
       - "9092:9092"
       - "29092:29092"

--- a/instrumentation/ruby_kafka/docker-compose.yml
+++ b/instrumentation/ruby_kafka/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.9.1
     ports:
       - "9092:9092"
       - "29092:29092"

--- a/instrumentation/ruby_kafka/example/docker-compose.yml
+++ b/instrumentation/ruby_kafka/example/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.9.1
     ports:
       - "9092:9092"
       - "29092:29092"


### PR DESCRIPTION
Temporary fix for kafka ci failures, related issue https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1563

Mongo is also failing, will address separately. 