### PR TITLE
test: Install older version of bson for JRuby

### DIFF
--- a/instrumentation/mongo/Appraisals
+++ b/instrumentation/mongo/Appraisals
@@ -7,8 +7,6 @@
 appraise 'mongo-2' do
   gem 'mongo', '~> 2.13'
 
-  # TODO: bson 5.1.0 isn't compatible with JRuby at this time
-  if defined?(JRUBY_VERSION)
-    gem 'bson', '< 5.1.0'
-  end
+  # TODO: bson 5.1.0 isn't compatible with JRuby as of 2025/06/17
+  gem 'bson', '< 5.1.0' if defined?(JRUBY_VERSION)
 end

--- a/instrumentation/mongo/Appraisals
+++ b/instrumentation/mongo/Appraisals
@@ -6,4 +6,9 @@
 
 appraise 'mongo-2' do
   gem 'mongo', '~> 2.13'
+
+  # TODO: bson 5.1.0 isn't compatible with JRuby at this time
+  if defined?(JRUBY_VERSION)
+    gem 'bson', '< 5.1.0'
+  end
 end


### PR DESCRIPTION
At this time, bson 5.1.0 is not compatible with JRuby 9.x. (It might be compatible with JRuby 10, but we're not running that in our tests yet) 

This updates the appraisal to run an older version if we're on JRuby.