### PR TITLE
fix: update span name when semconv stability is enabled

### DIFF
--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/client.rb
@@ -65,12 +65,12 @@ module OpenTelemetry
             def create_request_span_name(request_method, request_path)
               if (implementation = config[:span_name_formatter])
                 updated_span_name = implementation.call(request_method, request_path)
-                updated_span_name.is_a?(String) ? updated_span_name : "HTTP #{request_method}"
+                updated_span_name.is_a?(String) ? updated_span_name : request_method.to_s
               else
-                "HTTP #{request_method}"
+                request_method.to_s
               end
             rescue StandardError
-              "HTTP #{request_method}"
+              request_method.to_s
             end
 
             def tracer

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/connection.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
                 'server.port' => req.uri.port
               }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
-              tracer.in_span('HTTP CONNECT', attributes: attributes) do
+              tracer.in_span('CONNECT', attributes: attributes) do
                 super
               end
             end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/client.rb
@@ -56,12 +56,12 @@ module OpenTelemetry
             def create_request_span_name(request_method, request_path)
               if (implementation = config[:span_name_formatter])
                 updated_span_name = implementation.call(request_method, request_path)
-                updated_span_name.is_a?(String) ? updated_span_name : "HTTP #{request_method}"
+                updated_span_name.is_a?(String) ? updated_span_name : request_method.to_s
               else
-                "HTTP #{request_method}"
+                request_method.to_s
               end
             rescue StandardError
-              "HTTP #{request_method}"
+              request_method.to_s
             end
 
             def tracer

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/connection.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
                 'server.port' => req.uri.port
               }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
-              tracer.in_span('HTTP CONNECT', attributes: attributes) do
+              tracer.in_span('CONNECT', attributes: attributes) do
                 super
               end
             end

--- a/instrumentation/http/test/instrumentation/http/patches/dup/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/dup/client_test.rb
@@ -48,7 +48,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
     it 'traces a simple request' do
       HTTP.get('http://example.com/success')
       _(exporter.finished_spans.size).must_equal(1)
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -77,7 +77,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       HTTP.post('http://example.com/failure')
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP POST'
+      _(span.name).must_equal 'POST'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'POST'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -107,7 +107,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       end.must_raise HTTP::TimeoutError
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'https'
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       end
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       let(:span_name_formatter) do
         # demonstrate simple addition of path and string to span name:
         lambda { |request_method, request_path|
-          "HTTP #{request_method} #{request_path} miniswan"
+          "#{request_method} #{request_path} miniswan"
         }
       end
 
@@ -182,7 +182,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET /success miniswan'
+        _(span.name).must_equal 'GET /success miniswan'
         # Old semantic conventions
         _(span.attributes['http.method']).must_equal 'GET'
         _(span.attributes['http.scheme']).must_equal 'http'
@@ -221,7 +221,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET'
+        _(span.name).must_equal 'GET'
         # Old semantic conventions
         _(span.attributes['http.method']).must_equal 'GET'
         _(span.attributes['http.scheme']).must_equal 'http'

--- a/instrumentation/http/test/instrumentation/http/patches/dup/connection_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/dup/connection_test.rb
@@ -41,7 +41,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Connection do
       end
 
       _(exporter.finished_spans.size).must_equal(2)
-      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.name).must_equal 'CONNECT'
       # Old semantic conventions
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil

--- a/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
@@ -49,7 +49,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
     it 'traces a simple request' do
       HTTP.get('http://example.com/success')
       _(exporter.finished_spans.size).must_equal(1)
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 200
@@ -69,7 +69,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       HTTP.post('http://example.com/failure')
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP POST'
+      _(span.name).must_equal 'POST'
       _(span.attributes['http.request.method']).must_equal 'POST'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 500
@@ -91,7 +91,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       end.must_raise HTTP::TimeoutError
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'https'
       _(span.attributes['http.response.status_code']).must_be_nil
@@ -119,7 +119,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       end
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 200
@@ -139,7 +139,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       let(:span_name_formatter) do
         # demonstrate simple addition of path and string to span name:
         lambda { |request_method, request_path|
-          "HTTP #{request_method} #{request_path} miniswan"
+          "#{request_method} #{request_path} miniswan"
         }
       end
 
@@ -149,7 +149,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET /success miniswan'
+        _(span.name).must_equal 'GET /success miniswan'
         _(span.attributes['http.request.method']).must_equal 'GET'
         _(span.attributes['url.scheme']).must_equal 'http'
         _(span.attributes['http.response.status_code']).must_equal 200
@@ -179,7 +179,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET'
+        _(span.name).must_equal 'GET'
         _(span.attributes['http.request.method']).must_equal 'GET'
         _(span.attributes['url.scheme']).must_equal 'http'
         _(span.attributes['http.response.status_code']).must_equal 200

--- a/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
@@ -41,7 +41,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Connection do
       end
 
       _(exporter.finished_spans.size).must_equal(2)
-      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.name).must_equal 'CONNECT'
       _(span.attributes['server.address']).must_equal('localhost')
       _(span.attributes['server.port']).wont_be_nil
     ensure


### PR DESCRIPTION
[Semantic conventions 1.34.0 updates span names](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/#http-server-span-name) to drop the leading `HTTP`, for example `HTTP GET` becomes just `GET`. To facilitate the transition from old to new HTTP semantic conventions, a new stability mode was introduced in #1547. However, the PR did not account for the span name update.

If `OTEL_SEMCONV_STABILITY_OPT_IN` is set to either `http` or `http/dup`, the span name should be inline with the new conventions. This PR makes this update and drops the leading `HTTP` from span names.
