### PR TITLE
fix: support GraphQL::Query::Partial in graphql instrumentation

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -99,7 +99,7 @@ module OpenTelemetry
           def execute_query(query:, &block)
             attributes = {}
             attributes['graphql.operation.name'] = query.selected_operation_name if query.selected_operation_name
-            if query.is_a?(::GraphQL::Query::Partial)
+            if defined?(::GraphQL::Query::Partial) && query.is_a?(::GraphQL::Query::Partial)
               attributes['graphql.partial.path'] = query.path.to_s
             else
               attributes['graphql.operation.type'] = query.selected_operation.operation_type

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -99,8 +99,12 @@ module OpenTelemetry
           def execute_query(query:, &block)
             attributes = {}
             attributes['graphql.operation.name'] = query.selected_operation_name if query.selected_operation_name
-            attributes['graphql.operation.type'] = query.selected_operation.operation_type
-            attributes['graphql.document'] = query.query_string
+            if query.is_a?(::GraphQL::Query::Partial)
+              attributes['graphql.partial.path'] = query.path.to_s
+            else
+              attributes['graphql.operation.type'] = query.selected_operation.operation_type
+              attributes['graphql.document'] = query.query_string
+            end
 
             tracer.in_span('graphql.execute_query', attributes: attributes) do
               super


### PR DESCRIPTION
I caught this by using the `@stream` directive with graphql-ruby and got a NPE on `query.selected_operation.operation_type`.

Since [graphql-ruby 2.5.6](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#256-5-may-2025), `GraphQL::Query::Partial` was added for running sub-trees of valid queries. The `query` argument of `execute_query` might be a `GraphQL::Query::Partial` in which case we don't have direct access to the operation type and the query string; I thought in this case it would be nice to see the query path 