### PR TITLE
feat: allow for propagation_style in Sidekiq instrumentation to have dynamic option

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/dynamic_validator.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/dynamic_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    # Can wrap a static validation in this class to allow users to
+    # alternatively invoke a callable.
+    class DynamicValidator
+      def initialize(static_validation)
+        raise ArgumentError, 'static_validation cannot be dynamic' if static_validation.is_a?(self.class)
+
+        @static_validation = static_validation
+      end
+
+      attr_reader :static_validation
+    end
+  end
+end

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -37,6 +37,7 @@ module OpenTelemetry
       # - `:none` - The job will be represented by a separate trace from the span that enqueued the job.
       #   There will be no explicit relationship between the job trace and the trace containing the span that
       #   enqueued the job.
+      # - Can alternatively be a callable which resolves to one of the above values.
       #
       # ### `:trace_launcher_heartbeat`
       #
@@ -101,7 +102,7 @@ module OpenTelemetry
         end
 
         option :span_naming,                 default: :queue, validate: %I[job_class queue]
-        option :propagation_style,           default: :link,  validate: %i[link child none]
+        option :propagation_style,           default: :link,  validate: DynamicValidator.new(%i[link child none])
         option :trace_launcher_heartbeat,    default: false, validate: :boolean
         option :trace_poller_enqueue,        default: false, validate: :boolean
         option :trace_poller_wait,           default: false, validate: :boolean


### PR DESCRIPTION
This still permits static values (and environment variable to configure them) but allows users to opt-in to having a callable/dynamic value for the given option.

Resolves open-telemetry/opentelemetry-ruby-contrib#991