### PR TITLE
feat: Puma plugin to gracefully shut down providers

### DIFF
--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -51,6 +51,7 @@ jobs:
           - koala
           - lmdb
           - net_http
+          - puma
           - rack
           - rails
           - restclient

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -30,6 +30,10 @@ commit_lint:
 #  *  changelog_path: Path to CHANGLEOG.md relative to the gem directory.
 #     (Required only if it is not in the expected location.)
 gems:
+  - name: opentelemetry-instrumentation-puma
+    directory: instrumentation/puma
+    version_constant: [OpenTelemetry, Instrumentation, Puma, VERSION]
+
   - name: opentelemetry-instrumentation-active_storage
     directory: instrumentation/active_storage
     version_constant: [OpenTelemetry, Instrumentation, ActiveStorage, VERSION]

--- a/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
+++ b/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry-instrumentation-puma'
 require 'opentelemetry-instrumentation-gruf'
 require 'opentelemetry-instrumentation-trilogy'
 require 'opentelemetry-instrumentation-active_support'

--- a/instrumentation/puma/.rubocop.yml
+++ b/instrumentation/puma/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/instrumentation/puma/.yardopts
+++ b/instrumentation/puma/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Puma Instrumentation
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/instrumentation/**/*.rb
+./lib/opentelemetry/instrumentation.rb
+-
+README.md
+CHANGELOG.md

--- a/instrumentation/puma/Appraisals
+++ b/instrumentation/puma/Appraisals
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+## TODO: Include the supported version to be tested here.
+## Example:
+# appraise 'rack-2.1' do
+#   gem 'rack', '~> 2.1.2'
+# end
+
+# appraise 'rack-2.0' do
+#   gem 'rack', '2.0.8'
+# end

--- a/instrumentation/puma/Appraisals
+++ b/instrumentation/puma/Appraisals
@@ -4,12 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-## TODO: Include the supported version to be tested here.
-## Example:
-# appraise 'rack-2.1' do
-#   gem 'rack', '~> 2.1.2'
-# end
+appraise 'puma-7.0' do
+  gem 'puma', '~> 7.0'
+end
 
-# appraise 'rack-2.0' do
-#   gem 'rack', '2.0.8'
-# end
+appraise 'puma-6.0' do
+  gem 'puma', '~> 6.0'
+end

--- a/instrumentation/puma/CHANGELOG.md
+++ b/instrumentation/puma/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-instrumentation-puma

--- a/instrumentation/puma/Gemfile
+++ b/instrumentation/puma/Gemfile
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+# DO NOT ADD DEPENDENCIES HERE!
+# Please declare a minimum development dependency in the gemspec,
+# then target specific versions in the Appraisals file.
+
+gemspec
+
+group :test do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'appraisal', '~> 2.5'
+  gem 'bundler', '~> 2.4'
+  gem 'minitest', '~> 5.0'
+  gem 'opentelemetry-sdk', '~> 1.0'
+  gem 'opentelemetry-test-helpers', '~> 0.3'
+  gem 'rake', '~> 13.0'
+  gem 'rubocop', '~> 1.79.1'
+  gem 'rubocop-performance', '~> 1.25.0'
+  gem 'simplecov', '~> 0.17.1'
+  gem 'yard', '~> 0.9'
+end

--- a/instrumentation/puma/Gemfile
+++ b/instrumentation/puma/Gemfile
@@ -6,10 +6,6 @@
 
 source 'https://rubygems.org'
 
-# DO NOT ADD DEPENDENCIES HERE!
-# Please declare a minimum development dependency in the gemspec,
-# then target specific versions in the Appraisals file.
-
 gemspec
 
 group :test do

--- a/instrumentation/puma/LICENSE
+++ b/instrumentation/puma/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/puma/README.md
+++ b/instrumentation/puma/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Puma Instrumentation
 
-The OpenTelemetry Puma gem is a community maintained instrumentation for [Puma][puma-home].
+The OpenTelemetry Puma gem is a community maintained instrumentation for [Puma][puma-home]. It currently does not emit Puma telemetry and only registers hooks to ensure application telemetry is sent before the Puma process exits.
 
 ## How do I get started?
 

--- a/instrumentation/puma/README.md
+++ b/instrumentation/puma/README.md
@@ -1,0 +1,50 @@
+# OpenTelemetry Puma Instrumentation
+
+The OpenTelemetry Puma gem is a community maintained instrumentation for [Puma][puma-home].
+
+## How do I get started?
+
+Install the gem using:
+
+```console
+gem install opentelemetry-instrumentation-puma
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-puma` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Puma'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-puma` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-puma` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[puma-home]: https://puma.io/
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[slack-channel]: https://cloud-native.slack.com/archives/C01NWKKMKMY
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/instrumentation/puma/Rakefile
+++ b/instrumentation/puma/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/instrumentation/puma/lib/opentelemetry-instrumentation-puma.rb
+++ b/instrumentation/puma/lib/opentelemetry-instrumentation-puma.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'opentelemetry/instrumentation'

--- a/instrumentation/puma/lib/opentelemetry/instrumentation.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Instrumentation should be able to handle the case when the library is not installed on a user's system.
+  module Instrumentation
+  end
+end
+
+require_relative 'instrumentation/puma'

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+require 'opentelemetry-instrumentation-base'
+
+module OpenTelemetry
+  module Instrumentation
+    # Contains the OpenTelemetry instrumentation for the Puma gem
+    module Puma
+    end
+  end
+end
+
+require_relative 'puma/instrumentation'
+require_relative 'puma/version'

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma/instrumentation.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma/instrumentation.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module Puma
+      # The Instrumentation class contains logic to detect and install the Puma instrumentation
+      class Instrumentation < OpenTelemetry::Instrumentation::Base
+        install do |_config|
+          require_dependencies
+          patch_configuration
+        end
+
+        present do
+          defined?(::Puma)
+        end
+
+        private
+
+        def require_dependencies
+          require_relative 'plugin'
+          require_relative 'patches/configuration'
+        end
+
+        def patch_configuration
+          ::Puma::Configuration.prepend(Patches::Configuration)
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma/patches/configuration.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma/patches/configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module Puma
+      module Patches
+        # The Configuration module adds the instrumentation plugin
+        module Configuration
+          def initialize(...)
+            super
+            @user_dsl.plugin('opentelemetry')
+          end
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma/plugin.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma/plugin.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'puma/plugin'
+
+module OpenTelemetry
+  module Instrumentation
+    module Puma
+      # The Puma plugin for OpenTelemetry
+      class Plugin < ::Puma::Plugin
+        ::Puma::Plugins.register('opentelemetry', self)
+
+        def start(launcher)
+          launcher.events.on_stopped do
+            shutdown_providers
+          end
+
+          launcher.events.on_restart do
+            shutdown_providers
+          end
+        end
+
+        private
+
+        def shutdown_providers
+          OpenTelemetry.tracer_provider.shutdown
+          OpenTelemetry.meter_provider.shutdown if OpenTelemetry.respond_to?(:meter_provider)
+          OpenTelemetry.logger_provider.shutdown if OpenTelemetry.respond_to?(:logger_provider)
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma/plugin.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma/plugin.rb
@@ -34,6 +34,8 @@ module OpenTelemetry
         end
 
         def shutdown_providers
+          return if ENV['OTEL_SDK_DISABLED'] == 'true'
+
           OpenTelemetry.tracer_provider.shutdown
           OpenTelemetry.meter_provider.shutdown if OpenTelemetry.respond_to?(:meter_provider)
           OpenTelemetry.logger_provider.shutdown if OpenTelemetry.respond_to?(:logger_provider)

--- a/instrumentation/puma/lib/opentelemetry/instrumentation/puma/version.rb
+++ b/instrumentation/puma/lib/opentelemetry/instrumentation/puma/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module Puma
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/instrumentation/puma/opentelemetry-instrumentation-puma.gemspec
+++ b/instrumentation/puma/opentelemetry-instrumentation-puma.gemspec
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/instrumentation/puma/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-instrumentation-puma'
+  spec.version     = OpenTelemetry::Instrumentation::Puma::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Puma instrumentation for the OpenTelemetry framework'
+  spec.description = 'Puma instrumentation for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = Dir.glob('lib/**/*.rb') +
+               Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.4.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
+  spec.add_dependency 'puma', '~> 6.0'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/puma'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues'
+    spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  end
+end

--- a/instrumentation/puma/opentelemetry-instrumentation-puma.gemspec
+++ b/instrumentation/puma/opentelemetry-instrumentation-puma.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.4.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
-  spec.add_dependency 'puma', '~> 6.0'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/puma/test/opentelemetry/instrumentation/puma/instrumentation_test.rb
+++ b/instrumentation/puma/test/opentelemetry/instrumentation/puma/instrumentation_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/puma'
+
+describe OpenTelemetry::Instrumentation::Puma do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::Puma::Instrumentation.instance }
+
+  it 'has #name' do
+    _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::Puma'
+  end
+
+  it 'has #version' do
+    _(instrumentation.version).wont_be_nil
+    _(instrumentation.version).wont_be_empty
+  end
+
+  describe '#install' do
+    it 'accepts argument' do
+      _(instrumentation.install({})).must_equal(true)
+      instrumentation.instance_variable_set(:@installed, false)
+    end
+
+    it 'allows the plugin to be found' do
+      instrumentation.install
+      _(Puma::Plugins.find('opentelemetry')).must_equal(OpenTelemetry::Instrumentation::Puma::Plugin)
+    end
+
+    it 'prepends the patch to automatically load the plugin' do
+      instrumentation.install
+      puma_config = Puma::Configuration.new
+      _(puma_config.plugins.instance_variable_get(:@instances).map(&:class))
+        .must_include(OpenTelemetry::Instrumentation::Puma::Plugin)
+    end
+  end
+end

--- a/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
+++ b/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
@@ -24,7 +24,8 @@ describe OpenTelemetry::Instrumentation::Puma::Plugin do
   end
 
   it 'flushes providers on stop' do
-    @launcher.events.on_booted do
+    event_name = ::Puma::Const::PUMA_VERSION < '7' ? :on_booted : :after_booted
+    @launcher.events.public_send(event_name) do
       sleep 1.1 unless mri?
       @launcher.stop
     end

--- a/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
+++ b/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
@@ -24,7 +24,7 @@ describe OpenTelemetry::Instrumentation::Puma::Plugin do
   end
 
   it 'flushes providers on stop' do
-    event_name = ::Puma::Const::PUMA_VERSION < '7' ? :on_booted : :after_booted
+    event_name = Puma::Const::PUMA_VERSION < '7' ? :on_booted : :after_booted
     @launcher.events.public_send(event_name) do
       sleep 1.1 unless mri?
       @launcher.stop

--- a/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
+++ b/instrumentation/puma/test/opentelemetry/instrumentation/puma/plugin_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+require 'opentelemetry/instrumentation/puma/plugin'
+
+describe OpenTelemetry::Instrumentation::Puma::Plugin do
+  before do
+    conf = Puma::Configuration.new do |user_config|
+      user_config.app do |_env|
+        [200, {}, ['hello world']]
+      end
+      user_config.bind("tcp://127.0.0.1:#{unique_port}")
+      user_config.plugin 'opentelemetry'
+    end
+    @launcher = Puma::Launcher.new(conf, log_writer: Puma::LogWriter.null)
+  end
+
+  after do
+    @launcher&.stop
+  end
+
+  it 'flushes providers on stop' do
+    @launcher.events.on_booted do
+      sleep 1.1 unless mri?
+      @launcher.stop
+    end
+    @launcher.run
+    sleep 1 unless mri?
+
+    _(OpenTelemetry.tracer_provider.instance_variable_get(:@stopped)).must_equal(true)
+    _(OpenTelemetry.meter_provider.instance_variable_get(:@stopped)).must_equal(true) if OpenTelemetry.respond_to?(:meter_provider)
+    _(OpenTelemetry.logger_provider.instance_variable_get(:@stopped)).must_equal(true) if OpenTelemetry.respond_to?(:logger_provider)
+  end
+
+  private
+
+  def unique_port
+    TCPServer.open('127.0.0.1', 0) do |server|
+      server.connect_address.ip_port
+    end
+  end
+
+  def mri?
+    RUBY_ENGINE == 'ruby'
+  end
+end

--- a/instrumentation/puma/test/test_helper.rb
+++ b/instrumentation/puma/test/test_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'minitest/autorun'
+require 'puma'
+require 'puma/configuration'
+
+# global opentelemetry-sdk setup:
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
+  c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
+  c.add_span_processor span_processor
+end


### PR DESCRIPTION
Following discussion at https://github.com/open-telemetry/opentelemetry-ruby/discussions/1357 and [on Slack](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1754426751777279) I decided to take a moment and write a Puma plugin to shutdown tracer/meter/logger providers and make sure nothing is lost before the process exits. Given that puma is the default for newly generated Rails apps, this should make things "just work" a little better.

First time contributor, I'm sure I'm missing things :) any feedback welcome!

