### PR TITLE
feat: add Render resource detector

### DIFF
--- a/resources/render/.rubocop.yml
+++ b/resources/render/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/resources/render/.yardopts
+++ b/resources/render/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Render Instrumentation
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/instrumentation/**/*.rb
+./lib/opentelemetry/instrumentation.rb
+-
+README.md
+CHANGELOG.md

--- a/resources/render/CHANGELOG.md
+++ b/resources/render/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-resource-detector-render

--- a/resources/render/Gemfile
+++ b/resources/render/Gemfile
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+group :test do
+  gem 'bundler', '~> 2.4'
+  gem 'minitest', '~> 5.0'
+  gem 'opentelemetry-test-helpers', '~> 0.3'
+  gem 'rake', '~> 13.0'
+  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop-performance', '~> 1.24.0'
+  gem 'simplecov', '~> 0.22.0'
+  gem 'yard', '~> 0.9'
+end

--- a/resources/render/LICENSE
+++ b/resources/render/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/resources/render/README.md
+++ b/resources/render/README.md
@@ -1,0 +1,66 @@
+# OpenTelemetry::Resource::Detector::Render
+
+The `opentelemetry-resource-detector-render` gem provides a Render resource detector for OpenTelemetry.
+
+## What is OpenTelemetry?
+
+OpenTelemetry is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-resource-detector-render` gem provides a means of retrieving a resource for supported environments following the resource semantic conventions. When running on the Render platform, this detector automatically identifies and populates resource attributes with relevant metadata from the environment.
+
+## How do I get started?
+
+Install the gem using:
+
+```console
+gem install opentelemetry-sdk
+gem install opentelemetry-instrumentation-render
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk` and `opentelemetry-instrumentation-render` in your `Gemfile`.
+
+## Usage
+
+```ruby
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector'
+
+OpenTelemetry::SDK.configure do |c|
+  c.resource = OpenTelemetry::Resource::Detector::Render.detect
+end
+```
+
+Populates `cloud`, `render` and `service` for processes running on Render.
+
+| Resource Attribute | Description |
+|--------------------|-------------|
+| `cloud.provider` | The cloud provider. In this context, it's always "render" |
+| `render.is_pull_request` | Value of the `IS_PULL_REQUEST` environment variable |
+| `render.git.branch` | Value of the `RENDER_GIT_BRANCH` environment variable |
+| `render.git.repo_slug` | Value of the `RENDER_GIT_REPO_SLUG` environment variable |
+| `service.id` | Value of the `RENDER_SERVICE_ID` environment variable |
+| `service.instance.id` | Value of the `RENDER_INSTANCE_ID` environment variable |
+| `service.name` | Value of the `RENDER_SERVICE_NAME` environment variable |
+| `service.version` | Value of the `RENDER_GIT_COMMIT` environment variable |
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-render` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-render` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[slack-channel]: https://cloud-native.slack.com/archives/C01NWKKMKMY
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/resources/render/Rakefile
+++ b/resources/render/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/resources/render/lib/opentelemetry-resource-detector-render.rb
+++ b/resources/render/lib/opentelemetry-resource-detector-render.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/semantic_conventions/resource'
+require_relative 'opentelemetry/resource/detector'

--- a/resources/render/lib/opentelemetry/resource/detector.rb
+++ b/resources/render/lib/opentelemetry/resource/detector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+require 'opentelemetry/resource/detector/render'
+require 'opentelemetry/resource/detector/render/version'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  module Resource
+    # Detector contains the resource detectors
+    module Detector
+    end
+  end
+end

--- a/resources/render/lib/opentelemetry/resource/detector/render.rb
+++ b/resources/render/lib/opentelemetry/resource/detector/render.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Resource
+    module Detector
+      # Render contains detect class method for determining Render environment resource attributes
+      module Render
+        extend self
+
+        RESOURCE = OpenTelemetry::SemanticConventions::Resource
+
+        def detect
+          resource_attributes = {}
+          if ENV.fetch('RENDER', false) == 'true'
+            resource_attributes[RESOURCE::CLOUD_PROVIDER] = 'render'
+            resource_attributes['render.is_pull_request'] = ENV.fetch('IS_PULL_REQUEST', 'false')
+            resource_attributes['render.git.branch'] = ENV.fetch('RENDER_GIT_BRANCH', nil)
+            resource_attributes['render.git.repo_slug'] = ENV.fetch('RENDER_GIT_REPO_SLUG', nil)
+            resource_attributes[RESOURCE::SERVICE_INSTANCE_ID] = ENV.fetch('RENDER_INSTANCE_ID', nil)
+            resource_attributes[RESOURCE::SERVICE_NAME] = ENV.fetch('RENDER_SERVICE_NAME', 'unknown_service')
+            resource_attributes[RESOURCE::SERVICE_VERSION] = ENV.fetch('RENDER_GIT_COMMIT', nil)
+
+            resource_attributes.delete_if { |_key, value| value.nil? || value.empty? }
+          else
+            OpenTelemetry.logger.warn('Render resource detector did not detect Render environment')
+          end
+
+          OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
+        end
+      end
+    end
+  end
+end

--- a/resources/render/lib/opentelemetry/resource/detector/render/version.rb
+++ b/resources/render/lib/opentelemetry/resource/detector/render/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Resource
+    module Detector
+      module Render
+        VERSION = '0.0.0'
+      end
+    end
+  end
+end

--- a/resources/render/opentelemetry-resource-detector-render.gemspec
+++ b/resources/render/opentelemetry-resource-detector-render.gemspec
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/resource/detector/render/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-resource-detector-render'
+  spec.version     = OpenTelemetry::Resource::Detector::Render::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Render resource detector for OpenTelemetry'
+  spec.description = 'Render resource detector for OpenTelemetry'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = Dir.glob('lib/**/*.rb') +
+               ['LICENSE', 'README.md']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
+
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/render'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues'
+    spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  end
+end

--- a/resources/render/test/opentelemetry/resource/detector/render_test.rb
+++ b/resources/render/test/opentelemetry/resource/detector/render_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Resource::Detector::Render do
+  let(:detector) { OpenTelemetry::Resource::Detector::Render }
+
+  describe '.detect' do
+    let(:detected_resource) { detector.detect }
+    let(:detected_resource_attributes) { detected_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) { {} }
+
+    describe 'when NOT in a Render environment' do
+      it 'returns an empty resource' do
+        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+        _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      end
+    end
+
+    describe 'when in a Render environment' do
+      let(:render_environment_variables) do
+        {
+          'RENDER_EXTERNAL_HOSTNAME' => 'example.onrender.com',
+          'RENDER_GIT_REPO_SLUG' => 'foo/bar',
+          'RENDER' => 'true',
+          'RENDER_SERVICE_ID' => 'srv-1234567890',
+          'RENDER_CPU_COUNT' => '2',
+          'RENDER_EXTERNAL_URL' => 'https://example.onrender.com',
+          'RENDER_SERVICE_TYPE' => 'web',
+          'RENDER_GIT_BRANCH' => 'main',
+          'RENDER_INSTANCE_ID' => 'srv-1234567890-abcd1234',
+          'RENDER_GIT_COMMIT' => 'd94b5f7ec7c6d7602c78a5e9b8a5b8c94d093eda',
+          'RENDER_SERVICE_NAME' => 'example-22zn',
+          'RENDER_DISCOVERY_SERVICE' => 'example-discovery',
+          'PORT' => '10000'
+        }
+      end
+
+      let(:expected_resource_attributes) do
+        {
+          'cloud.provider' => 'render',
+          'render.is_pull_request' => 'false',
+          'render.git.branch' => 'main',
+          'render.git.repo_slug' => 'foo/bar',
+          'service.instance.id' => 'srv-1234567890-abcd1234',
+          'service.name' => 'example-22zn',
+          'service.version' => 'd94b5f7ec7c6d7602c78a5e9b8a5b8c94d093eda'
+        }
+      end
+
+      it 'returns a resource with container id for cgroup v1' do
+        OpenTelemetry::TestHelpers.with_env(render_environment_variables) do
+          _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+          _(detected_resource_attributes).must_equal(expected_resource_attributes)
+        end
+      end
+
+      describe 'and a nil resource value is detected' do
+        let(:render_environment_variables) do
+          {
+            'RENDER' => 'true'
+          }
+        end
+
+        it 'returns a resource without that attribute' do
+          OpenTelemetry::TestHelpers.with_env(render_environment_variables) do
+            _(detected_resource_attributes.key?('service.id')).must_equal(false)
+          end
+        end
+
+        it 'returns the default service name' do
+          OpenTelemetry::TestHelpers.with_env(render_environment_variables) do
+            _(detected_resource_attributes['service.name']).must_equal('unknown_service')
+          end
+        end
+      end
+
+      describe 'and an empty string resource value is detected' do
+        let(:render_environment_variables) do
+          {
+            'RENDER' => 'true',
+            'RENDER_SERVICE_ID' => ''
+          }
+        end
+
+        it 'returns a resource without that attribute' do
+          OpenTelemetry::TestHelpers.with_env(render_environment_variables) do
+            _(detected_resource_attributes.key?('service.id')).must_equal(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/resources/render/test/test_helper.rb
+++ b/resources/render/test/test_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'simplecov'
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'opentelemetry-resource-detector-render'
+require 'minitest/autorun'
+
+OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)


### PR DESCRIPTION
This implements a resource detector for the Render platform. I used the AWS EC2 implementation and [Heroku](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/heroku/) conventions as inspiration.

Docs:
- https://render.com/docs/environment-variables
- https://render.com/docs/metrics-streams#universal-properties to compare with the metrics the Render platform can emit