### PR TITLE
chore: replace bitnami redis images with official images

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -212,7 +212,7 @@ jobs:
           build: true
     services:
       redis:
-        image: bitnami/redis:6.2
+        image: redis:6.2
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -215,8 +215,9 @@ jobs:
         image: redis:6.2
         ports:
           - 6379:6379
+        command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
       - postgres_socket:/var/run/postgresql
 
   redis:
-    image: bitnami/redis:6.2
+    image: redis:6.2
     environment:
       - REDIS_PASSWORD=passw0rd
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,12 @@ services:
       - redis_data:/data
     ports:
       - "16379:6379"
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
+    options: >-
+      --health-cmd "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
 
   rabbitmq:
     image: rabbitmq:3.8-alpine


### PR DESCRIPTION
Closes #1683 

_note: we may want to bump the image to a more recent major version of redis (ie 8.x), but that can be done in a separate PR. At a glance I wasn't sure which major versions the gem supported._