### PR TITLE
fix: add Active Support as runtime dependency in Racecar instrumentation

### DIFF
--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
 


### PR DESCRIPTION
Installation of Racecar instrumentation silently fails without Active Support. Since this instrumentation doesn’t work at all without Active Support, it should be listed as a runtime dependency.

It was already being installed in test and example Gemfiles.