### PR TITLE
feat: Bump minimum API Version to 1.7

### DIFF
--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> <%= opentelemetry_version %>'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> <%= instrumentation_base_version %>'
 
   if spec.respond_to?(:metadata)

--- a/helpers/mysql/opentelemetry-helpers-mysql.gemspec
+++ b/helpers/mysql/opentelemetry-helpers-mysql.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
 
   if spec.respond_to?(:metadata)

--- a/helpers/sql/opentelemetry-helpers-sql.gemspec
+++ b/helpers/sql/opentelemetry-helpers-sql.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/action_mailer/opentelemetry-instrumentation-action_mailer.gemspec
+++ b/instrumentation/action_mailer/opentelemetry-instrumentation-action_mailer.gemspec
@@ -25,9 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.7'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
+++ b/instrumentation/action_pack/opentelemetry-instrumentation-action_pack.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -25,9 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.7'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
+++ b/instrumentation/active_model_serializers/opentelemetry-instrumentation-active_model_serializers.gemspec
@@ -25,9 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '>= 0.7.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
+++ b/instrumentation/active_record/opentelemetry-instrumentation-active_record.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/active_storage/opentelemetry-instrumentation-active_storage.gemspec
+++ b/instrumentation/active_storage/opentelemetry-instrumentation-active_storage.gemspec
@@ -25,9 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.7'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
+++ b/instrumentation/active_support/opentelemetry-instrumentation-active_support.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/anthropic/opentelemetry-instrumentation-anthropic.gemspec
+++ b/instrumentation/anthropic/opentelemetry-instrumentation-anthropic.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.6'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/aws_lambda/opentelemetry-instrumentation-aws_lambda.gemspec
+++ b/instrumentation/aws_lambda/opentelemetry-instrumentation-aws_lambda.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
   spec.add_dependency 'opentelemetry-registry', '~> 0.1'
 

--- a/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
+++ b/instrumentation/bunny/opentelemetry-instrumentation-bunny.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
+++ b/instrumentation/delayed_job/opentelemetry-instrumentation-delayed_job.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
+++ b/instrumentation/grape/opentelemetry-instrumentation-grape.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/grpc/opentelemetry-instrumentation-grpc.gemspec
+++ b/instrumentation/grpc/opentelemetry-instrumentation-grpc.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
+++ b/instrumentation/gruf/opentelemetry-instrumentation-gruf.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '>=  1.0.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23.0'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
+++ b/instrumentation/http_client/opentelemetry-instrumentation-http_client.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
+++ b/instrumentation/httpx/opentelemetry-instrumentation-httpx.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
+++ b/instrumentation/lmdb/opentelemetry-instrumentation-lmdb.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
+++ b/instrumentation/mongo/opentelemetry-instrumentation-mongo.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
   spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-helpers-sql'
   spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
+++ b/instrumentation/racecar/opentelemetry-instrumentation-racecar.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-action_mailer', '~> 0.4'
   spec.add_dependency 'opentelemetry-instrumentation-action_pack', '~> 0.13'
   spec.add_dependency 'opentelemetry-instrumentation-action_view', '~> 0.9'
@@ -33,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-instrumentation-active_record', '~> 0.9'
   spec.add_dependency 'opentelemetry-instrumentation-active_storage', '~> 0.1'
   spec.add_dependency 'opentelemetry-instrumentation-active_support', '~> 0.8'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
   spec.add_dependency 'opentelemetry-instrumentation-concurrent_ruby', '~> 0.22'
 
   spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rails' if spec.respond_to?(:metadata)

--- a/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
+++ b/instrumentation/rake/opentelemetry-instrumentation-rake.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
+++ b/instrumentation/rdkafka/opentelemetry-instrumentation-rdkafka.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
+++ b/instrumentation/resque/opentelemetry-instrumentation-resque.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
+++ b/instrumentation/ruby_kafka/opentelemetry-instrumentation-ruby_kafka.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.23'
   spec.add_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.7'
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
   spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'

--- a/processor/baggage/opentelemetry-processor-baggage.gemspec
+++ b/processor/baggage/opentelemetry-processor-baggage.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
 
   if spec.respond_to?(:metadata)

--- a/propagator/google_cloud_trace_context/opentelemetry-propagator-google_cloud_trace_context.gemspec
+++ b/propagator/google_cloud_trace_context/opentelemetry-propagator-google_cloud_trace_context.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
+++ b/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/propagator/vitess/opentelemetry-propagator-vitess.gemspec
+++ b/propagator/vitess/opentelemetry-propagator-vitess.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-propagator-jaeger', '~> 0.21'
 
   if spec.respond_to?(:metadata)

--- a/propagator/xray/opentelemetry-propagator-xray.gemspec
+++ b/propagator/xray/opentelemetry-propagator-xray.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/sampler/xray/opentelemetry-sampler-xray.gemspec
+++ b/sampler/xray/opentelemetry-sampler-xray.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_dependency 'opentelemetry-semantic_conventions', '~> 1.11'


### PR DESCRIPTION
The instrumentation base gem already has a dependency on the API, so declaring the dependency again isn't necessary.

Removing the extra declaration in individual instrumentation gemspecs removes the need to keep all instrumentation gems in sync with each other.


## What am I trying to fix?

```console
Installing latest version of published gems and running tests
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Could not find compatible versions

Because opentelemetry-instrumentation-trilogy >= 0.62.0 depends on opentelemetry-api ~> 1.7
  and every version of opentelemetry-instrumentation-anthropic depends on opentelemetry-api ~> 1.6.0,
  opentelemetry-instrumentation-trilogy >= 0.62.0 is incompatible with opentelemetry-instrumentation-anthropic >= 0.
So, because Gemfile depends on opentelemetry-instrumentation-anthropic = 0.1.0
  and Gemfile depends on opentelemetry-instrumentation-trilogy = 0.62.0,
  version solving has failed.
```