### PR TITLE
fix: fallback to legacy bitnami for redis images

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -212,12 +212,11 @@ jobs:
           build: true
     services:
       redis:
-        image: redis:6.2
+        image: bitnamilegacy/redis:6.2
         ports:
           - 6379:6379
-        command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
         options: >-
-          --health-cmd "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"
+          --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,19 +198,13 @@ services:
       - postgres_socket:/var/run/postgresql
 
   redis:
-    image: redis:6.2
+    image: bitnamilegacy/redis:6.2
     environment:
       - REDIS_PASSWORD=passw0rd
     volumes:
       - redis_data:/data
     ports:
       - "16379:6379"
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
-    healthcheck:
-      test: ["CMD-SHELL", "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   rabbitmq:
     image: rabbitmq:3.8-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,11 +206,11 @@ services:
     ports:
       - "16379:6379"
     command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
-    options: >-
-      --health-cmd "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"
-      --health-interval 10s
-      --health-timeout 5s
-      --health-retries 5
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'redis-cli -a \"$REDIS_PASSWORD\" ping | grep PONG'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   rabbitmq:
     image: rabbitmq:3.8-alpine


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1703

Workflow run: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/18099693122/job/51499167553

The new Redis images I introduced in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1689 would require setting a password via cli, which is more complicated to configure than I had expected, and requires different configurations for both docker compose and gh workflows. It would appear for gh workflows, where we can't just modify the entrypoint script, we may have to find a different (or build/publish our own) image for redis. It requires further investigation.

I am limited on time but we can fallback to bitnamilegacy for now to unblock, which has a tradeoff of being unmaintained.