### PR TITLE
chore: Configure Dependabot to update recursively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    directory: "/"
+    directories: "**/*"
     schedule:
       interval: weekly
-    groups:
-      all-gems:
-        patterns:
-          - "**/Gemfile"


### PR DESCRIPTION
The gemspecs dependencies are currently not being updated automatically by dependabot.  

This change uses recursive directories instead of only updating the root Gemfile.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files