### PR TITLE
feat: sidekiq scheduled jobs improvements - `scheduled` operation and add links

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
               attributes[SemanticConventions::Trace::PEER_SERVICE] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
 
               scheduled_at = job['at']
-              op = scheduled_at.nil? ? "publish" : "scheduled"
+              op = scheduled_at.nil? ? 'publish' : 'scheduled'
 
               span_name = case instrumentation_config[:span_naming]
                           when :job_class then "#{job['wrapped']&.to_s || job['class']} #{op}"

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -33,11 +33,13 @@ module OpenTelemetry
               extracted_context = OpenTelemetry.propagation.extract(msg)
               created_at = time_from_timestamp(msg['created_at'])
               enqueued_at = time_from_timestamp(msg['created_at'])
+              scheduled_at = time_from_timestamp(msg['at']) unless msg['at'].nil?
               OpenTelemetry::Context.with_current(extracted_context) do
                 if instrumentation_config[:propagation_style] == :child
                   tracer.in_span(span_name, attributes: attributes, kind: :consumer) do |span|
                     span.add_event('created_at', timestamp: created_at)
                     span.add_event('enqueued_at', timestamp: enqueued_at)
+                    span.add_event('scheduled_at', timestamp: scheduled_at) unless scheduled_at.nil?
                     yield
                   end
                 else
@@ -48,6 +50,7 @@ module OpenTelemetry
                   OpenTelemetry::Trace.with_span(span) do
                     span.add_event('created_at', timestamp: created_at)
                     span.add_event('enqueued_at', timestamp: enqueued_at)
+                    span.add_event('scheduled_at', timestamp: scheduled_at) unless scheduled_at.nil?
                     yield
                   rescue Exception => e # rubocop:disable Lint/RescueException
                     span.record_exception(e)

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
 
               extracted_context = OpenTelemetry.propagation.extract(msg)
               created_at = time_from_timestamp(msg['created_at'])
-              enqueued_at = time_from_timestamp(msg['created_at'])
+              enqueued_at = time_from_timestamp(msg['enqueued_at'])
               scheduled_at = time_from_timestamp(msg['at']) unless msg['at'].nil?
               OpenTelemetry::Context.with_current(extracted_context) do
                 if instrumentation_config[:propagation_style] == :child

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(root_span.kind).must_equal :producer
 
         # process span is linked to the root enqueuing job
-        child_span1 = spans.find { |s| s.links && s.links.first.span_context.span_id == root_span.span_id }
+        child_span1 = spans.find { |s| s.links&.first&.span_context&.span_id == root_span.span_id }
         _(child_span1.name).must_equal 'default process'
         _(child_span1.kind).must_equal :consumer
 
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(child_span2.kind).must_equal :producer
 
         # last process job is linked back to the process job that enqueued it
-        child_span3 = spans.find { |s| s.links && s.links.first.span_context.span_id == child_span2.span_id }
+        child_span3 = spans.find { |s| s.links&.first&.span_context&.span_id == child_span2.span_id }
         _(child_span3.name).must_equal 'default process'
         _(child_span3.kind).must_equal :consumer
       end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(root_span.kind).must_equal :producer
 
         # process span is linked to the root enqueuing job
-        child_span1 = spans.find { |s| s.links && s.links.first && s.links.first.span_context.span_id == root_span.span_id }
+        child_span1 = spans.find { |s| s.links&.first&.span_context&.span_id == root_span.span_id }
         _(child_span1.name).must_equal 'default process'
         _(child_span1.kind).must_equal :consumer
 
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(child_span2.kind).must_equal :producer
 
         # last process job is linked back to the process job that enqueued it
-        child_span3 = spans.find { |s| s.links && s.links.first && s.links.first.span_context.span_id == child_span2.span_id }
+        child_span3 = spans.find { |s| s.links&.first&.span_context&.span_id == child_span2.span_id }
         _(child_span3.name).must_equal 'default process'
         _(child_span3.kind).must_equal :consumer
       end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(root_span.kind).must_equal :producer
 
         # process span is linked to the root enqueuing job
-        child_span1 = spans.find { |s| s.links&.first&.span_context&.span_id == root_span.span_id }
+        child_span1 = spans.find { |s| s.links && s.links.first && s.links.first.span_context.span_id == root_span.span_id }
         _(child_span1.name).must_equal 'default process'
         _(child_span1.kind).must_equal :consumer
 
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(child_span2.kind).must_equal :producer
 
         # last process job is linked back to the process job that enqueued it
-        child_span3 = spans.find { |s| s.links&.first&.span_context&.span_id == child_span2.span_id }
+        child_span3 = spans.find { |s| s.links && s.links.first && s.links.first.span_context.span_id == child_span2.span_id }
         _(child_span3.name).must_equal 'default process'
         _(child_span3.kind).must_equal :consumer
       end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(root_span.kind).must_equal :producer
 
         # process span is linked to the root enqueuing job
-        child_span1 = spans.find { |s| s.links&.first&.span_context&.span_id == root_span.span_id }
+        child_span1 = spans.find { |s| s.links&.first && s.links.first.span_context.span_id == root_span.span_id }
         _(child_span1.name).must_equal 'default process'
         _(child_span1.kind).must_equal :consumer
 
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
         _(child_span2.kind).must_equal :producer
 
         # last process job is linked back to the process job that enqueued it
-        child_span3 = spans.find { |s| s.links&.first&.span_context&.span_id == child_span2.span_id }
+        child_span3 = spans.find { |s| s.links&.first && s.links.first.span_context.span_id == child_span2.span_id }
         _(child_span3.name).must_equal 'default process'
         _(child_span3.kind).must_equal :consumer
       end


### PR DESCRIPTION
When a Job is pushed via `perform_in` or friends, it goes through the following life-cycle:
1. First the Job is pushed with `at` attribute in Redis from `Sidekiq::Client` - this will now create `<...> scheduled` span (before it was `<...> publish`
2. Then the Job is handled from `Sidekiq::Scheduled#enqueue` and pushed without `at` attribute in Redis from `Sidekiq::Client` - this will keep creating `<...> publish` span
3. Then the Job is handled by the Worker as usual

Additionally when using `:propagation_style = :link` and `:trace_poller_enqueue = true` a handy set of links are added between the 3 actors above.