### PR TITLE
chore: Fix dependabot syntax error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    directories: "**/*"
+    directories:
+      - "**/*"
     schedule:
       interval: weekly


### PR DESCRIPTION
Fixes this syntax error:

> Dependabot encountered the following error when parsing your .github/dependabot.yml:
> 
> The property '#/updates/1/directories' of type string did not match the following type: array
> Please update the config file to conform with Dependabot's specification.