### PR TITLE
revert: Bad dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    directories:
-      - "**/*"
+    directories: "**/*"
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    directories: "**/*"
+    directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all-gems:
+        patterns:
+          - "**/Gemfile"


### PR DESCRIPTION
Fixes the following errors https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/18297670748/job/52099249745:

```
updater | 2025/10/06 23:51:10 ERROR <job_1119074963> Error during file fetching; aborting: The following path based dependencies could not be retrieved: base

+-------------------------------------------------------+
|                        Errors                         |
+---------------------------------+---------------------+
| Type                            | Details             |
+---------------------------------+---------------------+
| path_dependencies_not_reachable | {                   |
|                                 |   "dependencies": [ |
|                                 |     "base"          |
|                                 |   ]                 |
|                                 | }                   |
+---------------------------------+---------------------+
```