### PR TITLE
fix: Fixing missing OpenTelemetry::Context detach on Excon instrumentation

### DIFF
--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/dup/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/dup/tracer_middleware.rb
@@ -84,7 +84,8 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
+                token = datum.delete(:otel_token)
+                OpenTelemetry::Context.detach(token) if token
                 return unless span.recording?
 
                 if datum.key?(:response)

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/dup/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/dup/tracer_middleware.rb
@@ -84,6 +84,7 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
+                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
                 return unless span.recording?
 
                 if datum.key?(:response)
@@ -99,7 +100,6 @@ module OpenTelemetry
                 end
 
                 span.finish
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
               end
             rescue StandardError => e
               OpenTelemetry.handle_error(e)

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/old/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/old/tracer_middleware.rb
@@ -76,6 +76,7 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
+                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
                 return unless span.recording?
 
                 if datum.key?(:response)
@@ -90,7 +91,6 @@ module OpenTelemetry
                 end
 
                 span.finish
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
               end
             rescue StandardError => e
               OpenTelemetry.handle_error(e)

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/old/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/old/tracer_middleware.rb
@@ -76,7 +76,8 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
+                token = datum.delete(:otel_token)
+                OpenTelemetry::Context.detach(token) if token
                 return unless span.recording?
 
                 if datum.key?(:response)

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/stable/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/stable/tracer_middleware.rb
@@ -76,6 +76,7 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
+                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
                 return unless span.recording?
 
                 if datum.key?(:response)
@@ -90,7 +91,6 @@ module OpenTelemetry
                 end
 
                 span.finish
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
               end
             rescue StandardError => e
               OpenTelemetry.handle_error(e)

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/stable/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/stable/tracer_middleware.rb
@@ -76,7 +76,8 @@ module OpenTelemetry
 
             def handle_response(datum)
               datum.delete(:otel_span)&.tap do |span|
-                OpenTelemetry::Context.detach(datum.delete(:otel_token)) if datum.include?(:otel_token)
+                token = datum.delete(:otel_token)
+                OpenTelemetry::Context.detach(token) if token
                 return unless span.recording?
 
                 if datum.key?(:response)

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/dup/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/dup/instrumentation_test.rb
@@ -201,22 +201,15 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
     end
 
     describe 'context detachment with non-recording spans' do
-      before do
-        @original_sampler = OpenTelemetry.tracer_provider.sampler
-        OpenTelemetry.tracer_provider.sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
-      end
-
-      after do
-        OpenTelemetry.tracer_provider.sampler = @original_sampler
-      end
-
       it 'detaches context when span is not recorded' do
-        initial_context = OpenTelemetry::Context.current
-        Excon.get('http://example.com/success')
-        final_context = OpenTelemetry::Context.current
+        with_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF) do
+          initial_context = OpenTelemetry::Context.current
+          Excon.get('http://example.com/success')
+          final_context = OpenTelemetry::Context.current
 
-        _(final_context).must_equal initial_context
-        _(exporter.finished_spans).must_be_empty
+          _(final_context).must_equal initial_context
+          _(exporter.finished_spans).must_be_empty
+        end
       end
     end
   end

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/dup/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/dup/instrumentation_test.rb
@@ -199,6 +199,26 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(span.attributes['peer.service']).must_equal 'example:custom'
     end
+
+    describe 'context detachment with non-recording spans' do
+      before do
+        @original_sampler = OpenTelemetry.tracer_provider.sampler
+        OpenTelemetry.tracer_provider.sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
+      end
+
+      after do
+        OpenTelemetry.tracer_provider.sampler = @original_sampler
+      end
+
+      it 'detaches context when span is not recorded' do
+        initial_context = OpenTelemetry::Context.current
+        Excon.get('http://example.com/success')
+        final_context = OpenTelemetry::Context.current
+
+        _(final_context).must_equal initial_context
+        _(exporter.finished_spans).must_be_empty
+      end
+    end
   end
 
   describe 'untraced?' do

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/old/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/old/instrumentation_test.rb
@@ -160,22 +160,15 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
     end
 
     describe 'context detachment with non-recording spans' do
-      before do
-        @original_sampler = OpenTelemetry.tracer_provider.sampler
-        OpenTelemetry.tracer_provider.sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
-      end
-
-      after do
-        OpenTelemetry.tracer_provider.sampler = @original_sampler
-      end
-
       it 'detaches context when span is not recorded' do
-        initial_context = OpenTelemetry::Context.current
-        Excon.get('http://example.com/success')
-        final_context = OpenTelemetry::Context.current
+        with_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF) do
+          initial_context = OpenTelemetry::Context.current
+          Excon.get('http://example.com/success')
+          final_context = OpenTelemetry::Context.current
 
-        _(final_context).must_equal initial_context
-        _(exporter.finished_spans).must_be_empty
+          _(final_context).must_equal initial_context
+          _(exporter.finished_spans).must_be_empty
+        end
       end
     end
   end

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
@@ -172,6 +172,26 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(span.attributes['peer.service']).must_equal 'example:custom'
     end
+
+    describe 'context detachment with non-recording spans' do
+      before do
+        @original_sampler = OpenTelemetry.tracer_provider.sampler
+        OpenTelemetry.tracer_provider.sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
+      end
+
+      after do
+        OpenTelemetry.tracer_provider.sampler = @original_sampler
+      end
+
+      it 'detaches context when span is not recorded' do
+        initial_context = OpenTelemetry::Context.current
+        Excon.get('http://example.com/success')
+        final_context = OpenTelemetry::Context.current
+
+        _(final_context).must_equal initial_context
+        _(exporter.finished_spans).must_be_empty
+      end
+    end
   end
 
   describe 'untraced?' do

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
@@ -174,22 +174,15 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
     end
 
     describe 'context detachment with non-recording spans' do
-      before do
-        @original_sampler = OpenTelemetry.tracer_provider.sampler
-        OpenTelemetry.tracer_provider.sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
-      end
-
-      after do
-        OpenTelemetry.tracer_provider.sampler = @original_sampler
-      end
-
       it 'detaches context when span is not recorded' do
-        initial_context = OpenTelemetry::Context.current
-        Excon.get('http://example.com/success')
-        final_context = OpenTelemetry::Context.current
+        with_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF) do
+          initial_context = OpenTelemetry::Context.current
+          Excon.get('http://example.com/success')
+          final_context = OpenTelemetry::Context.current
 
-        _(final_context).must_equal initial_context
-        _(exporter.finished_spans).must_be_empty
+          _(final_context).must_equal initial_context
+          _(exporter.finished_spans).must_be_empty
+        end
       end
     end
   end

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -20,3 +20,11 @@ OpenTelemetry::SDK.configure do |c|
   c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
   c.add_span_processor span_processor
 end
+
+def with_sampler(sampler)
+  previous_sampler = OpenTelemetry.tracer_provider.sampler
+  OpenTelemetry.tracer_provider.sampler = sampler
+  yield
+ensure
+  OpenTelemetry.tracer_provider.sampler = previous_sampler
+end


### PR DESCRIPTION
When a span is not recorded, for example when you are sampling traces, the OpenTelemetry::Context attached on `request_call` is never detached. This happens because `handle_response` is doing nothing if `span.recording?` is false.

Here is example of the error that the missing detach generated:
```
ERROR -- : OpenTelemetry error: calls to detach should match corresponding calls to attach.
```