### PR TITLE
chore: Fix release matching directories

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -39,7 +39,11 @@ gems:
     version_constant: [OpenTelemetry, Instrumentation, ActiveStorage, VERSION]
 
   - name: opentelemetry-helpers-sql
-    directory: helpers/sql
+    # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
+    # which casues helpers/sql to incorrectly match when changes occur in helpers/sql-processor or helpers/sql-obfuscation
+    # https://github.com/dazuma/toys/blob/17ed449da8299f272b834470ff6b279a59e8070b/.toys/release/.lib/release_utils.rb#L436
+    # https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1727
+    directory: helpers/sql/
     version_constant: [OpenTelemetry, Helpers, Sql, VERSION]
 
   - name: opentelemetry-instrumentation-gruf
@@ -130,7 +134,11 @@ gems:
     version_constant: [OpenTelemetry, Instrumentation, LMDB, VERSION]
 
   - name: opentelemetry-instrumentation-http
-    directory: instrumentation/http
+    # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
+    # which casues instrumentation/http to incorrectly match when changes occur in instrumentation/httpx
+    # https://github.com/dazuma/toys/blob/17ed449da8299f272b834470ff6b279a59e8070b/.toys/release/.lib/release_utils.rb#L436
+    # https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1512
+    directory: instrumentation/http/
     version_constant: [OpenTelemetry, Instrumentation, HTTP, VERSION]
 
   - name: opentelemetry-instrumentation-graphql

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -40,7 +40,7 @@ gems:
 
   - name: opentelemetry-helpers-sql
     # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
-    # which casues helpers/sql to incorrectly match when changes occur in helpers/sql-processor or helpers/sql-obfuscation
+    # which causes helpers/sql to incorrectly match when changes occur in helpers/sql-processor or helpers/sql-obfuscation
     # https://github.com/dazuma/toys/blob/17ed449da8299f272b834470ff6b279a59e8070b/.toys/release/.lib/release_utils.rb#L436
     # https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1727
     directory: helpers/sql/
@@ -135,7 +135,7 @@ gems:
 
   - name: opentelemetry-instrumentation-http
     # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
-    # which casues instrumentation/http to incorrectly match when changes occur in instrumentation/httpx
+    # which causes instrumentation/http to incorrectly match when changes occur in instrumentation/httpx
     # https://github.com/dazuma/toys/blob/17ed449da8299f272b834470ff6b279a59e8070b/.toys/release/.lib/release_utils.rb#L436
     # https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1512
     directory: instrumentation/http/


### PR DESCRIPTION
HTTP / HTTPX
SQL / Sql Obfuscation + Sql Processors

All these gems match on the substring and cause toys to initiate releases when changes have not been made to accidentally matching gems.

Adding a / should fix the match problem.

Related to #1727 and #1512