### PR TITLE
chore: Dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,26 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  # Update all dependencies - scans recursively through all subdirectories
   - package-ecosystem: bundler
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: weekly
+    ignore:
+      # Ignore internal instrumentation interdependencies managed via local paths in Gemfiles
+      - dependency-name: "opentelemetry-instrumentation-*"
+      - dependency-name: "opentelemetry-helpers-*"
+      - dependency-name: "opentelemetry-processor-*"
+      - dependency-name: "opentelemetry-propagator-*"
+      - dependency-name: "opentelemetry-sampler-*"
+      - dependency-name: "opentelemetry-resource-detector-*"
     groups:
-      all-gems:
+      production-dependencies:
+        dependency-type: "production"
         patterns:
-          - "**/Gemfile"
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"


### PR DESCRIPTION
These changes run dependabot recursively for each gem hosted in this repo.

It grouping test/development gems from runtime dependencies like the SDK and API.

I am intentionally skipping updating gems that are part of this repo due to a limitations in dependabot where it cannot update gems that use `path` references:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/18297670748/job/52099249745