### PR TITLE
chore: Try dependabot root again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-  # Update all dependencies - scans recursively through all subdirectories
+  # Update all dependencies - processes from root to handle path dependencies correctly
   - package-ecosystem: bundler
-    directories:
-      - "**/*"
+    directory: "/"
     schedule:
       interval: weekly
     ignore:


### PR DESCRIPTION
The previous configuration attempted to recursively run dependabot updates in isolation, and will not attempt to resolve relative paths defined in gemfiles.

https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/18429943040/job/52515960020#step:3:980

```
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+-------------------------------------------------------+
|                        Errors                         |
+---------------------------------+---------------------+
| Type                            | Details             |
+---------------------------------+---------------------+
| path_dependencies_not_reachable | {                   |
|                                 |   "dependencies": [ |
|                                 |     "base"          |
|                                 |   ]                 |
|                                 | }                   |
+---------------------------------+---------------------+
Failure running container 8818eca58542184456696bd19ff5b6a639da1fb7e3775bd540c83131bd065d28: Error: Command failed with exit code 1: /bin/sh -c $DEPENDABOT_HOME/dependabot-updater/bin/run fetch_files
Cleaned up container 8818eca58542184456696bd19ff5b6a639da1fb7e3775bd540c83131bd065d28
  proxy | 2025/10/11 13:19:36 0/6 calls cached (0%)
2025/10/11 13:19:36 Posting metrics to remote API endpoint
```

Fingers crossed that this works.