### PR TITLE
chore: Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ merge. You'll probably get some feedback from these fine folks which helps to
 make the project that much better. Respond to the feedback and work with your
 reviewer(s) to resolve any issues.
 
-The some of the things the code owners are looking for include:
+Some of the things the code owners are looking for include:
 
 * a signed [CNCF CLA][cncf-cla]
 * a passing CI build
@@ -246,10 +246,10 @@ Releases are normally performed using GitHub Actions.
     `Open release request` workflow, and run the workflow manually using the
     dropdown in the upper right.
      * Releases must be run from the main branch.
-     * If you leave the `Gems to release` field, blank, and the script will
+     * If you leave the `Gems to release` field blank, the script will
         find all the gems that have had conventional-commit-tagged changes since
         their last release. Alternately, you can specify which gems to release
-        by including their names, space-delimited, in this this field. You can
+        by including their names, space-delimited, in this field. You can
         optionally append `:<version>` to any gem in the list to specify the
         version to release, or omit the version to let the script decide based
         on conventional commits. You can also use the special name `all` to

--- a/helpers/mysql/README.md
+++ b/helpers/mysql/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Instrumentation Helpers: MySQL
 
-This Ruby gem contains logic shared among MySQL adapter libraries, such as mysql2 and trilogy. It's intended for use by by gem authors instrumenting MySQL adapter libraries.
+This Ruby gem contains logic shared among MySQL adapter libraries, such as mysql2 and trilogy. It's intended for use by gem authors instrumenting MySQL adapter libraries.
 
 ## Usage
 

--- a/helpers/sql-obfuscation/README.md
+++ b/helpers/sql-obfuscation/README.md
@@ -8,7 +8,7 @@ All future development, bug fixes, and feature releases will occur in the new ge
 
 ## OpenTelemetry Instrumentation Helpers: SQL Obfuscation
 
-This Ruby gem contains logic to obfuscate SQL. It's intended for use by by gem authors instrumenting SQL adapter libraries, such as mysql2, pg, and trilogy.
+This Ruby gem contains logic to obfuscate SQL. It's intended for use by gem authors instrumenting SQL adapter libraries, such as mysql2, pg, and trilogy.
 
 The logic is largely drawn from the [New Relic Ruby agent's SQL Obfuscation Helpers module][new-relic-obfuscation-helpers].
 

--- a/helpers/sql-obfuscation/lib/opentelemetry/helpers/sql_obfuscation.rb
+++ b/helpers/sql-obfuscation/lib/opentelemetry/helpers/sql_obfuscation.rb
@@ -96,8 +96,8 @@ module OpenTelemetry
       # @param sql [String] The SQL to obfuscate.
       # @param obfuscation_limit [optional Integer] the length at which the SQL string will not be obfuscated
       # @param adapter [optional Symbol] the type of database adapter calling the method. `:default`, `:mysql` and `:postgres` are supported.
-      # @return [String] The SQL query string where the values are replaced with "?". When the sql statement exceeds the obufscation limit
-      #  the first matched pair from the SQL statement will be returned, with an appended truncation message. If trunaction is unsuccessful,
+      # @return [String] The SQL query string where the values are replaced with "?". When the sql statement exceeds the obfuscation limit
+      #  the first matched pair from the SQL statement will be returned, with an appended truncation message. If truncation is unsuccessful,
       #  a string describing the error will be returned.
       #
       # @api public

--- a/helpers/sql-processor/README.md
+++ b/helpers/sql-processor/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Instrumentation Helpers: SQL Processor
 
-This Ruby gem contains logic to process SQL, including obfuscation. It's intended for use by by gem authors instrumenting SQL adapter libraries, such as mysql2, pg, and trilogy.
+This Ruby gem contains logic to process SQL, including obfuscation. It's intended for use by gem authors instrumenting SQL adapter libraries, such as mysql2, pg, and trilogy.
 
 Obfuscation logic is largely drawn from the [New Relic Ruby agent's SQL Obfuscation Helpers module][new-relic-obfuscation-helpers].
 

--- a/helpers/sql-processor/lib/opentelemetry/helpers/sql_obfuscation.rb
+++ b/helpers/sql-processor/lib/opentelemetry/helpers/sql_obfuscation.rb
@@ -96,8 +96,8 @@ module OpenTelemetry
       # @param sql [String] The SQL to obfuscate.
       # @param obfuscation_limit [optional Integer] the length at which the SQL string will not be obfuscated
       # @param adapter [optional Symbol] the type of database adapter calling the method. `:default`, `:mysql` and `:postgres` are supported.
-      # @return [String] The SQL query string where the values are replaced with "?". When the sql statement exceeds the obufscation limit
-      #  the first matched pair from the SQL statement will be returned, with an appended truncation message. If trunaction is unsuccessful,
+      # @return [String] The SQL query string where the values are replaced with "?". When the sql statement exceeds the obfuscation limit
+      #  the first matched pair from the SQL statement will be returned, with an appended truncation message. If truncation is unsuccessful,
       #  a string describing the error will be returned.
       #
       # @api public

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -47,7 +47,7 @@ The following steps are required to contribute a new instrumentation library:
 
 This repository contains a script to generate a new instrumentation library.
 
-The snippet below demonstrates how to generate a an instrumentation for the `werewolf` gem, starting from the repository root.
+The snippet below demonstrates how to generate an instrumentation for the `werewolf` gem, starting from the repository root.
 
 ```console
 
@@ -137,7 +137,7 @@ module OpenTelemetry
         end
 
         compatible do
-          Gem::Version.new(::Wereworlf::VERSION) >= MINIMUM_VERSION
+          Gem::Version.new(::Werewolf::VERSION) >= MINIMUM_VERSION
         end
       end
     end
@@ -189,7 +189,7 @@ If the attribute is specific to your instrumentation, then consider namespacing 
 
 Code that is not tested will not be accepted by maintainers. We understand that providing 100% test coverage is not always possible but we still ask that you provide your best effort when writing automated tests.
 
-Most of the libraries instrument introduce changes outside of our control. For this reason, integration or state-based tests are preferred over interaction (mock) tests.
+Most of the libraries we instrument introduce changes outside of our control. For this reason, integration or state-based tests are preferred over interaction (mock) tests.
 
 When you do in fact run into cases where test doubles or API stubs are absolutely necessary, we recommend using the [`rspec-mocks`](https://github.com/rspec/rspec-mocks) and [`webmocks`](https://github.com/bblimke/webmock) gems.
 

--- a/instrumentation/aws_sdk/README.md
+++ b/instrumentation/aws_sdk/README.md
@@ -38,8 +38,8 @@ This instrumentation offers the following configuration options:
  to Message Attributes for SQS/SNS messages.
 * `:enable_internal_instrumentation` (default: `false`): When set to `true`, any spans with 
  span kind of `internal` are traced.
-* `:suppress_internal_instrumentation`: **Deprecated**. This configuration has been 
- deprecated in a favor of `:enable_internal_instrumentation`
+* `:suppress_internal_instrumentation`: **Deprecated**. This configuration has been
+ deprecated in favor of `:enable_internal_instrumentation`
 
 ## Integration with SDK V3's Telemetry support
 AWS SDK for Ruby V3 added support for Observability which includes a new configuration, 

--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/instrumentation.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/instrumentation.rb
@@ -26,9 +26,9 @@ module OpenTelemetry
       # - `true` - Internal spans are traced.
       #
       # ### `:suppress_internal_instrumentation` (deprecated)
-      # This configuration has been deprecated in a favor of `:enable_internal_instrumentation`
+      # This configuration has been deprecated in favor of `:enable_internal_instrumentation`
       #
-      # @example An explicit default configurations
+      # @example An explicit default configuration
       #   OpenTelemetry::SDK.configure do |c|
       #     c.use 'OpenTelemetry::Instrumentation::AwsSdk', {
       #       inject_messaging_context: false,
@@ -105,7 +105,7 @@ module OpenTelemetry
 
         # Patches AWS SDK V3's telemetry plugin for integration
         # This patch supports configuration set by this gem and
-        # additional span attributes that was not provided by the plugin
+        # additional span attributes that were not provided by the plugin
         def patch_telemetry_plugin
           ::Aws::Plugins::Telemetry::Handler.prepend(Patches::Handler)
         end
@@ -125,7 +125,7 @@ module OpenTelemetry
 
         # This check does the following:
         # 1 - Checks if the service client is autoload or not
-        # 2 - Validates whether if is a service client
+        # 2 - Validates whether it is a service client
         # note that Seahorse::Client::Base is a superclass for V3 clients
         # but for V2, it is Aws::Client
         # rubocop:disable Style/MultipleComparison

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
     #
     # OpenTelemetry::Instrumentation::Sinatra.instance.tracer
     #
-    # The instrumention class establishes a convention for disabling an instrumentation
+    # The instrumentation class establishes a convention for disabling an instrumentation
     # by environment variable and local configuration. An instrumentation disabled
     # by environment variable will take precedence over local config. The
     # convention for environment variable name is the library name, upcased with

--- a/instrumentation/ethon/README.md
+++ b/instrumentation/ethon/README.md
@@ -10,7 +10,7 @@ Install the gem using:
 gem install opentelemetry-instrumentation-ethon
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-ethon` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-ethon` in your `Gemfile`.
 
 ## Usage
 

--- a/instrumentation/excon/README.md
+++ b/instrumentation/excon/README.md
@@ -10,7 +10,7 @@ Install the gem using:
 gem install opentelemetry-instrumentation-excon
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-excon` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-excon` in your `Gemfile`.
 
 ## Usage
 

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -16,7 +16,7 @@ Install the gem using:
 gem install opentelemetry-instrumentation-grpc
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-grpc` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-grpc` in your `Gemfile`.
 
 
 ## Usage

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
@@ -8,7 +8,7 @@ module OpenTelemetry
   module Instrumentation
     module Logger
       module Patches
-        # Instrumention for methods from Ruby's Logger class
+        # Instrumentation for methods from Ruby's Logger class
         module Logger
           attr_writer :skip_otel_emit
 

--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -50,9 +50,9 @@ OpenTelemetry::SDK.configure do |c|
     # will be included on all spans from this instrumentation:
     peer_service: 'postgres:readonly',
 
-    # By default, this instrumentation obfuscate/sanitize the executed SQL as the `db.statement`
+    # By default, this instrumentation obfuscates/sanitizes the executed SQL as the `db.statement`
     # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
-    # setting this option to :omit or disbale sanitization the attribute by setting to :include
+    # setting this option to :omit or disable sanitization of the attribute by setting it to :include
     db_statement: :include,
   }
 end

--- a/instrumentation/que/README.md
+++ b/instrumentation/que/README.md
@@ -10,7 +10,7 @@ Install the gem using:
 gem install opentelemetry-instrumentation-que
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-que` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-que` in your `Gemfile`.
 
 ## Usage
 
@@ -49,9 +49,9 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-If you wish the job will be executed in the same logical trace as a direct
-child of the span that enqueued the job then set propagation_style to `child`. By
-default the jobs are just linked together.
+If you wish the job to be executed in the same logical trace as a direct
+child of the span that enqueued the job, then set propagation_style to `child`. By
+default, the jobs are just linked together.
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|

--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -71,7 +71,7 @@ This is how the rails controller instrumentation is able to rename the span name
 
 ### High cardinality example
 
-You can pass in an url quantization lambda that simply uses the URL path, the result is you will end up with high cardinality span names, however this may be acceptable in your deployment and is easy configurable using the following example.
+You can pass in a url quantization lambda that simply uses the URL path; the result is you will end up with high cardinality span names. However, this may be acceptable in your deployment and is easily configurable using the following example.
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis_client_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis_client_test.rb
@@ -190,7 +190,7 @@ describe OpenTelemetry::Instrumentation::Redis::Middlewares::RedisClientInstrume
       # span is created. The 'connect' operation can be separately instrumented
       # via the connect hook in the middleware. If this expectation (last_span must be nil)
       # fails due to this implementation, it can be removed.
-      # This test remains here for parity the the V4 instrumentation, which _does_
+      # This test remains here for parity with the V4 instrumentation, which _does_
       # wrap the connect failure in a span.
       _(last_span).must_be_nil
     end

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
             }
 
             # If trace context is present in headers, extract and use it as parent. If there is _no_ trace context key
-            # in the headers, OpenTelemetry.propagation.extract will return an unmodified copy of the the current
+            # in the headers, OpenTelemetry.propagation.extract will return an unmodified copy of the current
             # Thread's context, so the next two lines preserve the correct Thread-local context.
             ctx = OpenTelemetry.propagation.extract(headers)
             OpenTelemetry::Context.with_current(ctx) do

--- a/instrumentation/sinatra/README.md
+++ b/instrumentation/sinatra/README.md
@@ -10,7 +10,7 @@ Install the gem using:
 gem install opentelemetry-instrumentation-sinatra
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-sinatra` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-sinatra` in your `Gemfile`.
 
 ### Version Compatibility
 

--- a/processor/baggage/README.md
+++ b/processor/baggage/README.md
@@ -5,7 +5,7 @@ This is an OpenTelemetry [span processor](https://opentelemetry.io/docs/specs/ot
 Keys and values added to Baggage will appear on all subsequent child spans, not the current active span, for a trace within this service *and* will be propagated to external services via propagation headers.
 If the external services also have a Baggage span processor, the keys and values will appear in those child spans as well.
 
-⚠️ Waning ⚠️
+⚠️ Warning ⚠️
 To repeat: a consequence of adding data to Baggage is that the keys and values will appear in all outgoing HTTP headers from the application.
 Do not put sensitive information in Baggage.
 
@@ -17,7 +17,7 @@ Install the gem using:
 gem install opentelemetry-processor-baggage
 ```
 
-Or, if you use [bundler][bundler-home], include `opentelemetry-processor-baggage` to your `Gemfile`.
+Or, if you use [bundler][bundler-home], include `opentelemetry-processor-baggage` in your `Gemfile`.
 
 ### Version Compatibility
 

--- a/propagator/ottrace/README.md
+++ b/propagator/ottrace/README.md
@@ -24,13 +24,13 @@ This issue was [fixed](https://github.com/open-telemetry/opentelemetry-go-contri
 
 ### Interop and trace ids
 
-OTTrace was changed to be interoperable with other format so it is supposed to 8 or 16 byte array values for the trace-id.
+OTTrace was changed to be interoperable with other formats so it is supposed to support 8 or 16 byte array values for the trace-id.
 
 In order to do that Lightstep released a version of the OTTrace propagators in OpenTracing SDKs that left padded 64-bit headers to 128-bits using an additional 64-bit of 0s.
 
 The reality of the world is not every application upgraded to support 16 byte array propagation format, but this propagator must still convert legacy 64-bit trace ids to match the W3C Trace Context Trace ID 16 byte array.
 
-In addition to that it must be interoperable with legacy OTTracers, which expect 64-bit headers so this propagator truncates the value from a 128-bit to a 64-bit value before inject it into the carrier.
+In addition to that, it must be interoperable with legacy OTTracers, which expect 64-bit headers, so this propagator truncates the value from a 128-bit to a 64-bit value before injecting it into the carrier.
 
 This propagator is compatible with 64-bit or 128-bit trace ids when extracting the parent context, however it truncates the trace ids down to 64-bit trace ids when injecting the context.
 

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/eks.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/eks.rb
@@ -101,7 +101,7 @@ module OpenTelemetry
           # @param cred_value [String] K8s credentials
           # @return [Boolean] true if running on EKS
           def eks?(cred_value)
-            # Just try to to access the aws-auth configmap
+            # Just try to access the aws-auth configmap
             # If it exists and we can access it, we're on EKS
             aws_http_request(AWS_AUTH_PATH, cred_value)
             true

--- a/resources/azure/README.md
+++ b/resources/azure/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry::Resource::Detector::Azure
 
-The `opentelemetry-resource-detector-azure` gem provides a Azure resource detector for OpenTelemetry.
+The `opentelemetry-resource-detector-azure` gem provides an Azure resource detector for OpenTelemetry.
 
 ## What is OpenTelemetry?
 


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help