### PR TITLE
fix: Raise original Ethon error after span updates

### DIFF
--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/dup/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/dup/easy.rb
@@ -39,10 +39,13 @@ module OpenTelemetry
               otel_before_request
               super
             rescue StandardError => e
-              # If an exception occurs before we can call `complete`, we should add and error status and close the span
+              # If an exception occurs before we can call `complete`
+              # we should add an error status and close the span
+              # and raise the original error
               @otel_span&.status = OpenTelemetry::Trace::Status.error("Request threw an exception: #{e.message}")
               @otel_span&.finish
               @otel_span = nil
+              raise e
             end
 
             def complete

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/old/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/old/easy.rb
@@ -36,10 +36,13 @@ module OpenTelemetry
               otel_before_request
               super
             rescue StandardError => e
-              # If an exception occurs before we can call `complete`, we should add and error status and close the span
+              # If an exception occurs before we can call `complete`
+              # we should add an error status and close the span
+              # and raise the original error
               @otel_span&.status = OpenTelemetry::Trace::Status.error("Request threw an exception: #{e.message}")
               @otel_span&.finish
               @otel_span = nil
+              raise e
             end
 
             def complete

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/stable/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/stable/easy.rb
@@ -39,10 +39,13 @@ module OpenTelemetry
               otel_before_request
               super
             rescue StandardError => e
-              # If an exception occurs before we can call `complete`, we should add and error status and close the span
+              # If an exception occurs before we can call `complete`
+              # we should add an error status and close the span
+              # and raise the original error
               @otel_span&.status = OpenTelemetry::Trace::Status.error("Request threw an exception: #{e.message}")
               @otel_span&.finish
               @otel_span = nil
+              raise e
             end
 
             def complete

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/dup/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/dup/instrumentation_test.rb
@@ -83,23 +83,26 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           end
         end
 
-        it 'when the perform fails before complete with an exception' do
-          Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
-            easy.perform
-
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP'
-            _(span.attributes['http.method']).must_equal 'N/A'
-            _(span.attributes['http.status_code']).must_be_nil
-            _(span.attributes['http.url']).must_equal 'http://example.com/test'
-            _(span.attributes['http.request.method']).must_equal '_OTHER'
-            _(span.attributes['http.response.status_code']).must_be_nil
-            _(span.attributes['url.full']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
+        describe 'when the perform fails before complete with an exception' do
+          it 'raises the original error and closes the span with error status' do
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.method']).must_equal 'N/A'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
+            end
           end
         end
       end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
@@ -78,20 +78,24 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           end
         end
 
-        it 'when the perform fails before complete with an exception' do
-          Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
-            easy.perform
+        describe 'when the perform fails before complete with an exception' do
+          it 'raises the original error and closes the span with error status' do
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
 
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP N/A'
-            _(span.attributes['http.method']).must_equal 'N/A'
-            _(span.attributes['http.status_code']).must_be_nil
-            _(span.attributes['http.url']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP N/A'
+              _(span.attributes['http.method']).must_equal 'N/A'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
+            end
           end
         end
       end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
@@ -79,20 +79,24 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
           end
         end
 
-        it 'when the perform fails before complete with an exception' do
-          Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
-            easy.perform
+        describe 'when the perform fails before complete with an exception' do
+          it 'raises the original error and closes the span with error status' do
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
 
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP'
-            _(span.attributes['http.request.method']).must_equal '_OTHER'
-            _(span.attributes['http.response.status_code']).must_be_nil
-            _(span.attributes['url.full']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
+            end
           end
         end
       end


### PR DESCRIPTION
Previously, we recorded the error status and finished the span without re-raising the original error. This was a mistake.

Resolves #1739