### PR TITLE
chore: Remove Logger from all's changelog

### DIFF
--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### v0.85.0 / 2025-10-11
 
-* ADDED: Ruby Logger instrumentation
 * BREAKING CHANGE: aws_sdk Suppress internal spans by default
 
 ### v0.84.0 / 2025-09-27


### PR DESCRIPTION
The changelog entry was misleading, because the logger instrumentation is not included in the `opentelemetry-instrumentation-all` gem. The entry was looped in because the logger instrumentation PR made some minor changes to all, like excluding logger from all's Gemfile.