### PR TITLE
feat: Semconv Span Helpers

### DIFF
--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         gem:
+          - semconv
           - sql
           - mysql
           - sql-obfuscation

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -38,6 +38,10 @@ gems:
     directory: instrumentation/active_storage
     version_constant: [OpenTelemetry, Instrumentation, ActiveStorage, VERSION]
 
+  - name: opentelemetry-helpers-semconv
+    directory: helpers/semconv
+    version_constant: [OpenTelemetry, Helpers, Semconv, VERSION]
+
   - name: opentelemetry-helpers-sql
     # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
     # which causes helpers/sql to incorrectly match when changes occur in helpers/sql-processor or helpers/sql-obfuscation

--- a/helpers/semconv/.rubocop.yml
+++ b/helpers/semconv/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/helpers/semconv/.yardopts
+++ b/helpers/semconv/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Sql Helpers
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/helpers/**/*.rb
+./lib/opentelemetry/helpers.rb
+-
+README.md
+CHANGELOG.md

--- a/helpers/semconv/CHANGELOG.md
+++ b/helpers/semconv/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-helpers-http

--- a/helpers/semconv/Gemfile
+++ b/helpers/semconv/Gemfile
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+group :test do
+  gem 'appraisal', '~> 2.5'
+  gem 'bundler', '~> 2.4'
+  gem 'minitest', '~> 5.0'
+  gem 'opentelemetry-test-helpers', '~> 0.3'
+  gem 'rake', '~> 13.0'
+  gem 'rubocop', '~> 1.81.1'
+  gem 'rubocop-performance', '~> 1.26.0'
+  gem 'simplecov', '~> 0.22.0'
+  gem 'yard', '~> 0.9'
+  if RUBY_VERSION >= '3.4'
+    gem 'base64'
+    gem 'mutex_m'
+  end
+end

--- a/helpers/semconv/LICENSE
+++ b/helpers/semconv/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/helpers/semconv/README.md
+++ b/helpers/semconv/README.md
@@ -1,0 +1,93 @@
+# OpenTelemetry Semantic Convention Helpers
+
+This gem provides semantic convention helpers for the OpenTelemetry framework, including HTTP span naming utilities. It is intended to be used by the instrumentation libraries and is not intended to be used directly by applications.
+
+## Installation
+
+Add a line similar to this in your `gemspec`:
+
+```ruby
+spec.add_dependency 'opentelemetry-helpers-semconv', '~> 0.1' # Use the appropriate version
+```
+
+Update your `Gemfile` to use the latest version of the gem in the contrib, if you are working locally in this repository e.g.
+
+```ruby
+group :test do
+  gem 'opentelemetry-helpers-semconv', path: '../../helpers/semconv' # Use the appropriate path
+end
+```
+
+## Usage
+
+### HTTP Span Naming
+
+The HTTP module provides consistent span naming for HTTP operations using the `OpenTelemetry::Helpers::Semconv::HTTP.name_from` method:
+
+```ruby
+require 'opentelemetry/helpers/semconv'
+
+# Basic usage with HTTP method and URL template
+attributes = {
+  'http.request.method' => 'GET',
+  'url.template' => '/users/:id'
+}
+span_name = OpenTelemetry::Helpers::Semconv::HTTP.name_from(attributes)
+# Returns: "GET /users/:id"
+```
+
+### Integration with Instrumentation
+
+Use in your instrumentation libraries to create consistent HTTP spans:
+
+```ruby
+require 'opentelemetry/helpers/semconv'
+
+# In your HTTP client instrumentation
+def instrument_request(method, url, attributes = {})
+  # Add HTTP attributes for span naming
+  attributes['http.request.method'] = method
+  attributes['url.template'] = extract_url_template(url)
+
+  span_name = OpenTelemetry::Helpers::Semconv::HTTP.name_from(attributes)
+
+  tracer.in_span(span_name, attributes: attributes) do |span|
+    # perform HTTP request
+  end
+end
+```
+
+### Supported Attributes
+
+The HTTP helper supports both current and legacy OpenTelemetry semantic conventions:
+
+- **Current**: `http.request.method`, `url.template`
+- **Legacy**: `http.method` (deprecated but supported)
+- **Behavior**: Prefers current conventions over legacy ones
+- **Method normalization**: Automatically converts standard HTTP methods to uppercase (e.g., 'get' → 'GET')
+- **Fallbacks**: Returns 'HTTP' when no recognizable attributes are present
+
+### Supported HTTP Methods
+
+The helper recognizes and normalizes the following standard HTTP methods:
+
+- `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`
+- Methods can be provided in any case (lowercase, uppercase, mixed) and will be normalized to uppercase
+- Custom/non-standard methods are supported but may not be automatically normalized
+
+## How can I get involved?
+
+The `opentelemetry-helpers-semconv` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-helpers-semconv` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[slack-channel]: https://cloud-native.slack.com/archives/C01NWKKMKMY
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/helpers/semconv/Rakefile
+++ b/helpers/semconv/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/helpers/semconv/lib/opentelemetry-helpers-semconv.rb
+++ b/helpers/semconv/lib/opentelemetry-helpers-semconv.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'opentelemetry/helpers'

--- a/helpers/semconv/lib/opentelemetry/helpers.rb
+++ b/helpers/semconv/lib/opentelemetry/helpers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Helpers should be able to handle the case when the library is not installed on a user's system.
+  module Helpers
+  end
+end
+
+require_relative 'helpers/semconv'

--- a/helpers/semconv/lib/opentelemetry/helpers/semconv.rb
+++ b/helpers/semconv/lib/opentelemetry/helpers/semconv.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Helpers
+    # Provides semantic convention helpers for OpenTelemetry spans.
+    #
+    # This module contains utilities that help instrumentation libraries create
+    # consistent span names and attributes according to OpenTelemetry semantic
+    # conventions. It's designed to be used by instrumentation authors, not
+    # end users directly.
+    #
+    # ## Available Helpers
+    #
+    # ### HTTP
+    # The {OpenTelemetry::Helpers::Semconv::HTTP} module provides utilities for
+    # naming HTTP spans consistently across different instrumentation libraries.
+    module Semconv
+    end
+  end
+end
+
+require_relative 'semconv/http'
+require_relative 'semconv/version'

--- a/helpers/semconv/lib/opentelemetry/helpers/semconv/http.rb
+++ b/helpers/semconv/lib/opentelemetry/helpers/semconv/http.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Helpers
+    module Semconv
+      # Provides HTTP semantic convention helpers for creating consistent span names per the specification
+      # <https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name>
+      #
+      # This module helps instrumentation libraries generate standardized span names
+      # for HTTP operations according to OpenTelemetry semantic conventions. It handles
+      # both current and legacy attribute formats and provides sensible fallbacks.
+      #
+      # ## Supported HTTP Methods
+      #
+      # The following standard HTTP methods are recognized and automatically normalized
+      # to uppercase:
+      # - CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE
+      #
+      # Methods can be provided in any case (lowercase, uppercase, mixed case) and will
+      # be normalized appropriately. Non-standard methods fall back to the default "HTTP".
+      #
+      # ## Semantic Convention Support
+      #
+      # Supports both current and legacy OpenTelemetry semantic conventions:
+      # - **Current**: `http.request.method`, `url.template`
+      # - **Legacy**: `http.method` (deprecated but supported for compatibility)
+      #
+      # When both current and legacy attributes are present, current conventions take
+      # precedence.
+      #
+      # @example Basic usage with method and URL template
+      #   attrs = {
+      #     'http.request.method' => 'GET',
+      #     'url.template' => '/users/:id'
+      #   }
+      #   HTTP.name_from(attrs) # => "GET /users/:id"
+      #
+      # @example Method normalization
+      #   attrs = { 'http.request.method' => 'get' }
+      #   HTTP.name_from(attrs) # => "GET"
+      #
+      # @example Legacy attribute support
+      #   attrs = { 'http.method' => 'POST' }
+      #   HTTP.name_from(attrs) # => "POST"
+      #
+      # @example Preference for current conventions
+      #   attrs = {
+      #     'http.request.method' => 'PUT',
+      #     'http.method' => 'GET'  # ignored in favor of current convention
+      #   }
+      #   HTTP.name_from(attrs) # => "PUT"
+      #
+      # @example Fallback behavior
+      #   # Unknown method falls back to HTTP
+      #   attrs = { 'http.request.method' => 'UNKNOWN' }
+      #   HTTP.name_from(attrs) # => "HTTP"
+      #
+      #   # URL template without method
+      #   attrs = { 'url.template' => '/health' }
+      #   HTTP.name_from(attrs) # => "HTTP /health"
+      #
+      #   # Empty attributes
+      #   HTTP.name_from({}) # => "HTTP"
+      module HTTP
+        # Mapping of HTTP methods (in various cases) to their uppercase equivalents.
+        # Only includes standard HTTP methods as defined by RFC specifications.
+        #
+        # @api private
+        HTTP_METHODS_TO_UPPERCASE = %w[connect delete get head options patch post put trace].each_with_object({}) do |method, hash|
+          uppercase_method = method.upcase
+          hash[method] = uppercase_method
+          hash[method.to_sym] = uppercase_method
+          hash[uppercase_method] = uppercase_method
+        end.freeze
+
+        module_function
+
+        # Generates a span name from HTTP semantic convention attributes.
+        #
+        # Creates consistent span names for HTTP operations by combining the HTTP method
+        # and URL template when available. Handles method normalization, attribute
+        # precedence, and provides appropriate fallbacks.
+        #
+        # ## Attribute Processing
+        #
+        # 1. **Method Resolution**: Looks for `http.request.method` first, then falls back
+        #    to `http.method` for legacy compatibility
+        # 2. **Method Normalization**: Standard HTTP methods are converted to uppercase
+        # 3. **Unknown Methods**: Non-standard methods default to "HTTP"
+        # 4. **URL Template**: Uses `url.template` when available
+        # 5. **Whitespace Handling**: Strips whitespace from all attribute values
+        #
+        # @param attrs [Hash] Hash of span attributes following OpenTelemetry semantic conventions
+        # @return [String] The generated span name
+        # - With method and template: `"GET /users/:id"`
+        # - Method only: `"GET"`
+        # - Template only: `"HTTP /health"`
+        # - No attributes: `"HTTP"`
+        def name_from(attrs)
+          http_method = HTTP_METHODS_TO_UPPERCASE[attrs['http.request.method']&.strip || attrs['http.method']&.strip]
+          http_method ||= 'HTTP'
+          url_template = attrs['url.template']&.strip
+
+          return "#{http_method} #{url_template}".strip if url_template && http_method
+
+          http_method
+        end
+      end
+    end
+  end
+end

--- a/helpers/semconv/lib/opentelemetry/helpers/semconv/version.rb
+++ b/helpers/semconv/lib/opentelemetry/helpers/semconv/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Helpers
+    module Semconv
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/helpers/semconv/opentelemetry-helpers-semconv.gemspec
+++ b/helpers/semconv/opentelemetry-helpers-semconv.gemspec
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/helpers/semconv/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-helpers-semconv'
+  spec.version     = OpenTelemetry::Helpers::Semconv::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Semconv helpers for the OpenTelemetry framework'
+  spec.description = 'Semconv helpers for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = Dir.glob('lib/**/*.rb') +
+               Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = ">= #{File.read(File.expand_path('../../gemspecs/RUBY_REQUIREMENT', __dir__))}"
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.7'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/helpers/semconv'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues'
+    spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  end
+end

--- a/helpers/semconv/test/opentelemetry/helpers/semconv/http/client_test.rb
+++ b/helpers/semconv/test/opentelemetry/helpers/semconv/http/client_test.rb
@@ -8,7 +8,7 @@ require 'test_helper'
 
 require_relative '../../../../../lib/opentelemetry/helpers/semconv/http'
 
-describe OpenTelemetry::Helpers::Semconv::HTTP do
+describe OpenTelemetry::Helpers::Semconv::HTTP::Client do
   describe 'span naming' do
     test_cases = [
       # [description, attributes, expected_result]
@@ -28,33 +28,33 @@ describe OpenTelemetry::Helpers::Semconv::HTTP do
 
     test_cases.each do |description, attributes, expected|
       it description do
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attributes)).must_equal expected
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attributes)).must_equal expected
       end
     end
 
     it 'normalizes HTTP methods to uppercase' do
       %w[GET POST PUT PATCH DELETE HEAD OPTIONS TRACE CONNECT].each do |method|
         attrs = { 'http.request.method' => method }
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attrs)).must_equal method
 
         attrs = { 'http.request.method' => method.downcase }
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attrs)).must_equal method
 
         attrs = { 'http.method' => method }
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attrs)).must_equal method
 
         attrs = { 'http.method' => method.downcase }
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attrs)).must_equal method
       end
     end
 
     it 'defaults to HTTP for unknown methods' do
       %w[PURGE FAKE PHONY].each do |method|
         attrs = { 'http.request.method' => method }
-        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal 'HTTP'
+        _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from(attrs)).must_equal 'HTTP'
       end
 
-      _(OpenTelemetry::Helpers::Semconv::HTTP.name_from({})).must_equal 'HTTP'
+      _(OpenTelemetry::Helpers::Semconv::HTTP::Client.name_from({})).must_equal 'HTTP'
     end
   end
 end

--- a/helpers/semconv/test/opentelemetry/helpers/semconv/http/http_test.rb
+++ b/helpers/semconv/test/opentelemetry/helpers/semconv/http/http_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../../lib/opentelemetry/helpers/semconv/http'
+
+describe OpenTelemetry::Helpers::Semconv::HTTP do
+  describe 'span naming' do
+    test_cases = [
+      # [description, attributes, expected_result]
+      ['uses latest semconv naming', { 'http.request.method' => 'GET', 'url.template' => '/users/:id' }, 'GET /users/:id'],
+      ['uses a mix of deprecated and latest semconv to name the span', { 'http.method' => 'POST', 'url.template' => '/api/v1/posts' }, 'POST /api/v1/posts'],
+      ['prefers latest semconv over deprecated', { 'http.request.method' => 'PUT', 'http.method' => 'GET', 'url.template' => '/users/:id' }, 'PUT /users/:id'],
+      ['uses the url template even if no HTTP method is present (edge case)', { 'url.template' => '/health' }, 'HTTP /health'],
+      ['uses the HTTP request method', { 'http.request.method' => 'DELETE' }, 'DELETE'],
+      ['supports the deprecated HTTP request method', { 'http.method' => 'PATCH' }, 'PATCH'],
+      ['has a default HTTP span name when no attributes are present', {}, 'HTTP'],
+      ['Empty method value (edge case)', { 'http.request.method' => '', 'url.template' => '/api/status' }, 'HTTP /api/status'],
+      ['uses default HTTP span name with invalid or blank attributes', { 'http.request.method' => '  ', 'url.template' => '' }, 'HTTP'],
+      ['uses the default HTTP span name when non-standard method is present', { 'http.request.method' => 'CUSTOM', 'url.template' => '/custom/endpoint' }, 'HTTP /custom/endpoint'],
+      ['normalizes to uppercase method names', { 'http.request.method' => 'get', 'url.template' => '/lowercase' }, 'GET /lowercase'],
+      ['requires string keys for attributes', { 'http.request.method': 'GET', 'url.template': '/symbol/keys' }, 'HTTP']
+    ]
+
+    test_cases.each do |description, attributes, expected|
+      it description do
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attributes)).must_equal expected
+      end
+    end
+
+    it 'normalizes HTTP methods to uppercase' do
+      %w[GET POST PUT PATCH DELETE HEAD OPTIONS TRACE CONNECT].each do |method|
+        attrs = { 'http.request.method' => method }
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+
+        attrs = { 'http.request.method' => method.downcase }
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+
+        attrs = { 'http.method' => method }
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+
+        attrs = { 'http.method' => method.downcase }
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal method
+      end
+    end
+
+    it 'defaults to HTTP for unknown methods' do
+      %w[PURGE FAKE PHONY].each do |method|
+        attrs = { 'http.request.method' => method }
+        _(OpenTelemetry::Helpers::Semconv::HTTP.name_from(attrs)).must_equal 'HTTP'
+      end
+
+      _(OpenTelemetry::Helpers::Semconv::HTTP.name_from({})).must_equal 'HTTP'
+    end
+  end
+end

--- a/helpers/semconv/test/test_helper.rb
+++ b/helpers/semconv/test/test_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/setup'
+Bundler.require(:default, :development, :test)
+
+require 'minitest/autorun'


### PR DESCRIPTION
Introduces a helper gem for use in instrumentations that will standardize semantic convention naming.

The initial implementation adds an implementation for HTTP Client span names: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name 

The usage of this helper is intended to replace uses in all client gems (excon, http, net-http, etc...). This will allow wrapper libraries to enrich span names without the need for custom code and reuse the existing HTTP ClientContext helper. 