### PR TITLE
fix: does not trace resolve type unless enable

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_trace.rb
@@ -148,12 +148,16 @@ module OpenTelemetry
 
           def resolve_type(query:, type:, object:, &)
             platform_key = @_otel_resolve_type_key_cache[type]
+            return super unless platform_key
+
             attributes = @_otel_type_attrs_cache[type]
             tracer.in_span(platform_key, attributes: attributes) { super }
           end
 
           def resolve_type_lazy(query:, type:, object:, &)
             platform_key = @_otel_resolve_type_key_cache[type]
+            return super unless platform_key
+
             attributes = @_otel_lazy_type_attrs_cache[type]
             tracer.in_span(platform_key, attributes: attributes) { super }
           end

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -221,6 +221,29 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
         end
       end
 
+      describe 'when platform_resolve_type is disabled' do
+        let(:config) { { enable_platform_resolve_type: false } }
+
+        it 'does not trace .resolve_type' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+          parent = spans.find { |s| s.name == 'graphql.execute_query' }
+          span = spans.find { |s| s.parent_span_id == parent.span_id }
+          _(span).must_be_nil
+        end
+
+
+        it 'does not traces .resolve_type_lazy' do
+          skip unless supports_authorized_and_resolved_types?
+          SomeGraphQLAppSchema.execute('{ vehicle { __typename } }', context: { lazy_type_resolve: true })
+
+          parent = spans.find { |s| s.name == 'graphql.execute_query_lazy' }
+          span = spans.find { |s| s.parent_span_id == parent.span_id }
+          _(span).must_be_nil
+        end
+      end
+
       describe 'when platform_resolve_type is enabled with legacy naming' do
         let(:config) { { enable_platform_resolve_type: true, legacy_platform_span_names: true } }
 

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_trace_test.rb
@@ -233,7 +233,6 @@ describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTrace do
           _(span).must_be_nil
         end
 
-
         it 'does not traces .resolve_type_lazy' do
           skip unless supports_authorized_and_resolved_types?
           SomeGraphQLAppSchema.execute('{ vehicle { __typename } }', context: { lazy_type_resolve: true })


### PR DESCRIPTION
Currently, a span with "empty" name is generated