### PR TITLE
fix: Sidekiq spans crashing when enqueued by Exq

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -31,13 +31,10 @@ module OpenTelemetry
                           end
 
               extracted_context = OpenTelemetry.propagation.extract(msg)
-              created_at = time_from_timestamp(msg['created_at'] || msg['enqueued_at'] || 0)
-              enqueued_at = time_from_timestamp(msg['enqueued_at'] || 0)
               OpenTelemetry::Context.with_current(extracted_context) do
                 if instrumentation_config[:propagation_style] == :child
                   tracer.in_span(span_name, attributes: attributes, kind: :consumer) do |span|
-                    span.add_event('created_at', timestamp: created_at)
-                    span.add_event('enqueued_at', timestamp: enqueued_at)
+                    add_span_timestamps(span, msg)
                     yield
                   end
                 else
@@ -46,8 +43,7 @@ module OpenTelemetry
                   links << OpenTelemetry::Trace::Link.new(span_context) if instrumentation_config[:propagation_style] == :link && span_context.valid?
                   span = tracer.start_root_span(span_name, attributes: attributes, links: links, kind: :consumer)
                   OpenTelemetry::Trace.with_span(span) do
-                    span.add_event('created_at', timestamp: created_at)
-                    span.add_event('enqueued_at', timestamp: enqueued_at)
+                    add_span_timestamps(span, msg)
                     yield
                   rescue Exception => e # rubocop:disable Lint/RescueException
                     span.record_exception(e)
@@ -68,6 +64,13 @@ module OpenTelemetry
 
             def tracer
               Sidekiq::Instrumentation.instance.tracer
+            end
+
+            def add_span_timestamps(span, msg)
+              created_at = msg['created_at']
+              enqueued_at = msg['enqueued_at']
+              span.add_event('created_at', timestamp: time_from_timestamp(created_at)) if created_at
+              span.add_event('enqueued_at', timestamp: time_from_timestamp(enqueued_at)) if enqueued_at
             end
 
             def time_from_timestamp(timestamp)

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -31,8 +31,8 @@ module OpenTelemetry
                           end
 
               extracted_context = OpenTelemetry.propagation.extract(msg)
-              created_at = time_from_timestamp(msg['created_at'])
-              enqueued_at = time_from_timestamp(msg['created_at'])
+              created_at = time_from_timestamp(msg['created_at'] || msg['enqueued_at'] || 0)
+              enqueued_at = time_from_timestamp(msg['enqueued_at'] || 0)
               OpenTelemetry::Context.with_current(extracted_context) do
                 if instrumentation_config[:propagation_style] == :child
                   tracer.in_span(span_name, attributes: attributes, kind: :consumer) do |span|

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -16,6 +16,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
   let(:job_span) { spans.last }
   let(:root_span) { spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID } }
   let(:config) { {} }
+  let(:timestamp) { Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond) }
 
   before do
     instrumentation.install(config)
@@ -67,9 +68,9 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       _(job_span.attributes['messaging.operation']).must_equal 'process'
     end
 
-    it 'traces when enqueued with minimal data' do
-      payload = { 'queue' => 'default', 'args' => [], 'class' => SimpleJob, 'enqueued_at' => Time.current, 'jid' => '4' }
-      Sidekiq::Client.new.send(:raw_push, [payload])
+    it 'traces when enqueued with only enqueued_at' do
+      payload = { 'queue' => 'default', 'args' => [], 'class' => SimpleJob.to_s, 'enqueued_at' => timestamp, 'jid' => '4' }
+      Sidekiq::Queues.push('default', 'SimpleJob', payload)
       Sidekiq::Worker.drain_all
 
       _(job_span.name).must_equal 'default process'
@@ -86,6 +87,44 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       enqueued_event = job_span.events[0]
       _(enqueued_event.name).must_equal('enqueued_at')
       _(enqueued_event.timestamp.digits.count).must_equal(19)
+    end
+
+    it 'traces when enqueued with only created_at' do
+      payload = { 'queue' => 'default', 'args' => [], 'class' => SimpleJob.to_s, 'created_at' => timestamp, 'jid' => '4' }
+      Sidekiq::Queues.push('default', 'SimpleJob', payload)
+      Sidekiq::Worker.drain_all
+
+      _(job_span.name).must_equal 'default process'
+      _(job_span.kind).must_equal :consumer
+      _(job_span.attributes['messaging.system']).must_equal 'sidekiq'
+      _(job_span.attributes['messaging.sidekiq.job_class']).must_equal 'SimpleJob'
+      _(job_span.attributes['messaging.message_id']).must_equal '4'
+      _(job_span.attributes['messaging.destination']).must_equal 'default'
+      _(job_span.attributes['messaging.destination_kind']).must_equal 'queue'
+      _(job_span.attributes['messaging.operation']).must_equal 'process'
+      _(job_span.attributes['peer.service']).must_be_nil
+      _(job_span.events.size).must_equal(1)
+
+      enqueued_event = job_span.events[0]
+      _(enqueued_event.name).must_equal('created_at')
+      _(enqueued_event.timestamp.digits.count).must_equal(19)
+    end
+
+    it 'traces when enqueued with minimal data' do
+      payload = { 'queue' => 'default', 'args' => [], 'class' => SimpleJob.to_s, 'jid' => '4' }
+      Sidekiq::Queues.push('default', 'SimpleJob', payload)
+      Sidekiq::Worker.drain_all
+
+      _(job_span.name).must_equal 'default process'
+      _(job_span.kind).must_equal :consumer
+      _(job_span.attributes['messaging.system']).must_equal 'sidekiq'
+      _(job_span.attributes['messaging.sidekiq.job_class']).must_equal 'SimpleJob'
+      _(job_span.attributes['messaging.message_id']).must_equal '4'
+      _(job_span.attributes['messaging.destination']).must_equal 'default'
+      _(job_span.attributes['messaging.destination_kind']).must_equal 'queue'
+      _(job_span.attributes['messaging.operation']).must_equal 'process'
+      _(job_span.attributes['peer.service']).must_be_nil
+      _(job_span.events).must_be_nil
     end
 
     it 'defaults to using links to the enqueing span but does not continue the trace' do

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -67,7 +67,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       _(job_span.attributes['messaging.operation']).must_equal 'process'
     end
 
-    it 'traces when enqueued through another system' do
+    it 'traces when enqueued with minimal data' do
       payload = { 'queue' => 'default', 'args' => [], 'class' => SimpleJob, 'enqueued_at' => Time.current, 'jid' => '4' }
       Sidekiq::Client.new.send(:raw_push, [payload])
       Sidekiq::Worker.drain_all

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -81,13 +81,9 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       _(job_span.attributes['messaging.destination_kind']).must_equal 'queue'
       _(job_span.attributes['messaging.operation']).must_equal 'process'
       _(job_span.attributes['peer.service']).must_be_nil
-      _(job_span.events.size).must_equal(2)
+      _(job_span.events.size).must_equal(1)
 
-      created_event = job_span.events[0]
-      _(created_event.name).must_equal('created_at')
-      _(created_event.timestamp.digits.count).must_equal(19)
-
-      enqueued_event = job_span.events[1]
+      enqueued_event = job_span.events[0]
       _(enqueued_event.name).must_equal('enqueued_at')
       _(enqueued_event.timestamp.digits.count).must_equal(19)
     end


### PR DESCRIPTION
Exq doesn't seem to pass "created_at" with its messages. [Current Sidekiq API](https://github.com/sidekiq/sidekiq/blob/f9e0a026543c93ae49c1d1d41c6592d2877d318a/lib/sidekiq/api.rb#L456) defaults `created_at` to `enqueued_at` or `0` if it's not available, so we can mimic that method for safely defaulting these values.

Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1795