### PR TITLE
feat!: update Ethon span name when unknown method

### DIFF
--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/http_helper.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/http_helper.rb
@@ -74,7 +74,7 @@ module OpenTelemetry
             )
           else
             SpanCreationAttributes.new(
-              span_name: semconv == :old ? 'HTTP N/A' : 'HTTP',
+              span_name: 'HTTP',
               normalized_method: '_OTHER',
               original_method: method.to_s
             )

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
@@ -69,7 +69,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             easy.stub(:complete, nil) do
               easy.perform
 
-              _(span.name).must_equal 'HTTP N/A'
+              _(span.name).must_equal 'HTTP'
               _(span.attributes['http.method']).must_equal '_OTHER'
               _(span.attributes['http.status_code']).must_be_nil
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -87,7 +87,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
               # NOTE: check the finished spans since we expect to have closed it
               span = exporter.finished_spans.first
-              _(span.name).must_equal 'HTTP N/A'
+              _(span.name).must_equal 'HTTP'
               _(span.attributes['http.method']).must_equal '_OTHER'
               _(span.attributes['http.status_code']).must_be_nil
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -113,7 +113,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
         it 'when response is successful' do
           stub_response(response_code: 200) do
-            _(span.name).must_equal 'HTTP N/A'
+            _(span.name).must_equal 'HTTP'
             _(span.attributes['http.method']).must_equal '_OTHER'
             _(span.attributes['http.status_code']).must_equal 200
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -126,7 +126,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
         it 'when response is not successful' do
           stub_response(response_code: 500) do
-            _(span.name).must_equal 'HTTP N/A'
+            _(span.name).must_equal 'HTTP'
             _(span.attributes['http.method']).must_equal '_OTHER'
             _(span.attributes['http.status_code']).must_equal 500
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -139,7 +139,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
         it 'when request times out' do
           stub_response(response_code: 0, return_code: :operation_timedout) do
-            _(span.name).must_equal 'HTTP N/A'
+            _(span.name).must_equal 'HTTP'
             _(span.attributes['http.method']).must_equal '_OTHER'
             _(span.attributes['http.status_code']).must_be_nil
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -255,7 +255,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
           stub_response(response_code: 200) do
             _(exporter.finished_spans.size).must_equal 1
-            _(span.name).must_equal 'HTTP N/A'
+            _(span.name).must_equal 'HTTP'
             _(span.attributes['http.method']).must_equal '_OTHER'
             _(span.attributes['http.url']).must_equal 'http://example.com/purge'
           end


### PR DESCRIPTION
This is a followup PR to https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1781. It fixes Ethon span names when an unknown method is encountered. The previous (incorrect) name `HTTP N/A`is now just `HTTP`.