### PR TITLE
chore: Resolve md linting issues

### DIFF
--- a/instrumentation/action_pack/README.md
+++ b/instrumentation/action_pack/README.md
@@ -38,8 +38,8 @@ This instrumentation now relies on `ActiveSupport::Notifications` and registers 
 
 See the table below for details of what [Rails Framework Hook Events](https://guides.rubyonrails.org/active_support_instrumentation.html#action-controller) are recorded by this instrumentation:
 
-| Event Name | Subscribe? | Creates Span? |  Notes |
-| - | - | - | - |
+| Event Name | Subscribe? | Creates Span? | Notes |
+| ---- | --- | --- | --- |
 | `process_action.action_controller` | :white_check_mark: | :x: | It modifies the existing Rack span |
 
 ## Semantic Conventions

--- a/propagator/ottrace/README.md
+++ b/propagator/ottrace/README.md
@@ -7,8 +7,8 @@ The `opentelemetry-propagator-ottrace` gem contains injectors and extractors for
 
 | Header Name         | Description                                                                                                                            | Required              |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `ot-tracer-traceid` | 64-bit; 16 hex digits (extract and inject) or 128-bit; 32 hex digits (extract)                                             | yes                   |
-| `ot-tracer-spanid`  | 64-bit; 16 hex digits                                                                                    | yes                   |
+| `ot-tracer-traceid` | 64-bit; 16 hex digits (extract and inject) or 128-bit; 32 hex digits (extract)                                                         | yes                   |
+| `ot-tracer-spanid`  | 64-bit; 16 hex digits                                                                                                                  | yes                   |
 | `ot-tracer-sampled` | boolean or bit encoded as a string with the values `'true'`,`'false'`, `'1'`, or `'0'`                                                 | no                    |
 | `ot-baggage-*`      | repeated string to string key-value baggage items; keys are prefixed with `ot-baggage-` and the corresponding value is the raw string. | if baggage is present |
 

--- a/resources/aws/README.md
+++ b/resources/aws/README.md
@@ -49,7 +49,7 @@ end
 Populates `cloud` and `host` for processes running on Amazon EC2, including abstractions such as ECS on EC2. Notably, it does not populate anything on AWS Fargate.
 
 | Resource Attribute | Description |
-|--------------------|-------------|
+| ------------------ | ----------- |
 | `cloud.account.id` | Value of `accountId` from `/latest/dynamic/instance-identity/document` request |
 | `cloud.availability_zone` | Value of `availabilityZone` from `/latest/dynamic/instance-identity/document` request |
 | `cloud.platform` | The cloud platform. In this context, it's always "aws_ec2" |
@@ -64,7 +64,7 @@ Populates `cloud` and `host` for processes running on Amazon EC2, including abst
 <!-- cspell:ignore launchtype awslogs -->
 Populates `cloud`, `container`, and AWS ECS-specific attributes for processes running on Amazon ECS.
 | Resource Attribute | Description |
-|--------------------|-------------|
+| ------------------ | ----------- |
 | `cloud.platform` | The cloud platform. In this context, it's always "aws_ecs" |
 | `cloud.provider` | The cloud provider. In this context, it's always "aws" |
 | `container.id` | The container ID from the `/proc/self/cgroup` file |
@@ -81,7 +81,7 @@ Populates `cloud`, `container`, and AWS ECS-specific attributes for processes ru
 
 Populates `cloud`, `container`, and Kubernetes (k8s) attributes for processes running on Amazon EKS.
 | Resource Attribute | Description |
-|--------------------|-------------|
+| ------------------ | ----------- |
 | `cloud.platform` | The cloud platform. In this context, it's always "aws_eks" |
 | `cloud.provider` | The cloud provider. In this context, it's always "aws" |
 | `container.id` | The container ID from the `/proc/self/cgroup` file |
@@ -95,7 +95,7 @@ The EKS detector verifies that the process is running on EKS by checking:
 ### AWS Lambda Detector
 Populates `cloud` and `faas` (Function as a Service) attributes for processes running on AWS Lambda.
 | Resource Attribute | Description |
-|--------------------|-------------|
+| ------------------ | ----------- |
 | `cloud.platform` | The cloud platform. In this context, it's always "aws_lambda" |
 | `cloud.provider` | The cloud provider. In this context, it's always "aws" |
 | `cloud.region` | The AWS region from the `AWS_REGION` environment variable |


### PR DESCRIPTION
This ensures that all the markdown pages pass the linting rules. Note failures can be seen at https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/19679278773/job/56368875727#step:3:1