### PR TITLE
ci: update markdownlint setup

### DIFF
--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -20,7 +20,6 @@ jobs:
       # equivalent cli: markdownlint-cli2  "**/*.md" "#**/CHANGELOG.md"  --config .markdownlint.json
       - name: "Markdown Lint Check"
         uses: DavidAnson/markdownlint-cli2-action@v21
-        continue-on-error: true
         with:
           fix: false
           globs: |

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -21,6 +21,7 @@ jobs:
       - name: "Markdown Lint Check"
         uses: DavidAnson/markdownlint-cli2-action@v21
         with:
+          config: .markdownlint.json
           fix: false
           globs: |
             **/*.md


### PR DESCRIPTION
This turns on build failures when linting fails. After #1812 has been merged this should pass.

Note this also ensures that the config is being used.