### PR TITLE
chore: Fix all changelog v0.88.0

### DIFF
--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History: opentelemetry-instrumentation-all
 
-### v0.87.1 / 2025-11-26
+### v0.88.0 / 2025-11-26
 
 * BREAKING CHANGE: Update Ethon span name when unknown method
 


### PR DESCRIPTION
I had committed the incorrect version number in the changelog when I released the gem.

Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1809