### PR TITLE
fix: Use sql-processor gem in instrumentations

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry-helpers-mysql'
-require 'opentelemetry-helpers-sql-obfuscation'
+require 'opentelemetry-helpers-sql-processor'
 
 module OpenTelemetry
   module Instrumentation
@@ -53,8 +53,10 @@ module OpenTelemetry
               attributes[SemanticConventions::Trace::DB_STATEMENT] = sql
             when :obfuscate
               attributes[SemanticConventions::Trace::DB_STATEMENT] =
-                OpenTelemetry::Helpers::SqlObfuscation.obfuscate_sql(
-                  sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql
+                OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(
+                  sql,
+                  obfuscation_limit: config[:obfuscation_limit],
+                  adapter: :mysql
                 )
             end
 

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/pg/example/Gemfile
+++ b/instrumentation/pg/example/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 gem 'opentelemetry-api'
 gem 'opentelemetry-common'
-gem 'opentelemetry-instrumentation-pg'
+gem 'opentelemetry-instrumentation-pg', path: '..'
 gem 'opentelemetry-sdk'
 gem 'pg'

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry-helpers-sql-obfuscation'
+require 'opentelemetry-helpers-sql-processor'
 require_relative '../constants'
 require_relative '../lru_cache'
 
@@ -116,7 +116,7 @@ module OpenTelemetry
           def obfuscate_sql(sql)
             return sql unless config[:db_statement] == :obfuscate
 
-            OpenTelemetry::Helpers::SqlObfuscation.obfuscate_sql(
+            OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(
               sql,
               obfuscation_limit: config[:obfuscation_limit],
               adapter: :postgres

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry-helpers-mysql'
-require 'opentelemetry-helpers-sql-obfuscation'
+require 'opentelemetry-helpers-sql-processor'
 
 module OpenTelemetry
   module Instrumentation
@@ -82,7 +82,11 @@ module OpenTelemetry
               case config[:db_statement]
               when :obfuscate
                 attributes[::OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT] =
-                  OpenTelemetry::Helpers::SqlObfuscation.obfuscate_sql(sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql)
+                  OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(
+                    sql,
+                    obfuscation_limit: config[:obfuscation_limit],
+                    adapter: :mysql
+                  )
               when :include
                 attributes[::OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT] = sql
               end

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
   spec.add_dependency 'opentelemetry-semantic_conventions', '>= 1.8.0'
 


### PR DESCRIPTION
The 'opentelemetry-helpers-sql-obfuscation' gem has been renamed to 'opentelemetry-helpers-sql-processor'.