### PR TITLE
fix: update gemspec dependencies to sql-processor

### DIFF
--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-helpers-mysql'
   spec.add_dependency 'opentelemetry-helpers-sql'
-  spec.add_dependency 'opentelemetry-helpers-sql-obfuscation'
+  spec.add_dependency 'opentelemetry-helpers-sql-processor'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
   spec.add_dependency 'opentelemetry-semantic_conventions', '>= 1.8.0'
 


### PR DESCRIPTION
Fix dependencies for trilogy, mysql2, and pg `opentelemetry-helpers-sql-obfuscation` -> `opentelemetry-helpers-sql-processor`

Fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1829