### PR TITLE
fix: Remove anthropic gem from all

### DIFF
--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -29,7 +29,7 @@ group :test do
      .sort
      .each { |dir| gem "opentelemetry-helpers-#{dir}", path: "../../helpers/#{dir}" }
 
-  excluded_instrumentations = %w[. .. all logger]
+  excluded_instrumentations = %w[. .. all logger anthropic]
   Dir.entries('../')
      .select { |entry| File.directory?(File.join('../', entry)) }
      .reject { |entry| excluded_instrumentations.include?(entry) }

--- a/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
+++ b/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry-instrumentation-anthropic'
 require 'opentelemetry-instrumentation-active_support'
 require 'opentelemetry-instrumentation-action_pack'
 require 'opentelemetry-instrumentation-active_job'

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'opentelemetry-instrumentation-active_model_serializers', '~> 0.24.0'
-  spec.add_dependency 'opentelemetry-instrumentation-anthropic', '~> 0.3.0'
   spec.add_dependency 'opentelemetry-instrumentation-aws_lambda', '~> 0.6.0'
   spec.add_dependency 'opentelemetry-instrumentation-aws_sdk', '~> 0.11.0'
   spec.add_dependency 'opentelemetry-instrumentation-bunny', '~> 0.24.0'


### PR DESCRIPTION
The anthropic test suite was not integrated into the test suite so I am removing it from the all gem.

cc: @robertlaurin

https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1699