### PR TITLE
fix: use a unique consumer group in tests to fix racecar tests

### DIFF
--- a/instrumentation/racecar/Appraisals
+++ b/instrumentation/racecar/Appraisals
@@ -11,3 +11,11 @@ end
 appraise 'racecar-2.8' do
   gem 'racecar', '~> 2.8.2'
 end
+
+appraise 'racecar-2.10' do
+  gem 'racecar', '~> 2.10'
+end
+
+appraise 'racecar-2.12' do
+  gem 'racecar', '~> 2.12'
+end

--- a/instrumentation/racecar/test/opentelemetry/instrumentation/racecar_test.rb
+++ b/instrumentation/racecar/test/opentelemetry/instrumentation/racecar_test.rb
@@ -49,12 +49,17 @@ describe OpenTelemetry::Instrumentation::Racecar do
 
     producer.close
   end
+  let(:config) do
+    config = Racecar::Config.new
+    config.group_id = "test-#{SecureRandom.hex(10)}"
+    config.brokers = ["#{host}:#{port}"]
+    config.pause_timeout = 0 # fail fast and exit
+    config
+  end
 
   let(:racecar) do
-    Racecar.config.brokers = ["#{host}:#{port}"]
-    Racecar.config.pause_timeout = 0 # fail fast and exit
-    Racecar.config.load_consumer_class(consumer_class)
-    Racecar::Runner.new(consumer_class.new, config: Racecar.config, logger: Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym), instrumenter: Racecar.instrumenter)
+    config.load_consumer_class(consumer_class)
+    Racecar::Runner.new(consumer_class.new, config: config, logger: Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym), instrumenter: Racecar.instrumenter)
   end
 
   def run_racecar(racecar)


### PR DESCRIPTION
The tests for this instrumentation are failing on racecar 2.10+. This is due to an issue caused by reuse of consumer group ids (derived from the class name in racecar unless specified) in tests.
Switching to use a unique consumer group fixes the tests.

In Racecar 2.10 a [change](https://github.com/zendesk/racecar/pull/339) was intrdouced to add a RebalanceListener by default to every consumer.

Now, when a consumer leaves a group, rdkafka's
rebalance protocol waits for acknowledgment from the listener before completing the leave.

When the test's consumer closes and the next test's consumer tries to join the same group ID, Kafka's group coordinator now waits for the rebalance protocol to complete, which takes longer than before due to the new listener-based coordination.