### PR TITLE
chore: require Approval for major updates to ruby dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,11 @@
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "matchManagers": ["ruby"],
+      "dependencyDashboardApproval": true
     }
   ],
   "labels": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":separateMultipleMajorReleases"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
This adds a dashboard approval requirement for major ruby dependency updates and avoid pr's such as #1891

Also to help pr's will now only bump 1 major version at a time to enable better alignment with supported versions. Hence the linked pr would become a bump to v7 not v8.