### PR TITLE
ci: Constrain actions

### DIFF
--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   helpers:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -73,6 +74,7 @@ jobs:
           ruby: "jruby-10.0.2.0"
 
   propagators:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +115,7 @@ jobs:
           ruby: "jruby-10.0.2.0"
 
   resource-detectors:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +157,7 @@ jobs:
           ruby: "jruby-10.0.2.0"
 
   processors:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -192,6 +196,7 @@ jobs:
           ruby: "jruby-10.0.2.0"
 
   samplers:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -62,7 +62,13 @@ concurrency:
   cancel-in-progress: true  # Cancel any previous runs of this workflow
 
 jobs:
+  check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Repository check passed"
   instrumentation:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -42,7 +42,13 @@ concurrency:
   cancel-in-progress: true  # Cancel any previous runs of this workflow
 
 jobs:
+  check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Repository check passed"
   instrumentation_with_services:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +91,7 @@ jobs:
           - 27017:27017
 
   instrumentation_mysql:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +129,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.0.31 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
   instrumentation_kafka:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +184,7 @@ jobs:
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   instrumentation_redis:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -222,6 +231,7 @@ jobs:
           REDIS_PASSWORD: "passw0rd"
 
   instrumentation_postgresql:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -265,6 +275,7 @@ jobs:
           - "/var/run/postgresql:/var/run/postgresql"
 
   instrumentation_rabbitmq:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   instrumentation_all:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   markdownlint-check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Markdown Lint Check
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +29,7 @@ jobs:
             !**/CHANGELOG.md
 
   markdown-link-check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Markdown Link Check
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +44,7 @@ jobs:
           fail_on_error: true
 
   spelling-check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Spelling Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   run_self:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     permissions:
       pull-requests: write # required for assigning reviewers to PRs
     runs-on: ubuntu-latest

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   validate-commits:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Conventional Commits Validation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   installation-tests:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   stale:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
 
     permissions:
       issues: write # required for labeling and closing stale issues


### PR DESCRIPTION
This should restrict actions defined in the contrib repo from running in forked repo actions environments

cc: @wsmoak