### PR TITLE
ci: leverage public dictionaries and increase cspell usage

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -3,22 +3,14 @@
 # https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
 version: '0.2'
 caseSensitive: false
+useGitignore: true
 import:
   - https://cdn.jsdelivr.net/npm/@cspell/dict-people-names/cspell-ext.json
+  - https://cdn.jsdelivr.net/npm/@cspell/dict-redis/cspell-ext.json
 ignorePaths:
   - 'bin'
-  - '**.conf'
-  - '**.gemspec'
-  - '**.json'
   - '**.proto'
-  - '**.rb'
-  - '**.ru'
-  - '**.yml'
-  - 'Appraisals'
   - 'CODEOWNERS'
-  - 'Dockerfile'
-  - 'Gemfile'
-  - 'Rakefile'
 patterns:
   - name: CodeBlock
     pattern: |
@@ -37,12 +29,34 @@ patterns:
       /x
   - name: "GitHub Handle"
     pattern: "@[a-zA-Z0-9-_]+\\b"
+enabledLanguageIds:
+  - dockercompose
+  - dockerfile
+  - json
+  - jsonc
+  - markdown
+  - properties
+  - ruby
+  - yaml
 languageSettings:
+  - languageId: json, jsonc
+    includeRegExpList:
+      - CStyleComment
   - languageId: markdown
     ignoreRegExpList:
       - CodeBlock
       - CodeName
       - GitHub Handle
+  - languageId: ruby
+    includeRegExpList:
+      - "#.*/g"
+    ignoreRegExpList:
+      - CodeName
+  - languageId: dockerfile, dockercompose, properties, yaml
+    includeRegExpList:
+      - "/#.*/g"
+    ignoreRegExpList:
+      - CodeName
 dictionaries:
   - aws
   - companies
@@ -50,8 +64,14 @@ dictionaries:
   - ruby
   - softwareTerms
   - software-tools
+  - redis
+ignoreWords:
+  - sendfile
+  - millis
 words:
   - AWSXRayTrace
+  - AWSXRaySamplingClient
+  - AWSXRayRemoteSampler
   - enqueuers
   - myapp
   - otelcol
@@ -62,6 +82,12 @@ words:
   - traceid
   - traceparent
   - traceresponse
+  - tracestate
+
+  - Resolv
+  - rackup
+  - miniswan
+  - BSON
   
   # Ruby
   - dalli

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -3,6 +3,8 @@
 # https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
 version: '0.2'
 caseSensitive: false
+import:
+  - https://cdn.jsdelivr.net/npm/@cspell/dict-people-names/cspell-ext.json
 ignorePaths:
   - 'bin'
   - '**.conf'
@@ -44,6 +46,7 @@ languageSettings:
 dictionaries:
   - aws
   - companies
+  - people-names
   - ruby
   - softwareTerms
   - software-tools
@@ -59,29 +62,7 @@ words:
   - traceid
   - traceparent
   - traceresponse
-# Companies
-  - Lightstep
-# People Names
-  - Azuma
-  - Bogsanyi
-  - Laurin
-  - Mustin
-  - Reopelle
-  - Robb
-  - Šimánek
-  - Xuan
-# Software terms
-  - codeowners 
-  - FaaS
-  - microbenchmarking
-  - namespacing
-  - triager
-  - triagers
-  - untrace
-# Software tools
-  - Gitter
-  - RabbitMQ
-  - Vitess
+  
   # Ruby
   - dalli
   - ethon

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -62,6 +62,7 @@ dictionaries:
   - companies
   - people-names
   - ruby
+  - ruby-gems
   - softwareTerms
   - software-tools
   - redis
@@ -83,20 +84,3 @@ words:
   - traceparent
   - traceresponse
   - tracestate
-
-  - Resolv
-  - rackup
-  - miniswan
-  - BSON
-  
-  # Ruby
-  - dalli
-  - ethon
-  - gruf
-  - httpx
-  - lmdb
-  - Railtie
-  - racecar
-  - rdkafka
-  - restclient
-  - rubydocs

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -4,13 +4,16 @@
 version: '0.2'
 caseSensitive: false
 useGitignore: true
+enableGlobDot: true
 import:
   - https://cdn.jsdelivr.net/npm/@cspell/dict-people-names/cspell-ext.json
   - https://cdn.jsdelivr.net/npm/@cspell/dict-redis/cspell-ext.json
 ignorePaths:
+  - '.git'
   - 'bin'
-  - '**.proto'
+  - '*.proto'
   - 'CODEOWNERS'
+  - '*.tt'
 patterns:
   - name: CodeBlock
     pattern: |
@@ -29,15 +32,6 @@ patterns:
       /x
   - name: "GitHub Handle"
     pattern: "@[a-zA-Z0-9-_]+\\b"
-enabledLanguageIds:
-  - dockercompose
-  - dockerfile
-  - json
-  - jsonc
-  - markdown
-  - properties
-  - ruby
-  - yaml
 languageSettings:
   - languageId: json, jsonc
     includeRegExpList:
@@ -75,6 +69,7 @@ words:
   - AWSXRayRemoteSampler
   - enqueuers
   - myapp
+  - otelbot
   - otelcol
   - ottrace
   - ruboproof
@@ -84,3 +79,6 @@ words:
   - traceparent
   - traceresponse
   - tracestate
+
+  - linkspector
+  - sarif

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -3,6 +3,20 @@
 # https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
 version: '0.2'
 caseSensitive: false
+ignorePaths:
+  - 'bin'
+  - '**.conf'
+  - '**.gemspec'
+  - '**.json'
+  - '**.proto'
+  - '**.rb'
+  - '**.ru'
+  - '**.yml'
+  - 'Appraisals'
+  - 'CODEOWNERS'
+  - 'Dockerfile'
+  - 'Gemfile'
+  - 'Rakefile'
 patterns:
   - name: CodeBlock
     pattern: |
@@ -12,76 +26,70 @@ patterns:
           [\s\S]*?         # content
           \1               # code-block end
       /igmx
+  - name: CodeName
+    pattern: |
+      /
+          ([~`])          # Matches a single backtick or tilde to start a code block.
+          [^~`]*?         # Matches any characters except backticks or tildes, non-greedy.
+          \1              # Matches the same symbol which started the match.
+      /x
+  - name: "GitHub Handle"
+    pattern: "@[a-zA-Z0-9-_]+\\b"
 languageSettings:
   - languageId: markdown
     ignoreRegExpList:
       - CodeBlock
+      - CodeName
+      - GitHub Handle
+dictionaries:
+  - aws
+  - companies
+  - ruby
+  - softwareTerms
+  - software-tools
 words:
-  - AWSX
-  - Azuma
-  - backports
-  - behaviour
-  - Bogsanyi
-  - callables
-  - circleci
-  - Clientcontext
-  - codeowners
-  - dalli
-  - datadog
+  - AWSXRayTrace
   - enqueuers
-  - ethon
-  - excon
-  - faas
-  - fanout
-  - faraday
-  - gettime
-  - gemfile
-  - Gitter
-  - gruf
-  - hibachrach
-  - HTTPX
-  - httpx
-  - instrumenter
-  - Laurin
-  - Lightstep
-  - linux
-  - lmdb
-  - microbenchmarks
-  - Mustin
   - myapp
-  - namespacing
-  - opentelemetry
   - otelcol
   - ottrace
-  - postgres
-  - postgresql
-  - racecar
-  - rabbitmq
-  - Railtie
-  - Rakefile
-  - Reopelle
-  - rdkafka
-  - resque
-  - restclient
-  - Robb
-  - rubocop
-  - rubydocs
   - ruboproof
-  - rubygems
-  - Šimánek
   - semconv
-  - sidekiq
-  - sinatra
-  - Solarwinds
   - spanid
-  - toolset
   - traceid
-  - traceresponse
-  - Triager
-  - triagers
-  - Untrace
-  - vitess
-  - webmocks
-  - Xuan
-  - yardoc
   - traceparent
+  - traceresponse
+# Companies
+  - Lightstep
+# People Names
+  - Azuma
+  - Bogsanyi
+  - Laurin
+  - Mustin
+  - Reopelle
+  - Robb
+  - Šimánek
+  - Xuan
+# Software terms
+  - codeowners 
+  - FaaS
+  - microbenchmarking
+  - namespacing
+  - triager
+  - triagers
+  - untrace
+# Software tools
+  - Gitter
+  - RabbitMQ
+  - Vitess
+  # Ruby
+  - dalli
+  - ethon
+  - gruf
+  - httpx
+  - lmdb
+  - Railtie
+  - racecar
+  - rdkafka
+  - restclient
+  - rubydocs

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Notify us of an error or incorrect behaviour
+about: Notify us of an error or incorrect behavior
 title: ''
 labels: 'bug'
 assignees: ''
@@ -9,7 +9,7 @@ assignees: ''
 
 <!--
 
-NOTE: Please use this form to submit bugs or demonstrations of non spec compliant behaviour
+NOTE: Please use this form to submit bugs or demonstrations of non spec compliant behavior
 
 -->
 
@@ -17,7 +17,7 @@ NOTE: Please use this form to submit bugs or demonstrations of non spec complian
 
 <!--
 
-If this for behaviour that is not compliant with the OpenTelemetry Specification, please describe
+If this for behavior that is not compliant with the OpenTelemetry Specification, please describe
 what happened and what you expected with a link to the relevant portion of the spec.
 
 -->

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: streetsidesoftware/cspell-action@24fa8d3096a314ce263f39578744e9d9f8d80acf # v8.1.2
         with:
-          # Files should be consistent with check:spelling files
-          files: |
-            **/*.md
+          use_cspell_files: true
           config: .cspell.yml
+          suggestions: true
+          treat_flagged_words_as_errors: true

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -36,7 +36,7 @@ jobs:
               echo "Current directory: $(pwd)"
               echo "Creating lock file for: $gemfile"
               
-              # Generate the gemlock files
+              # Generate the Gemfile.lock files
               bundle lock || echo "Warning: Failed to generate lock file for $gemfile, continuing..."
 
               cd "$ORIGINAL_DIR" || exit 1

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -18,7 +18,7 @@ commit_lint:
   # Merge types allowed by the repo.
   merge: squash
 
-# List of all releaseable gems. Each gem should include:
+# List of all releasable gems. Each gem should include:
 #  *  name: The name of the gem. (Required.)
 #  *  directory: Gem directory relative to the repo root. (Required.)
 #  *  version_rb_path: Path to version.rb relative to the gem directory.
@@ -27,7 +27,7 @@ commit_lint:
 #  *  version_constant: The fully-qualified version constant as an array.
 #     (Required because the OpenTelemetry namespace does not match the gem
 #     name "opentelemetry".)
-#  *  changelog_path: Path to CHANGLEOG.md relative to the gem directory.
+#  *  changelog_path: Path to CHANGELOG.md relative to the gem directory.
 #     (Required only if it is not in the expected location.)
 gems:
   - name: opentelemetry-instrumentation-factory_bot

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -193,7 +193,7 @@ Code that is not tested will not be accepted by maintainers. We understand that 
 
 Most of the libraries we instrument introduce changes outside of our control. For this reason, integration or state-based tests are preferred over interaction (mock) tests.
 
-When you do in fact run into cases where test doubles or API stubs are absolutely necessary, we recommend using the [`rspec-mocks`](https://github.com/rspec/rspec-mocks) and [`webmocks`](https://github.com/bblimke/webmock) gems.
+When you do in fact run into cases where test doubles or API stubs are absolutely necessary, we recommend using the [`rspec-mocks`](https://github.com/rspec/rspec-mocks) and [`WebMock`](https://github.com/bblimke/webmock) gems.
 
 ### Understand performance characteristics
 
@@ -202,7 +202,7 @@ The OTel Specification describes expectations around the performance of SDKs, wh
 Instrumentation libraries should be as lightweight as possible and must:
 
 * Rely on `rubocop-performance` linters to catch performance issues
-* Consider using [microbenchmarks](https://github.com/evanphx/benchmark-ips) and [profiling](https://ruby-prof.github.io/) to address any possible performance issues
+* Consider using [microbenchmarking](https://github.com/evanphx/benchmark-ips) and [profiling](https://ruby-prof.github.io/) to address any possible performance issues
 * Provide minimal solutions and code paths
 
 #### Provide minimal solutions and code paths

--- a/instrumentation/action_view/CHANGELOG.md
+++ b/instrumentation/action_view/CHANGELOG.md
@@ -86,7 +86,7 @@
 
 ### v0.1.3 / 2021-10-06
 
-* FIXED: Do not replace fanout
+* FIXED: Do not replace fan-out
 
 ### v0.1.2 / 2021-09-29
 

--- a/instrumentation/active_model_serializers/CHANGELOG.md
+++ b/instrumentation/active_model_serializers/CHANGELOG.md
@@ -118,4 +118,4 @@
 
 ### v0.9.0 / 2020-11-03
 
-* Initial release of Active Model Serializers instrumenter (ported from Datadog)
+* Initial release of Active Model Serializers Instrumentation (ported from Datadog)

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/persistence_insert_class_methods.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/persistence_insert_class_methods.rb
@@ -7,7 +7,7 @@ module OpenTelemetry
   module Instrumentation
     module ActiveRecord
       module Patches
-        # Module to prepend to ActiveRecord::Base for instrumentating
+        # Module to prepend to ActiveRecord::Base for instrumenting
         # insert/upsert class methods added in Rails 6.0
         module PersistenceInsertClassMethods
           def self.prepended(base)

--- a/instrumentation/aws_lambda/example/trace_demonstration.rb
+++ b/instrumentation/aws_lambda/example/trace_demonstration.rb
@@ -28,7 +28,7 @@ class MockLambdaContext
   end
 end
 
-# To accommendate the test case, handler class doesn't need to require the sample file if it's required here
+# To accommodate the test case, handler class doesn't need to require the sample file if it's required here
 # In lambda environment, the env will find the handler file.
 module OpenTelemetry
   module Instrumentation

--- a/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/instrumentation.rb
+++ b/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/instrumentation.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
           require_dependencies
         end
 
-        # determine if current environment is lambda by checking _HANLDER or ORIG_HANDLER
+        # determine if current environment is lambda by checking _HANDLER or ORIG_HANDLER
         present do
           ENV.key?('_HANDLER') || ENV.key?('ORIG_HANDLER')
         end

--- a/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
+++ b/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
@@ -127,7 +127,7 @@ module OpenTelemetry
           attributes
         end
 
-        # fass.trigger set to http: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/aws-lambda.md#api-gateway
+        # faas.trigger set to http: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/aws-lambda.md#api-gateway
         # TODO: need to update Semantic Conventions for invocation_id, trigger and resource_id
         def otel_attributes(event, context)
           span_attributes = {}

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -42,7 +42,7 @@ module OpenTelemetry
     # The instrumentation name and version will be inferred from the namespace of the
     # class. In this example, they'd be 'OpenTelemetry::Instrumentation::Sinatra' and
     # OpenTelemetry::Instrumentation::Sinatra::VERSION, but can be explicitly set using
-    # the +instrumentation_name+ and +instrumetation_version+ methods if necessary.
+    # the +instrumentation_name+ and +instrumentation_version+ methods if necessary.
     #
     # All subclasses of OpenTelemetry::Instrumentation::Base are automatically
     # registered with OpenTelemetry.instrumentation_registry which is used by
@@ -328,7 +328,7 @@ module OpenTelemetry
 
       # Checks to see if the user has passed any environment variables that set options
       # for instrumentation. By convention, the environment variable will be the name
-      # of the instrumentation, uppercased, with '::' replaced by underscores,
+      # of the instrumentation, upper-cased, with '::' replaced by underscores,
       # OPENTELEMETRY shortened to OTEL_{LANG}, and _CONFIG_OPTS appended.
       # For example, the environment variable name for OpenTelemetry::Instrumentation::Faraday
       # will be OTEL_RUBY_INSTRUMENTATION_FARADAY_CONFIG_OPTS. A value of 'peer_service=new_service;'

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -96,7 +96,7 @@
 ### v0.18.0 / 2021-05-21
 
 * ADDED: Updated API dependency for 1.0.0.rc1
-* BREAKING CHANGE: Replace Time.now with Process.clock_gettime
+* BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/ethon/Appraisals
+++ b/instrumentation/ethon/Appraisals
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -2,7 +2,7 @@
 
 # add more tests for excon
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/faraday/Appraisals
+++ b/instrumentation/faraday/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -65,7 +65,7 @@ module OpenTelemetry
         #
         # The schemas key expects an array of Schemas, and is used to specify
         # which schemas are to be instrumented. If this value is not supplied
-        # the default behaviour is to instrument all schemas.
+        # the default behavior is to instrument all schemas.
         option :schemas,                      default: [],    validate: :array
         option :enable_platform_field,        default: false, validate: :boolean
         option :enable_platform_authorized,   default: false, validate: :boolean

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -23,7 +23,7 @@ end
 
 # Hack that allows us to reset the internal state of the tracer to test installation
 module SchemaTestPatches
-  # Reseting @graphql_definition is needed for tests running against version `1.9.x`
+  # Resetting @graphql_definition is needed for tests running against version `1.9.x`
   # Other variables are used by ~> 2.0.19
   def _reset_tracer_for_testing
     %w[own_tracers trace_modes trace_class tracers graphql_definition own_trace_modes].each do |name|

--- a/instrumentation/http/Appraisals
+++ b/instrumentation/http/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # HTTP gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -113,7 +113,7 @@
 
 ### v0.16.2 / 2021-03-29
 
-* FIXED: HTTP instrumenter should check for gem presence
+* FIXED: HTTP Instrumentation should check for gem presence
 
 ### v0.16.1 / 2021-03-25
 

--- a/instrumentation/http_client/Appraisals
+++ b/instrumentation/http_client/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # HTTP gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/dup/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/dup/client_test.rb
@@ -106,7 +106,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Dup::Client do
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['net.peer.port']).must_equal 443
-      # stable semantic coventions
+      # stable semantic conventions
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'https'
       _(span.attributes['http.response.status_code']).must_be_nil

--- a/instrumentation/httpx/Appraisals
+++ b/instrumentation/httpx/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/logger/test/test_helper.rb
+++ b/instrumentation/logger/test/test_helper.rb
@@ -23,6 +23,6 @@ OpenTelemetry::SDK.configure do |c|
 end
 
 # Create a globally available Rails app, this should be used in test unless
-# specifically testing behaviour with different initialization configs.
+# specifically testing behavior with different initialization configs.
 DEFAULT_RAILS_APP = AppConfig.initialize_app
 Rails.application = DEFAULT_RAILS_APP

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -79,10 +79,10 @@
 
 ### v0.18.0 / 2021-05-21
 
-* BREAKING CHANGE: Replace Time.now with Process.clock_gettime
+* BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
 
 * ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Replace Time.now with Process.clock_gettime
+* FIXED: Replace `Time.now` with `Process.clock_gettime`
 * FIXED: Mongodb test asserting error message
 
 ### v0.17.0 / 2021-04-22
@@ -108,7 +108,7 @@
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Mongo Instrumenter: Do not send nil attributes
+* FIXED: Mongo Instrumentation: Do not send nil attributes
 
 ### v0.12.0 / 2020-12-24
 
@@ -124,4 +124,4 @@
 
 ### v0.9.0 / 2020-11-03
 
-* Initial release of Mongo instrumenter (ported from Datadog)
+* Initial release of Mongo Instrumentation (ported from Datadog)

--- a/instrumentation/net_http/Appraisals
+++ b/instrumentation/net_http/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # HTTP gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/net_http/CHANGELOG.md
+++ b/instrumentation/net_http/CHANGELOG.md
@@ -93,7 +93,7 @@
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Clientcontext attrs overwrite in net::http
+* FIXED: Client Context attrs overwrite in net::http
 * FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-01

--- a/instrumentation/racecar/README.md
+++ b/instrumentation/racecar/README.md
@@ -36,7 +36,7 @@ end
 
 ## Examples
 
-Example usage can be seen in the [`./example` directory](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/racecar/example). Run `./trace_demonstration.sh` to see its behaviour.
+Example usage can be seen in the [`./example` directory](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/racecar/example). Run `./trace_demonstration.sh` to see its behavior.
 
 ## How can I get involved?
 

--- a/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/process_message_subscriber.rb
+++ b/instrumentation/racecar/lib/opentelemetry/instrumentation/racecar/process_message_subscriber.rb
@@ -2,7 +2,7 @@
 
 module OpenTelemetry
   module Instrumentation
-    # This class contains the ASN subsciber that instruments message processing
+    # This class contains the ASN subscriber that instruments message processing
     class ProcessMessageSubscriber
       GETTER = if Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.13.0')
                  Context::Propagation.text_map_getter

--- a/instrumentation/rack/Appraisals
+++ b/instrumentation/rack/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # HTTP gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -130,7 +130,7 @@
 
 The default was to set the span name as the path of the request, we have
 corrected this as it was not adhering to the spec requirement using low
-cardinality span names.  You can restore the previous behaviour of high
+cardinality span names.  You can restore the previous behavior of high
 cardinality span names by passing in a url quantization function that
 forwards the uri path.  More details on this is available in the readme.
 

--- a/instrumentation/rack/example/trace_demonstration2.rb
+++ b/instrumentation/rack/example/trace_demonstration2.rb
@@ -14,7 +14,7 @@ builder = Rack::Builder.new
 app = ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['All responses are OK']] }
 builder.run app
 
-# demonstrate integration using 'retain_middlware_names' and 'application':
+# demonstrate integration using 'retain_middleware_names' and 'application':
 ENV['OTEL_TRACES_EXPORTER'] = 'console'
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Rack',

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/dup/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/dup/event_handler.rb
@@ -90,7 +90,7 @@ module OpenTelemetry
             # @note does nothing if the span is a non-recording span
             # @param [Rack::Request] The current HTTP request
             # @param [Rack::Response] The current HTTP response
-            # @param [Exception] An unxpected error raised by the application
+            # @param [Exception] An unexpected error raised by the application
             def on_error(request, _, error)
               span = OpenTelemetry::Instrumentation::Rack.current_span
               return unless span.recording?

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/old/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/old/event_handler.rb
@@ -90,7 +90,7 @@ module OpenTelemetry
             # @note does nothing if the span is a non-recording span
             # @param [Rack::Request] The current HTTP request
             # @param [Rack::Response] The current HTTP response
-            # @param [Exception] An unxpected error raised by the application
+            # @param [Exception] An unexpected error raised by the application
             def on_error(request, _, error)
               span = OpenTelemetry::Instrumentation::Rack.current_span
               return unless span.recording?

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/stable/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/stable/event_handler.rb
@@ -90,7 +90,7 @@ module OpenTelemetry
             # @note does nothing if the span is a non-recording span
             # @param [Rack::Request] The current HTTP request
             # @param [Rack::Response] The current HTTP response
-            # @param [Exception] An unxpected error raised by the application
+            # @param [Exception] An unexpected error raised by the application
             def on_error(request, _, error)
               span = OpenTelemetry::Instrumentation::Rack.current_span
               return unless span.recording?

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('7')
 
-        # This gem requires the instrumentantion gems for the different
+        # This gem requires the instrumentation gems for the different
         # components of Rails, as a result it does not have any explicit
         # work to do in the install step.
         install { true }

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
@@ -6,7 +6,7 @@
 module OpenTelemetry
   module Instrumentation
     module Rails
-      # Railtie automatically configure the OpentTelemetry SDK
+      # Railtie automatically configure the OpenTelemetry SDK
       #
       # This railtie will set defaults for the following environment variables:
       # `OTEL_SERVICE_NAME` - if unset, will default to the Rails application name

--- a/instrumentation/restclient/Appraisals
+++ b/instrumentation/restclient/Appraisals
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# To faclitate HTTP semantic convention stability migration, we are using
+# To facilitate HTTP semantic convention stability migration, we are using
 # appraisal to test the different semantic convention modes along with different
 # gem versions. For more information on the semantic convention modes, see:
 # https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/

--- a/instrumentation/rspec/README.md
+++ b/instrumentation/rspec/README.md
@@ -47,7 +47,7 @@ RSpec.configure do |config|
 end
 ```
 
-If you need to test trace behaviour in your specs then you should be able to use a custom tracer provider and the instrumentation's output should not interfere with your specs.
+If you need to test trace behavior in your specs then you should be able to use a custom tracer provider and the instrumentation's output should not interfere with your specs.
 
 ### Sampling
 

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -127,7 +127,7 @@
 
 * BREAKING CHANGE: Sidekiq propagation config 
   - Config option enable_job_class_span_names renamed to span_naming and now expects a symbol of value :job_class, or :queue
-  - The default behaviour is no longer to have one continuous trace for the enqueue and process spans, using links is the new default.  To maintain the previous behaviour the config option propagation_style must be set to :child.
+  - The default behavior is no longer to have one continuous trace for the enqueue and process spans, using links is the new default.  To maintain the previous behavior the config option propagation_style must be set to :child.
 * BREAKING CHANGE: Total order constraint on span.status= 
 
 * FIXED: Sidekiq propagation config 

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -51,7 +51,7 @@ Sidekiq.configure_client do |config|
   config.redis = { password: 'passw0rd', url: redis_url }
 end
 
-# Silence Actibe Job logging noise
+# Silence Active Job logging noise
 ActiveJob::Base.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
 
 class SimpleJobWithActiveJob < ActiveJob::Base

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/extensions/tracer_extension.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
         # Sinatra extension that installs TracerMiddleware and provides
         # tracing for template rendering
         module TracerExtension
-          # Contants patches for `render` method
+          # Constants patches for `render` method
           module RenderPatches
             def render(_engine, data, *)
               template_name = data.is_a?(Symbol) ? data : :literal

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in opentelemetry-propragator-ottrace.gemspec
+# Specify your gem's dependencies in opentelemetry-propagator-ottrace.gemspec
 gemspec
 
 group :test do

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in opentelemetry-propragator-vitess.gemspec
+# Specify your gem's dependencies in opentelemetry-propagator-vitess.gemspec
 gemspec
 
 group :test do

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
@@ -102,7 +102,7 @@ module OpenTelemetry
           # Extracting logging-related resource attributes
           #
           # @param container_metadata [Hash] Container metadata from ECS metadata endpoint
-          # @returhn [Hash] Resource attributes for logging configuration
+          # @return [Hash] Resource attributes for logging configuration
           def get_logs_resource(container_metadata)
             log_attributes = {}
 


### PR DESCRIPTION
This updates the cspell setup to use public dictionaries rather than custom words to reduce maintenance effort and barriers especially when writing new documents due to the extensive list of worlds available. In the process the checking scope is broadened to include more file types but limited to comments in those documents