### PR TITLE
fix: ensure major ruby updates need approval

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,12 @@
       "schedule": ["before 8am every weekday"]
     },
     {
-      "matchUpdateTypes": ["minor", "major"],
+      "matchUpdateTypes": ["minor"],
+      "schedule": ["before 8am on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "matchManagers": ["!ruby"],
       "schedule": ["before 8am on Monday"]
     },
     {


### PR DESCRIPTION
Extends #1900 

The linked pr didn't achieve its objective of requiring approval of major ruby updates based on the pr's that have been raised, it looks to be due to the approval requirement not removing the schedule, hence have split major non ruby packages into their own rule.

This will have blocked #1905 #1906 #1908 and #1909 from being raised and instead have required approval first.