### PR TITLE
ci: directly set ruby version rather than env

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -14,14 +14,12 @@ jobs:
       pull-requests: write # required for updating release PRs
       issues: write # required to create issues for failed releases
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -14,14 +14,12 @@ jobs:
       contents: write # required for updating releases
       pull-requests: write # required for updating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -23,14 +23,12 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -13,14 +13,12 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -17,14 +17,12 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -20,14 +20,12 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
-    env:
-      RUBY_VERSION: "3.2"
     runs-on: ubuntu-latest
     steps:
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: "3.2"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
The ruby version is now explicitly set in workflows as was done in the release please Workflow. This enables renovate to know about it and in the future after approval bump the version.