### PR TITLE
fix: Fix formatting in renovate.json5 for YAML matchers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
       "dependencyDashboardApproval": true
     },
     {
-      "matchFileNames": [".github/workflows/release-*.yaml"]
+      "matchFileNames": [".github/workflows/release-*.yaml"],
       "ignoreDeps": ["ruby"]
     }
   ],


### PR DESCRIPTION
Add a missing comma to renovate config and resolves #1921