### PR TITLE
revert: "chore(deps): update dependency ruby to v4.0.1 (#1947)"

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
 
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
This reverts commit 98fd155b15bd85873eceba3ba0339b035c53f18d that broke the release actions.