### PR TITLE
fix: Handle `Self` field in X-Amzn-Trace-Id header

### DIFF
--- a/propagator/xray/test/text_map_propagator_test.rb
+++ b/propagator/xray/test/text_map_propagator_test.rb
@@ -54,6 +54,18 @@ describe OpenTelemetry::Propagator::XRay::TextMapPropagator do
       _(extracted_context).must_be(:remote?)
     end
 
+    it 'extracts context with self field' do
+      parent_context = OpenTelemetry::Context.empty
+      carrier = { 'X-Amzn-Trace-Id' => 'Self=1-696f97a4-68ce1b2e0232080e03cce4f7;Root=1-80f198ea-e56343ba864fe8b2a57d3eff;Parent=e457b5a2e4d86bd1' }
+
+      context = propagator.extract(carrier, context: parent_context)
+      extracted_context = OpenTelemetry::Trace.current_span(context).context
+
+      _(extracted_context.hex_trace_id).must_equal('80f198eae56343ba864fe8b2a57d3eff')
+      _(extracted_context.hex_span_id).must_equal('e457b5a2e4d86bd1')
+      _(extracted_context).must_be(:remote?)
+    end
+
     it 'converts debug flag to sampled' do
       parent_context = OpenTelemetry::Context.empty
       carrier = { 'X-Amzn-Trace-Id' => 'Root=1-80f198ea-e56343ba864fe8b2a57d3eff;Parent=e457b5a2e4d86bd1;Sampled=d' }


### PR DESCRIPTION
AWS' load balancers add a `Self` field to the X-Amzn-Trace-Id header [^1] if the header exists, and a `Root` field is already present. This breaks the regex used to parse the header and leads to the traces not being associated with each other.

Allow for an optional Self field at the start of the header. Don't capture this.

[^1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
