### PR TITLE
chore: canary test for release workflows

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: "4.0.1"
+          ruby-version: "4.0"
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,27 @@
+name: Test for release workflows
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths: &path_filters
+      - ".github/workflows/release-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  release-test:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Ruby
+        uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
+        with:
+          ruby-version: "4.0.1"
+      - name: Checkout repo
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Install Toys
+        run: "gem install --no-document toys -v 0.19.1"
+      - name: Test CLI
+        run: "toys release --help < /dev/null"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -23,5 +23,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Toys
         run: "gem install --no-document toys -v 0.19.1"
+      # TODO: The invocation below simply tests that Toys will run and will
+      # successfully load the release system. We could also include additional
+      # test invocations that exercise key parts of the release system in
+      # dry-run mode if we want to further expand our checks.
       - name: Test CLI
-        run: "toys release --help < /dev/null"
+        run: "toys release request --help < /dev/null"


### PR DESCRIPTION
This is an alternative to #1952, for discussion.

#1952 modifies the existing release workflows so they partially run during pull request CI if the workflows are changed (e.g. when Renovate updates them). This is meant to catch problems like #1947 which silently broke the workflows. However, the changes are pretty invasive to the workflows themselves, because the logic needed to trigger the workflow in a normal release context *or* a CI context, and the logic needed to distinguish the two cases, is sometimes tricky to implement.

This pull request is a simpler alternative with some trade-offs. It introduces a new "canary" workflow that runs only in the CI context and duplicates the installations in the other release workflows. It does not modify any of the other workflows. The idea is, when Renovate does any updates, it should open a pull request that affects all the workflows, including this one. Any installation breakages should manifest at CI time in this workflow run without needing to run the others. This should catch Renovate-driven cases like #1947, but may not catch other cases such as someone modifying individual workflows without making corresponding changes to this one.

So to summarize the pros and cons.

Arguments for #1952:

* Can catch individual changes (e.g. not driven by Renovate) to release workflows that do not also touch this "canary" workflow.
* ~Framework for potential future invocation of CLIs in dry-run mode to catch breakages that would manifest only when running the CLI itself. (Does not provide this yet, but can in the future.)~ Edit: now that I think about it, such "dry-run test invocations" of the CLI itself could simply be added to this canary workflow, so this is not a *distinguishing* argument for 1952.

Arguments for the current PR:

* Non-invasive in the existing release workflows, does not increase their complexity or require more third-party dependencies.
