### PR TITLE
chore: Add deprecation notice to ruby_kafka README

### DIFF
--- a/instrumentation/ruby_kafka/README.md
+++ b/instrumentation/ruby_kafka/README.md
@@ -2,6 +2,11 @@
 
 The RubyKafka instrumentation is a community-maintained instrumentation for [RubyKafka][ruby_kafka-home], a client library for Apache Kafka.
 
+> [!IMPORTANT]
+> 
+> **Deprecation Notice:**
+> This gem is deprecated due to the upstream dependency it relies on no longer being maintained. The code remains available for reference, but no further updates or fixes will be provided. Users should consider migrating to actively supported alternatives.
+
 ## How do I get started?
 
 Install the gem using:


### PR DESCRIPTION
Progresses: #1769 

Added deprecation notice for the RubyKafka instrumentation.

