### PR TITLE
chore: Update release system to toys-release 0.5.1

### DIFF
--- a/.toys/release.rb
+++ b/.toys/release.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-load_gem "toys-release", "= 0.4.0"
+load_gem "toys-release", "= 0.5.1"


### PR DESCRIPTION
Changes include:

* Support for updating release pull requests when new commits are added
* Disabled GitHub check validation for now, as it looks like GitHub is making some changes that are interfering with toys-release's logic
* Multiple release pull requests are now allowed as long as they don't release any of the same components
* Fixed a number of crashes in the retry tool
* Various other fixes
