### PR TITLE
chore(release): Set the toys binary install location and ensure it can be found

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -30,6 +31,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release _onclosed --verbose \
+          ${{ github.workspace }}/bin/toys release _onclosed --verbose \
             "--event-path=${{ github.event_path }}" \
             < /dev/null

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -29,5 +30,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          toys release _onpush --verbose \
+          ${{ github.workspace }}/bin/toys release _onpush --verbose \
             < /dev/null

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -40,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release perform --yes --verbose \
+          ${{ github.workspace }}/bin/toys release perform --yes --verbose \
             "--release-ref=${{ github.sha }}" \
             ${{ github.event.inputs.flags }} \
             "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" \

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -38,6 +39,6 @@ jobs:
           # Using the app token instead of GITHUB_TOKEN to trigger workflows
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          toys release request --yes --verbose \
+          ${{ github.workspace }}/bin/toys release request --yes --verbose \
             "--target-branch=${{ github.ref }}" \
             < /dev/null

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -26,6 +26,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -41,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          toys release request --yes --verbose \
+          ${{ github.workspace }}/bin/toys release request --yes --verbose \
             "--target-branch=${{ github.ref }}" \
             ${{ github.event.inputs.names }} \
             < /dev/null

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -30,6 +30,7 @@ jobs:
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
+          BUNDLE_SYSTEM_BINDIR: ${{ github.workspace }}/bin
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -39,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release retry --yes --verbose \
+          ${{ github.workspace }}/bin/toys release retry --yes --verbose \
             ${{ github.event.inputs.flags }} \
             "${{ github.event.inputs.release_pr }}" \
             < /dev/null


### PR DESCRIPTION
The bundle cache feature in setup-ruby installs gems in a local vendor directory, and executables are not present in the PATH by default. Since we want the release-related gems to be specified by a Gemfile and installed by bundler (#1954), we need to instruct it to install the executables in a specific location, and then run the executables from that location.