### PR TITLE
chore(release): Use bundle exec to run the release scripts for now

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -15,13 +15,13 @@ jobs:
       issues: write # required to create issues for failed releases
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -30,6 +30,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release _onclosed --verbose \
+          bundle exec toys release _onclosed --verbose \
             "--event-path=${{ github.event_path }}" \
             < /dev/null

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -15,13 +15,13 @@ jobs:
       pull-requests: write # required for updating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -29,5 +29,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          toys release _onpush --verbose \
+          bundle exec toys release _onpush --verbose \
             < /dev/null

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -25,13 +25,13 @@ jobs:
       issues: write # required for creating new issues on failed releases
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release perform --yes --verbose \
+          bundle exec toys release perform --yes --verbose \
             "--release-ref=${{ github.sha }}" \
             ${{ github.event.inputs.flags }} \
             "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" \

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -14,14 +14,14 @@ jobs:
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -38,6 +38,6 @@ jobs:
           # Using the app token instead of GITHUB_TOKEN to trigger workflows
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          toys release request --yes --verbose \
+          bundle exec toys release request --yes --verbose \
             "--target-branch=${{ github.ref }}" \
             < /dev/null

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -18,14 +18,14 @@ jobs:
       pull-requests: write # required for creating release PRs
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          toys release request --yes --verbose \
+          bundle exec toys release request --yes --verbose \
             "--target-branch=${{ github.ref }}" \
             ${{ github.event.inputs.names }} \
             < /dev/null

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -22,14 +22,14 @@ jobs:
       issues: write # required for creating new issues on failed releases
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          toys release retry --yes --verbose \
+          bundle exec toys release retry --yes --verbose \
             ${{ github.event.inputs.flags }} \
             "${{ github.event.inputs.release_pr }}" \
             < /dev/null

--- a/.toys/release/Gemfile
+++ b/.toys/release/Gemfile
@@ -6,5 +6,6 @@
 
 source 'https://rubygems.org'
 
+gem 'base64', '= 0.3.0'
 gem 'toys', '= 0.19.1'
 gem 'toys-release', '= 0.5.1'


### PR DESCRIPTION
We previously (#1954) caused the release workflows to install toys via setup-ruby's bundle cache so that versions can be specified and managed via the Gemfile. However, the bundle cache installs gems in a local vendor directory, which causes two problems:

* The vendor directory is not present in the PATH by default, so bash cannot find the toys executable.
* Rubygems doesn't by itself know about the bundler-installed gems because they're not in its gem path.

For now we'll solve this by using `bundle exec` to run the release scripts. This is normally not recommended when running toys for reasons detailed in its users guide (and indeed this would break yardoc publishing, but luckily we're currently not using that feature for this repo). But we'll make do for now until we can find a better solution.