### PR TITLE
fix: skip instrumenting dalli 4.2.0

### DIFF
--- a/instrumentation/dalli/Appraisals
+++ b/instrumentation/dalli/Appraisals
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-%w[2.7.0 3.2.0].each do |version|
+%w[2.7.0 3.2.0 4.1.0].each do |version|
   appraise "dalli-#{version}" do
     gem 'dalli', "~> #{version}"
   end
 end
 
-appraise 'dalli-latest' do
-  gem 'dalli'
-end
+# Dalli 4.2.0+ has native OpenTelemetry support, so we no longer need
+# to test our instrumentation against it.
+# appraise 'dalli-latest' do
+#   gem 'dalli'
+# end

--- a/instrumentation/dalli/README.md
+++ b/instrumentation/dalli/README.md
@@ -2,6 +2,15 @@
 
 The OpenTelemetry Dalli gem is a community maintained instrumentation for the [Dalli][dalli-home] Memcache client.
 
+## Dalli 4.2.0+ Native Integration
+
+Dalli 4.2.0+ includes native OpenTelemetry instrumentation. For the best experience and continued support, we recommend:
+
+- **Dalli < 4.2.0**: Use `opentelemetry-instrumentation-dalli` gem
+- **Dalli ≥ 4.2.0**: Use Dalli's built-in OpenTelemetry support (remove `opentelemetry-instrumentation-dalli` gem)
+
+Community instrumentation is compatible with Dalli versions up to 4.1.x. Development of this gem is frozen for newer Dalli versions in favor of the native integration.
+
 ## How do I get started?
 
 Install the gem using:

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -30,12 +30,23 @@ module OpenTelemetry
         end
 
         def add_patches
+          if dalli_has_native_otel_support?
+            OpenTelemetry.logger.info("Dalli #{::Dalli::VERSION} has native OpenTelemetry support. Skipping community instrumentation") 
+
+            return
+          end
+
           if Gem::Version.new(::Dalli::VERSION) < Gem::Version.new('3.0.0')
             ::Dalli::Server.prepend(Patches::Server)
           else
             ::Dalli::Protocol::Binary.prepend(Patches::Server) if defined?(::Dalli::Protocol::Binary)
             ::Dalli::Protocol::Meta.prepend(Patches::Server) if defined?(::Dalli::Protocol::Meta)
           end
+        end
+
+        def dalli_has_native_otel_support?
+          # Dalli 4.2.0+ has native OpenTelemetry instrumentation
+          Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('4.2.0')
         end
       end
     end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -19,17 +19,6 @@ module OpenTelemetry
           defined?(::Dalli)
         end
 
-        compatible do
-          version = Gem::Version.new(::Dalli::VERSION)
-          
-          if version >= Gem::Version.new('4.2.0') # Dalli 4.2.0+ has native OpenTelemetry instrumentation
-            OpenTelemetry.logger.info("Dalli #{version} has native OpenTelemetry support. Skipping community instrumentation.")
-            return false
-          end
-
-          true
-        end
-
         option :peer_service, default: nil, validate: :string
         option :db_statement, default: :obfuscate, validate: %I[omit obfuscate include]
 

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
 
         def add_patches
           if dalli_has_native_otel_support?
-            OpenTelemetry.logger.info("Dalli #{::Dalli::VERSION} has native OpenTelemetry support. Skipping community instrumentation") 
+            OpenTelemetry.logger.info("Dalli #{::Dalli::VERSION} has native OpenTelemetry support. Skipping community instrumentation")
 
             return
           end

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
+  spec.add_dependency 'dalli', '< 4.2.0' # Dalli 4.2.0+ has native OpenTelemetry instrumentation
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.2'
 
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
   spec.add_dependency 'dalli', '< 4.2.0' # Dalli 4.2.0+ has native OpenTelemetry instrumentation
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.2'
 
-  spec.add_dependency 'dalli', '< 4.2.0' # Dalli 4.2.0+ has native OpenTelemetry instrumentation
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Dalli 4.2.0 [added](https://github.com/petergoldstein/dalli/pull/1061) Otel instrumentation 🎉

This PR disables our Dalli 4.2.0+ community instrumentation in favor of their native instrumentation to prevent double reporting.

I've [opened](https://github.com/petergoldstein/dalli/issues/1070) an issue with the Dalli team to add their instrumentation to the [Otel Registry](https://opentelemetry.io/ecosystem/registry/adding/), as well as noted differences in between the two instrumentations.