### PR TITLE
ci: Improve renovate setup

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,7 @@
     {
       "allowedVersions": "<={{add major 1}}",
       "matchCategories": ["docker"],
+      "schedule": ["before 8am on Monday"],
       "dependencyDashboardApproval": false
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "excludeManagers": ["regex"],
+      "matchPackageNames": ["!ruby"],
       "matchUpdateTypes": ["patch"],
       "schedule": ["before 8am every weekday"]
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "excludeManagers": ["regex"]
+      "excludeManagers": ["regex"],
       "matchUpdateTypes": ["patch"],
       "schedule": ["before 8am every weekday"]
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
+      "excludeManagers": ["regex"]
       "matchUpdateTypes": ["patch"],
       "schedule": ["before 8am every weekday"]
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,13 +8,19 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchPackageNames": ["!ruby"],
+      "matchDepNames": ["!ruby"],
       "matchUpdateTypes": ["patch"],
       "schedule": ["before 8am every weekday"]
     },
     {
       "groupName": "all digest versions",
+      "matchDepNames": ["!ruby"],
       "matchUpdateTypes": ["digest"],
+      "schedule": ["before 8am every weekday"]
+    },
+    {
+      "matchDepNames": ["ruby"],
+      "matchUpdateTypes": ["digest","patch"],
       "schedule": ["before 8am every weekday"]
     },
     {
@@ -23,17 +29,18 @@
     },
     {
       "matchUpdateTypes": ["major"],
-      "matchCategories": ["!ruby"],
+      "matchCategories": ["ci", "js"],
       "schedule": ["before 8am on Monday"]
     },
     {
       "matchUpdateTypes": ["major"],
-      "matchCategories": ["ruby"],
+      "matchCategories": ["ruby", "docker"],
       "dependencyDashboardApproval": true
     },
     {
-      "matchUpdateTypes": ["multipleMajor"],
-      "dependencyDashboardApproval": true
+      "allowedVersions": "<={{add major 1}}",
+      "matchCategories": ["docker"],
+      "dependencyDashboardApproval": false
     },
     {
       "matchFileNames": [".github/actions/test_gem/action.yml", ".github/workflows/installation-tests.yml", ".github/workflows/release-*.yml"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,7 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose",
-      "currentValueTemplate": "{{depVersion}}-alpine{{alpineVersion}}",
+      "currentValueTemplate": "{{depVersion}}",
       "extractVersionTemplate": "^(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)-alpine{{alpineVersion}}$"
     },
     {
@@ -67,7 +67,7 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose",
-      "currentValueTemplate": "{{depVersion}}-alpine{{alpineVersion}}",
+      "currentValueTemplate": "{{alpineVersion}}",
       "extractVersionTemplate": "^{{depVersion}}-alpine(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)$",
       "depNameTemplate": "{{packageName}}-alpine"
     }


### PR DESCRIPTION
This switches the currentvaluetemplate in renovate config to the other option I tested when implementing the custom manager. This switch will hopefully resolve the errors which are appearing in the renovate dashboard.

Also for maintainability ruby updates will now always be standalone updates which helps with the other issue.

Also tackled is how to get dashboard approvals to be required as expected which is all major ruby updates and docker when more than 1.