### PR TITLE
fix: Return the original logger value instead of broadcasts array

### DIFF
--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger.rb
@@ -45,8 +45,9 @@ module OpenTelemetry
           # Set @skip_otel_emit to `false` after the log is emitted.
           def emit_one_broadcast(*args)
             broadcasts[1..-1].each { |broadcasted_logger| broadcasted_logger.instance_variable_set(:@skip_otel_emit, true) }
-            yield
+            ret = yield
             broadcasts.each { |broadcasted_logger| broadcasted_logger.instance_variable_set(:@skip_otel_emit, false) }
+            ret
           end
         end
       end

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
@@ -25,10 +25,11 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
   describe '#add' do
     it 'emits the log to the broadcasted loggers' do
       body = 'Ground control to Major Tom'
-      broadcast.add(Logger::DEBUG, body)
+      return_value = broadcast.add(Logger::DEBUG, body)
 
       assert_includes(LOG_STREAM.string, body)
       assert_includes(BROADCASTED_STREAM.string, body)
+      assert_equal true, return_value
     end
 
     it 'emits only one OpenTelemetry log record' do
@@ -46,10 +47,11 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
   describe '#unknown' do
     it 'emits the log to the broadcasted loggers' do
       body = 'I know when to go out'
-      broadcast.unknown(body)
+      return_value = broadcast.unknown(body)
 
       assert_includes(LOG_STREAM.string, body)
       assert_includes(BROADCASTED_STREAM.string, body)
+      assert_equal true, return_value
     end
 
     it 'emits only one OpenTelemetry log record' do
@@ -69,10 +71,11 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
     describe "##{severity}" do
       it 'emits the log to the broadcasted loggers' do
         body = "Still don't know what I was waiting for...#{rand(7)}"
-        broadcast.send(severity.to_sym, body)
+        return_value = broadcast.send(severity.to_sym, body)
 
         assert_includes(LOG_STREAM.string, body)
         assert_includes(BROADCASTED_STREAM.string, body)
+        assert_equal true, return_value
       end
 
       it 'emits only one OpenTelemetry log record' do


### PR DESCRIPTION
I'm doing some experimentation in the Rails console on logging and noticed it's extremely noisy:
```
thatch(dev)(writable):001:0> Rails.logger.info { "foo" }
foo
=>
[#<ActiveSupport::Logger:0x0000000128d702e8
  @default_formatter=#<Logger::Formatter:0x0000000128db7030 @datetime_format=nil>,
  @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x0000000128db6cc0 @datetime_format=nil, @thread_key="activesupport_tagged_logging_tags:24576">,
  @level=0,
  @level_override={},
  @local_level_key=:logger_thread_safe_level_8064,
  @logdev=
   #<Logger::LogDevice:0x00000001268c85d0
    @binmode=false,
    @dev=#<File:/Users/bdewater/src/github.com/thatch-health/thatch/log/development.log>,
    @filename="/Users/bdewater/src/github.com/thatch-health/thatch/log/development.log",
    @mon_data=#<Monitor:0x0000000128db6fb8>,
    @mon_data_owner_object_id=8056,
    @reraise_write_errors=[],
    @shift_age=1,
    @shift_period_suffix="%Y%m%d",
    @shift_size=104857600,
    @skip_header=false>,
  @progname=nil,
  @skip_otel_emit=false>,
 #<ActiveSupport::Logger:0x000000012d653208
  @default_formatter=#<Logger::Formatter:0x0000000129a95680 @datetime_format=nil>,
  @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x0000000129a94c80 @datetime_format=nil>,
  @level=0,
  @level_override={},
  @local_level_key=:logger_thread_safe_level_23728,
  @logdev=
   #<Logger::LogDevice:0x000000012d2ddf38
    @binmode=false,
    @dev=#<IO:<STDERR>>,
    @filename=nil,
    @mon_data=#<Monitor:0x0000000129a95360>,
    @mon_data_owner_object_id=23720,
    @reraise_write_errors=[],
    @shift_age=nil,
    @shift_period_suffix=nil,
    @shift_size=nil,
    @skip_header=false>,
  @progname=nil,
  @skip_otel_emit=false>]
```

After this fix, it's the same as on a vanilla Rails app without OTel:
```
thatch(dev)(writable):001:0> Rails.logger.info { "foo" }
foo
=> true
```