### PR TITLE
chore: Partial lint of changelog

### DIFF
--- a/helpers/sql-obfuscation/CHANGELOG.md
+++ b/helpers/sql-obfuscation/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### v0.4.0 / 2025-10-08
 
-## Deprecation Notice
+#### Deprecation Notice
 
 * **DEPRECATED:** This gem, `opentelemetry-helpers-sql-obfuscation`, has been replaced by `opentelemetry-helpers-sql-processor`. This is the final release and serves as a transitional package.
 * **ACTION REQUIRED:** No action is needed unless you use this gem directly. If you use this gem directly, update your `Gemfile` to use `gem 'opentelemetry-helpers-sql-processor'` instead.

--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -56,7 +56,6 @@
 
 * BREAKING CHANGE: This requires upgrading both the SDK and Instrumentation gem in tandem
 
-
 ### v0.20.0 / 2022-05-02
 
 * ADDED: Validate Using Enums

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -48,7 +48,6 @@
 
 * BREAKING CHANGE: Move shared sql behavior to helper gems
 
-
 ### v0.7.1 / 2023-11-23
 
 * CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -57,7 +57,7 @@
 ### v0.25.0 / 2023-09-07
 
 * BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
-*
+
 ### v0.24.4 / 2023-08-07
 
 * FIXED: Allow traces inside jobs while avoiding Redis noise


### PR DESCRIPTION
This does a couple of nits/lint on the changelog.

Note whitespace has been linted with #2002