### PR TITLE
feat: instrument `PG::Connection`'s pipeline methods

### DIFF
--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -138,6 +138,24 @@ module OpenTelemetry
             end
           end
 
+          define_method :enter_pipeline_mode do |*args|
+            tracer.in_span('ENTER_PIPELINE_MODE', attributes: client_attributes, kind: :client) do
+              super(*args)
+            end
+          end
+
+          define_method :pipeline_sync do |*args|
+            tracer.in_span('PIPELINE_SYNC', attributes: client_attributes, kind: :client) do
+              super(*args)
+            end
+          end
+
+          define_method :exit_pipeline_mode do |*args|
+            tracer.in_span('EXIT_PIPELINE_MODE', attributes: client_attributes, kind: :client) do
+              super(*args)
+            end
+          end
+
           private
 
           def obfuscate_sql(sql)

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -273,6 +273,43 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
+    it 'after connection entered pipeline_mode' do
+      client.enter_pipeline_mode
+
+      _(last_span.name).must_equal 'ENTER_PIPELINE_MODE'
+      _(last_span.attributes['db.system']).must_equal 'postgresql'
+      _(last_span.attributes['db.name']).must_equal 'postgres'
+      _(last_span.attributes['net.peer.name']).must_equal host.to_s
+      _(last_span.attributes['net.peer.port']).must_equal port.to_i
+
+      client.exit_pipeline_mode
+    end
+
+    it 'after pipeline_sync message' do
+      client.enter_pipeline_mode
+      client.pipeline_sync
+
+      _(last_span.name).must_equal 'PIPELINE_SYNC'
+      _(last_span.attributes['db.system']).must_equal 'postgresql'
+      _(last_span.attributes['db.name']).must_equal 'postgres'
+      _(last_span.attributes['net.peer.name']).must_equal host.to_s
+      _(last_span.attributes['net.peer.port']).must_equal port.to_i
+
+      client.get_result
+      client.exit_pipeline_mode
+    end
+
+    it 'after connection exited pipeline_mode' do
+      client.enter_pipeline_mode
+      client.exit_pipeline_mode
+
+      _(last_span.name).must_equal 'EXIT_PIPELINE_MODE'
+      _(last_span.attributes['db.system']).must_equal 'postgresql'
+      _(last_span.attributes['db.name']).must_equal 'postgres'
+      _(last_span.attributes['net.peer.name']).must_equal host.to_s
+      _(last_span.attributes['net.peer.port']).must_equal port.to_i
+    end
+
     it 'ignores prepend comment to extract operation' do
       client.query('/* comment */ SELECT 1')
 


### PR DESCRIPTION
We use query pipelining in our application, and I expected the `pg` otel plugin to instrument some of the pipeline methods. 

This PR instruments the following methods on the `pg` gem's `PG::Connection` class:
  - `enter_pipeline_mode`
  - `pipeline_sync`
  - `exit_pipeline_mode`