### PR TITLE
feat: Instrument PG Connection `send_*` async methods

### DIFF
--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/constants.rb
@@ -75,6 +75,8 @@ module OpenTelemetry
           exec_params
           async_exec_params
           sync_exec_params
+          send_query
+          send_query_params
         ].freeze
 
         # The following methods all take a statement name as the first
@@ -84,6 +86,7 @@ module OpenTelemetry
           prepare
           async_prepare
           sync_prepare
+          send_prepare
         ].freeze
 
         # The following methods take a prepared statement name as their first
@@ -93,6 +96,7 @@ module OpenTelemetry
           exec_prepared
           async_exec_prepared
           sync_exec_prepared
+          send_query_prepared
         ].freeze
 
         CONNECTION_METHODS = %i[

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -200,7 +200,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[exec query sync_exec async_exec].each do |method|
+    %i[exec query sync_exec async_exec send_query].each do |method|
       it "after request (with method: #{method})" do
         client.send(method, 'SELECT 1')
 
@@ -214,7 +214,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[exec_params async_exec_params sync_exec_params].each do |method|
+    %i[exec_params async_exec_params sync_exec_params send_query_params].each do |method|
       it "after request (with method: #{method}) " do
         client.send(method, 'SELECT $1 AS a', [1])
 
@@ -228,7 +228,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[prepare async_prepare sync_prepare].each do |method|
+    %i[prepare async_prepare sync_prepare send_prepare].each do |method|
       it "after preparing a statement (with method: #{method})" do
         client.send(method, 'foo', 'SELECT $1 AS a')
 
@@ -243,7 +243,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
+    %i[exec_prepared async_exec_prepared sync_exec_prepared send_query_prepared].each do |method|
       it "after executing prepared statement (with method: #{method})" do
         client.prepare('foo', 'SELECT $1 AS a')
         client.send(method, 'foo', [1])

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/patches/connection_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/patches/connection_test.rb
@@ -73,5 +73,36 @@ describe OpenTelemetry::Instrumentation::PG::Patches do
         end
       end
     end
+
+    describe 'method send_query' do
+      it 'returns nil immediately and the result can be obtained from a #get_result call' do
+        assert_nil(client.send_query('SELECT 1'))
+        assert_equal(['1'], client.get_last_result.column_values(0))
+      end
+    end
+
+    describe 'method send_query_params' do
+      it 'returns nil immediately and the result can be obtained from a #get_result call' do
+        assert_nil(client.send_query_params('SELECT $1', [1]))
+        assert_equal(['1'], client.get_last_result.column_values(0))
+      end
+    end
+
+    describe 'method send_prepare' do
+      it 'returns nil immediately and the result can be obtained from a #get_result call' do
+        assert_nil(client.send_prepare('foo', 'SELECT $1'))
+        assert_equal(PG::Constants::PGRES_COMMAND_OK, client.get_last_result.result_status)
+      end
+    end
+
+    describe 'method send_query_prepared' do
+      it 'returns nil immediately and the result can be obtained from a #get_result call' do
+        client.send_prepare('bar', 'SELECT $1')
+        assert_equal(PG::Constants::PGRES_COMMAND_OK, client.get_last_result.result_status)
+
+        assert_nil(client.send_query_prepared('bar', [1]))
+        assert_equal(['1'], client.get_result.column_values(0))
+      end
+    end
   end unless ENV['OMIT_SERVICES']
 end


### PR DESCRIPTION
I use query pipelining in my application and I expected these method calls to show up in the traces.

This PR instruments the following PG::Connection asynchronous processing methods:
- `send_query`
- `send_query_params`
- `send_prepare`
- `send_query_prepared`

