### PR TITLE
chore: Trim whitespace from changelogs

### DIFF
--- a/helpers/mysql/CHANGELOG.md
+++ b/helpers/mysql/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.4.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.3.0 / 2025-09-30
@@ -13,7 +12,6 @@
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.2 / 2024-11-26

--- a/helpers/sql-obfuscation/CHANGELOG.md
+++ b/helpers/sql-obfuscation/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.4.0 / 2025-10-08
@@ -17,7 +16,6 @@
 ### v0.3.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-11-26

--- a/helpers/sql-processor/CHANGELOG.md
+++ b/helpers/sql-processor/CHANGELOG.md
@@ -15,7 +15,6 @@
 ### v0.2.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.1.0 / 2025-10-08

--- a/helpers/sql/CHANGELOG.md
+++ b/helpers/sql/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.2.0 / 2025-09-30

--- a/instrumentation/action_mailer/CHANGELOG.md
+++ b/instrumentation/action_mailer/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.6.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.5.0 / 2025-09-30
@@ -18,7 +17,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 

--- a/instrumentation/action_pack/CHANGELOG.md
+++ b/instrumentation/action_pack/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.15.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.14.1 / 2025-10-07
@@ -42,7 +41,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -57,7 +55,6 @@
 ### v0.8.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
 
 ### v0.7.1 / 2023-10-16
@@ -72,13 +69,11 @@
 ### v0.6.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.5.0 / 2023-02-01
 
 * BREAKING CHANGE: Drop Rails 5 Support
-
 * ADDED: Drop Rails 5 Support
 * FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
@@ -91,7 +86,6 @@
 ### v0.4.0 / 2022-12-06
 
 * BREAKING CHANGE: Remove enable_recognize_route and span_naming options
-
 * FIXED: Remove enable_recognize_route and span_naming options
 
 ### v0.3.2 / 2022-11-16

--- a/instrumentation/action_view/CHANGELOG.md
+++ b/instrumentation/action_view/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.11.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.0 / 2025-09-30
@@ -22,7 +21,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -45,7 +43,6 @@
 ### v0.7.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
 
 ### v0.6.1 / 2023-10-16
@@ -60,13 +57,11 @@
 ### v0.5.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.4.0 / 2023-02-01
 
 * BREAKING CHANGE: Drop Rails 5 Support
-
 * ADDED: Drop Rails 5 Support
 
 ### v0.3.1 / 2023-01-14

--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.10.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.9.2 / 2025-10-07
@@ -26,7 +25,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -65,11 +63,8 @@
 ### v0.7.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
-
 * BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Monkey Patches
-
 * CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
 
 ### v0.6.1 / 2023-10-16
@@ -92,13 +87,11 @@
 ### v0.5.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.4.0 / 2023-02-01
 
 * BREAKING CHANGE: Drop Rails 5 Support
-
 * ADDED: Drop Rails 5 Support
 
 ### v0.3.1 / 2023-01-14

--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -91,32 +91,32 @@
 
 ### v0.5.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.4.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support 
+* BREAKING CHANGE: Drop Rails 5 Support
 
-* ADDED: Drop Rails 5 Support 
+* ADDED: Drop Rails 5 Support
 
 ### v0.3.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.3.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.2.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
-* ADDED: Make the context available in ActiveJob notifications 
-* FIXED: Fix deserialization of jobs that are missing metadata 
-* FIXED: RubyGems Fallback 
+* ADDED: Validate Using Enums
+* ADDED: Make the context available in ActiveJob notifications
+* FIXED: Fix deserialization of jobs that are missing metadata
+* FIXED: RubyGems Fallback
 
 ### v0.1.5 / 2021-12-02
 

--- a/instrumentation/active_model_serializers/CHANGELOG.md
+++ b/instrumentation/active_model_serializers/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.0 / 2025-09-30
@@ -13,7 +12,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.1 / 2025-01-07
@@ -39,7 +37,6 @@
 ### v0.20.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
@@ -93,7 +90,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29

--- a/instrumentation/active_record/CHANGELOG.md
+++ b/instrumentation/active_record/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.11.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.1 / 2025-09-30
@@ -22,7 +21,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -54,7 +52,6 @@
 ### v0.7.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
 
 ### v0.6.3 / 2023-10-16
@@ -72,13 +69,11 @@
 ### v0.6.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.5.0 / 2023-02-01
 
 * BREAKING CHANGE: Drop Rails 5 Support
-
 * ADDED: Drop Rails 5 Support
 
 ### v0.4.1 / 2023-01-14

--- a/instrumentation/active_storage/CHANGELOG.md
+++ b/instrumentation/active_storage/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.3.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.2.0 / 2025-09-30

--- a/instrumentation/active_support/CHANGELOG.md
+++ b/instrumentation/active_support/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.10.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.9.1 / 2025-09-30
@@ -22,7 +21,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -33,7 +31,6 @@
 ### v0.6.0 / 2024-07-02
 
 * BREAKING CHANGE: Custom ActiveSupport Span Names
-
 * ADDED: Custom ActiveSupport Span Names
 
 ### v0.5.3 / 2024-06-20
@@ -51,7 +48,6 @@
 ### v0.5.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
 
 ### v0.4.4 / 2023-10-31
@@ -73,13 +69,11 @@ FIXED: Reduce Object allocation
 ### v0.4.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.3.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-
+* BREAKING CHANE: Drop Rails 5 Support
 * ADDED: Drop Rails 5 Support
 
 ### v0.2.2 / 2023-01-14

--- a/instrumentation/active_support/CHANGELOG.md
+++ b/instrumentation/active_support/CHANGELOG.md
@@ -73,7 +73,7 @@ FIXED: Reduce Object allocation
 
 ### v0.3.0 / 2023-02-01
 
-* BREAKING CHANE: Drop Rails 5 Support
+* BREAKING CHANGE: Drop Rails 5 Support
 * ADDED: Drop Rails 5 Support
 
 ### v0.2.2 / 2023-01-14

--- a/instrumentation/active_support/CHANGELOG.md
+++ b/instrumentation/active_support/CHANGELOG.md
@@ -68,33 +68,33 @@ FIXED: Reduce Object allocation
 
 ### v0.4.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.4.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.3.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support 
+* BREAKING CHANGE: Drop Rails 5 Support
 
-* ADDED: Drop Rails 5 Support 
+* ADDED: Drop Rails 5 Support
 
 ### v0.2.2 / 2023-01-14
 
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation 
+* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.2.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.2.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.1.2 / 2022-05-05
 

--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -26,7 +26,6 @@
 ### v0.88.0 / 2025-11-26
 
 * BREAKING CHANGE: Update Ethon span name when unknown method
-
 * ADDED: Update Ethon span name when unknown method
 
 ### v0.87.0 / 2025-11-05
@@ -40,7 +39,6 @@
 ### v0.86.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Version Support For Ruby 3.2 and Rails 7.1
-
 * ADDED: Min Version Support For Ruby 3.2 and Rails 7.1
 
 ### v0.85.0 / 2025-10-11
@@ -58,7 +56,6 @@
 ### v0.82.0 / 2025-09-18
 
 * BREAKING CHANGE: AWS Lambda: Check if span has the attributes method to avoid internal error
-
 * FIXED: AWS Lambda: Check if span has the attributes method to avoid internal error
 
 ### v0.81.0 / 2025-09-16
@@ -120,7 +117,6 @@ ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility fo
 ### v0.72.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.71.1 / 2025-01-14

--- a/instrumentation/anthropic/CHANGELOG.md
+++ b/instrumentation/anthropic/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.2.1 / 2025-09-30

--- a/instrumentation/aws_lambda/CHANGELOG.md
+++ b/instrumentation/aws_lambda/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.6.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.4.0 / 2025-09-18
 
 * BREAKING CHANGE: Check if span has the attributes method to avoid internal error
-
 * FIXED: Check if span has the attributes method to avoid internal error
 
 ### v0.3.0 / 2025-02-04
@@ -28,7 +26,6 @@
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-07-30

--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -3,13 +3,11 @@
 ### v0.11.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.10.0 / 2025-10-11
 
 * BREAKING CHANGE: Suppress internal spans by default
-
 * ADDED: Suppress internal spans by default
 
 ### v0.9.1 / 2025-09-30
@@ -31,7 +29,6 @@
 ### v0.8.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.7.0 / 2024-10-08
@@ -73,7 +70,6 @@
 ### v0.4.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.3.2 / 2023-01-14

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
+0
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
@@ -17,7 +17,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-07-02
@@ -47,7 +46,6 @@
 ### v0.20.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-0
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -42,23 +42,23 @@
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-05
 
@@ -74,11 +74,11 @@
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration 
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* FIXED: Add missing require to bunny instrumentation 
+* FIXED: Add missing require to bunny instrumentation
 
 ### v0.18.0 / 2021-05-21
 

--- a/instrumentation/concurrent_ruby/CHANGELOG.md
+++ b/instrumentation/concurrent_ruby/CHANGELOG.md
@@ -34,23 +34,23 @@
 
 ### v0.21.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.21.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.19.3 / 2022-05-05
 
@@ -66,11 +66,11 @@
 
 ### v0.19.0 / 2021-09-29
 
-* ADDED: Add support for `Concurrent::Promises::Future` 
+* ADDED: Add support for `Concurrent::Promises::Future`
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration 
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/concurrent_ruby/CHANGELOG.md
+++ b/instrumentation/concurrent_ruby/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-07-23
@@ -39,7 +37,6 @@
 ### v0.21.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
@@ -116,13 +113,11 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Move context/span methods to Trace module
-
 * FIXED: Move context/span methods to Trace module
 
 ### v0.7.0 / 2020-10-07

--- a/instrumentation/dalli/CHANGELOG.md
+++ b/instrumentation/dalli/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.29.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.28.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.26.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 * FIXED: Format gat commands
 
@@ -56,7 +54,6 @@
 ### v0.25.0 / 2023-10-16
 
 * BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
-
 * ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
 ### v0.24.2 / 2023-07-21
@@ -74,7 +71,6 @@
 ### v0.23.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.22.2 / 2023-01-14
@@ -155,7 +151,6 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27

--- a/instrumentation/dalli/CHANGELOG.md
+++ b/instrumentation/dalli/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ### v0.24.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.24.0 / 2023-05-15
 
@@ -73,32 +73,32 @@
 
 ### v0.23.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.22.2 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.22.1 / 2022-11-28
 
-* FIXED: `format_command`'s terrible performance 
+* FIXED: `format_command`'s terrible performance
 
 ### v0.22.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.21.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
+* ADDED: Validate Using Enums
 
 ### v0.20.0 / 2021-12-01
 
-* ADDED: Add dalli obfuscation for db_statement 
-* FIXED: Resolve Dalli::Server deprecation in 3.0+ 
+* ADDED: Add dalli obfuscation for db_statement
+* FIXED: Resolve Dalli::Server deprecation in 3.0+
 
 ### v0.19.1 / 2021-09-29
 
@@ -106,8 +106,8 @@
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Add configuration options for dalli 
-* DOCS: Update docs to rely more on environment variable configuration 
+* ADDED: Add configuration options for dalli
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -54,28 +54,28 @@
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Rails 7.0.3 test suite incompatibility 
-* FIXED: Broken test file requirements 
+* FIXED: Rails 7.0.3 test suite incompatibility
+* FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-02
 
-* FIXED: RubyGems Fallback 
+* FIXED: RubyGems Fallback
 
 ### v0.18.4 / 2021-12-02
 
@@ -87,7 +87,7 @@
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration 
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.25.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.24.1 / 2025-09-30
@@ -22,7 +21,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -45,7 +43,6 @@
 ### v0.22.0 / 2023-10-16
 
 * BREAKING CHANGE: Drop DelayedJob ActiveRecord in Tests
-
 * FIXED: Drop DelayedJob ActiveRecord in Tests
 
 ### v0.21.0 / 2023-09-07
@@ -59,7 +56,6 @@
 ### v0.20.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
@@ -114,7 +110,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29

--- a/instrumentation/ethon/CHANGELOG.md
+++ b/instrumentation/ethon/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.26.0 / 2025-11-26
 
 * BREAKING CHANGE: Update Ethon span name when unknown method
-
 * ADDED: Update Ethon span name when unknown method
 
 ### v0.25.1 / 2025-11-25
@@ -17,7 +16,6 @@
 ### v0.25.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.24.2 / 2025-10-14
@@ -43,7 +41,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.9 / 2024-11-26
@@ -85,7 +82,6 @@
 ### v0.21.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
@@ -121,7 +117,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
@@ -146,7 +141,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -168,14 +162,12 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Move context/span methods to Trace module
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Move context/span methods to Trace module
 * FIXED: Remove 'canonical' from status codes
 

--- a/instrumentation/excon/CHANGELOG.md
+++ b/instrumentation/excon/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.26.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.25.2 / 2025-10-11
@@ -33,7 +32,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.5 / 2024-11-26
@@ -60,7 +58,6 @@
 ### v0.22.0 / 2023-11-28
 
 * BREAKING CHANGE: Add a connect span to excon
-
 * ADDED: Add a connect span to excon
 
 ### v0.21.3 / 2023-11-23
@@ -78,7 +75,6 @@
 ### v0.21.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
@@ -114,7 +110,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
@@ -139,7 +134,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -161,14 +155,12 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Move context/span methods to Trace module
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Move context/span methods to Trace module
 * FIXED: Remove 'canonical' from status codes
 

--- a/instrumentation/faraday/CHANGELOG.md
+++ b/instrumentation/faraday/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.30.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.29.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.26.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.0 / 2025-01-07
@@ -95,7 +93,6 @@
 ### v0.23.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.22.0 / 2023-01-14
@@ -134,7 +131,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.1 / 2021-06-08
@@ -164,7 +160,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -186,7 +181,6 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27

--- a/instrumentation/grape/CHANGELOG.md
+++ b/instrumentation/grape/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### v0.1.3 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.1.2 / 2023-05-02
 

--- a/instrumentation/grape/CHANGELOG.md
+++ b/instrumentation/grape/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.4.0 / 2025-09-30
@@ -13,7 +12,6 @@
 ### v0.3.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.0 / 2024-07-02

--- a/instrumentation/graphql/CHANGELOG.md
+++ b/instrumentation/graphql/CHANGELOG.md
@@ -81,8 +81,8 @@
 
 ### v0.26.2 / 2023-06-05
 
-* FIXED: Base config options 
-* FIXED: GraphQL resolve_type_lazy 
+* FIXED: Base config options
+* FIXED: GraphQL resolve_type_lazy
 
 ### v0.26.1 / 2023-05-30
 
@@ -90,15 +90,15 @@
 
 ### v0.26.0 / 2023-05-17
 
-* BREAKING CHANGE: GraphQL instrumentation: support new tracing API 
+* BREAKING CHANGE: GraphQL instrumentation: support new tracing API
 
 * ADDED: GraphQL instrumentation: support new tracing API
 
 ### v0.25.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.0 / 2023-03-15
 
@@ -114,21 +114,21 @@
 
 ### v0.22.0 / 2023-01-27
 
-* ADDED: Normalize GraphQL span names for easier aggregation analysis 
+* ADDED: Normalize GraphQL span names for easier aggregation analysis
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-07-12
 
-* FIXED: Use semantic graphql attribute names 
+* FIXED: Use semantic graphql attribute names
 
 ### v0.20.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.19.3 / 2022-05-05
 
@@ -144,8 +144,8 @@
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Add support for graphql errors 
-* DOCS: Update docs to rely more on environment variable configuration 
+* ADDED: Add support for graphql errors
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/graphql/CHANGELOG.md
+++ b/instrumentation/graphql/CHANGELOG.md
@@ -12,7 +12,6 @@
 ### v0.31.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.30.1 / 2025-09-30
@@ -26,7 +25,6 @@
 ### v0.29.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.28.4 / 2024-07-30
@@ -48,7 +46,6 @@
 ### v0.28.0 / 2024-02-16
 
 * BREAKING CHANGE: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
-
 * ADDED: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
 
 ### v0.27.0 / 2023-11-28
@@ -91,25 +88,21 @@
 ### v0.26.0 / 2023-05-17
 
 * BREAKING CHANGE: GraphQL instrumentation: support new tracing API
-
 * ADDED: GraphQL instrumentation: support new tracing API
 
 ### v0.25.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.0 / 2023-03-15
 
 * BREAKING CHANGE: Add support for GraphQL 2.0.19
-
 * FIXED: Add support for GraphQL 2.0.19
 
 ### v0.23.0 / 2023-03-13
 
 * BREAKING CHANGE: Lock graphql max version to 2.0.17
-
 * FIXED: Lock graphql max version to 2.0.17
 
 ### v0.22.0 / 2023-01-27

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.4.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.3.1 / 2025-09-30

--- a/instrumentation/gruf/CHANGELOG.md
+++ b/instrumentation/gruf/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.3.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-04-30

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.27.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.26.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.24.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.23.5 / 2024-11-26
@@ -63,7 +61,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
@@ -104,7 +101,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21

--- a/instrumentation/http_client/CHANGELOG.md
+++ b/instrumentation/http_client/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.26.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
@@ -29,7 +28,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
@@ -67,7 +65,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
@@ -104,7 +101,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21

--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.3 / 2024-11-26

--- a/instrumentation/koala/CHANGELOG.md
+++ b/instrumentation/koala/CHANGELOG.md
@@ -42,23 +42,23 @@
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-05
 
@@ -74,7 +74,7 @@
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration 
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/koala/CHANGELOG.md
+++ b/instrumentation/koala/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.23.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.22.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.21.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.20.6 / 2025-01-07
@@ -47,7 +45,6 @@
 ### v0.20.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14

--- a/instrumentation/lmdb/CHANGELOG.md
+++ b/instrumentation/lmdb/CHANGELOG.md
@@ -30,27 +30,27 @@
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.20.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
+* ADDED: Validate Using Enums
 
 ### v0.19.2 / 2021-12-02
 
@@ -62,8 +62,8 @@
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Configure db.statement toggle 
-* DOCS: Update docs to rely more on environment variable configuration 
+* ADDED: Configure db.statement toggle
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/lmdb/CHANGELOG.md
+++ b/instrumentation/lmdb/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.25.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.24.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.3 / 2024-07-23
@@ -35,7 +33,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14

--- a/instrumentation/logger/CHANGELOG.md
+++ b/instrumentation/logger/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.2.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.1.0 / 2025-10-09

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.25.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.24.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.4 / 2024-07-23
@@ -39,7 +37,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
@@ -80,7 +77,6 @@
 ### v0.18.0 / 2021-05-21
 
 * BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
-
 * ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Replace `Time.now` with `Process.clock_gettime`
 * FIXED: Mongodb test asserting error message
@@ -103,7 +99,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -34,32 +34,32 @@
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-10-04
 
-* ADDED: Support mongodb db statement without obfuscation 
+* ADDED: Support mongodb db statement without obfuscation
 
 ### v0.20.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.19.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
-* FIXED: RubyGems Fallback 
+* ADDED: Validate Using Enums
+* FIXED: RubyGems Fallback
 
 ### v0.18.4 / 2021-12-02
 
@@ -71,7 +71,7 @@
 
 ### v0.18.2 / 2021-08-12
 
-* FIXED: Flakey mongo test 
+* FIXED: Flakey mongo test
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -15,7 +15,6 @@
 ### v0.31.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.30.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.29.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.28.0 / 2024-09-12

--- a/instrumentation/net_http/CHANGELOG.md
+++ b/instrumentation/net_http/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.26.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
@@ -33,7 +32,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
@@ -71,7 +69,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 * FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
@@ -115,7 +112,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
@@ -138,7 +134,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -164,7 +159,6 @@
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07

--- a/instrumentation/pg/CHANGELOG.md
+++ b/instrumentation/pg/CHANGELOG.md
@@ -19,7 +19,6 @@
 ### v0.32.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.31.1 / 2025-09-30
@@ -38,7 +37,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### v0.11.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.1 / 2025-09-30
@@ -26,7 +25,6 @@
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -70,7 +68,6 @@
 ### v0.6.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 * FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -65,20 +65,20 @@
 
 ### v0.6.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.6.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation 
+* ADDED: Drop support for EoL Ruby 2.7
+* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.5.1 / 2023-01-14
 
-* FIXED: Remove `job_options` when using `bulk_enqueue` 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* FIXED: Remove `job_options` when using `bulk_enqueue`
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.5.0 / 2022-10-28
 
@@ -87,16 +87,16 @@
 ### v0.4.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.3.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
-* FIXED: RubyGems Fallback 
+* ADDED: Validate Using Enums
+* FIXED: RubyGems Fallback
 
 ### v0.2.0 / 2021-12-01
 
-* ADDED: Instrument Que poller 
+* ADDED: Instrument Que poller
 
 ### v0.1.1 / 2021-09-29
 

--- a/instrumentation/racecar/CHANGELOG.md
+++ b/instrumentation/racecar/CHANGELOG.md
@@ -46,13 +46,13 @@
 
 ### v0.2.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.2.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.2 / 2023-03-24
 
@@ -60,7 +60,7 @@
 
 ### v0.1.1 / 2023-01-14
 
-* DOCS: More gem documentation fixes 
+* DOCS: More gem documentation fixes
 
 ### v0.1.0 / 2022-11-08
 

--- a/instrumentation/racecar/CHANGELOG.md
+++ b/instrumentation/racecar/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.6.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
@@ -21,7 +20,6 @@
 ### v0.4.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.3.4 / 2024-07-09
@@ -51,7 +49,6 @@
 ### v0.2.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.2 / 2023-03-24

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.29.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.28.2 / 2025-10-07
@@ -29,7 +28,6 @@
 ### v0.26.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.0 / 2024-10-23
@@ -63,7 +61,6 @@
 ### v0.24.0 / 2024-01-06
 
 * BREAKING CHANGE: Use Rack Events By Default
-
 * ADDED: Use Rack Events By Default
 * FIXED: Backport Rack proxy event to middleware
 
@@ -91,7 +88,6 @@
 
 * BREAKING CHANGE: Remove retain_middleware_names Rack Option
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Remove retain_middleware_names Rack Option
 * ADDED: Drop support for EoL Ruby 2.7
 * ADDED: Use Rack::Events for instrumentation
@@ -149,7 +145,6 @@ forwards the uri path.  More details on this is available in the readme.
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * ADDED: Add Tracer.non_recording_span to API
 * FIXED: Total order constraint on span.status=
 
@@ -165,7 +160,6 @@ forwards the uri path.  More details on this is available in the readme.
 ### v0.16.0 / 2021-03-17
 
 * BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility
-
 * ADDED: Pass env to url quantization rack config to allow more flexibility
 * ADDED: Add rack instrumentation config option to accept callable to filter requests to trace
 * FIXED: Example scripts now reference local common lib
@@ -178,7 +172,6 @@ forwards the uri path.  More details on this is available in the readme.
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 * ADDED: Add untraced endpoints config to rack middleware
 
@@ -205,7 +198,6 @@ forwards the uri path.  More details on this is available in the readme.
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Instrument rails
 * ADDED: Add timeout for force_flush and shutdown
 
@@ -213,7 +205,6 @@ forwards the uri path.  More details on this is available in the readme.
 
 * BREAKING CHANGE: Move context/span methods to Trace module
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Move context/span methods to Trace module
 * FIXED: Remove 'canonical' from status codes
 

--- a/instrumentation/rails/CHANGELOG.md
+++ b/instrumentation/rails/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.39.0 / 2025-10-21
 
 * BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-
 * ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.38.0 / 2025-09-30
@@ -31,7 +30,6 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 
 * BREAKING CHANGE: Drop Support for EoL Rails 6.1
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Drop Support for EoL Rails 6.1
 * ADDED: Set minimum supported version to Ruby 3.1
 
@@ -89,7 +87,6 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 ### v0.29.0 / 2023-11-22
 
 * BREAKING CHANGE: Drop Rails 6.0 EOL
-
 * ADDED: Drop Rails 6.0 EOL
 
 ### v0.28.1 / 2023-10-16
@@ -112,14 +109,12 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 ### v0.26.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.25.0 / 2023-02-08
 
 * BREAKING CHANGE: Update Instrumentations GraphQL, HttpClient, Rails [#303](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/303)
 * BREAKING CHANGE: Drop Rails 5 Support [#315](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/315)
-
 * DOCS: Rails Instrumentation Compatibility
 
 ### v0.24.1 / 2023-01-14
@@ -129,7 +124,6 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 ### v0.24.0 / 2022-12-06
 
 * BREAKING CHANGE: Remove enable_recognize_route and span_naming options
-
 * FIXED: Remove enable_recognize_route and span_naming options
 
 ### v0.23.1 / 2022-11-08
@@ -177,7 +171,6 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 * ADDED: Add ActionView instrumentation via ActiveSupport::Notifications
 * FIXED: Rails instrumentation to not explicitly install sub gems
 * DOCS: Update docs to rely more on environment variable configuration
-
 * This release adds support for Active Record and Action View.
 * The `enable_recognize_route` configuration option has been moved to the ActionPack gem.
 * See readme for details on how to configure the sub instrumentation gems.

--- a/instrumentation/rake/CHANGELOG.md
+++ b/instrumentation/rake/CHANGELOG.md
@@ -30,17 +30,17 @@
 
 ### v0.2.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.2.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.1 / 2023-01-14
 
-* DOCS: More gem documentation fixes 
+* DOCS: More gem documentation fixes
 
 ### v0.1.0 / 2022-10-14
 

--- a/instrumentation/rake/CHANGELOG.md
+++ b/instrumentation/rake/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
@@ -21,7 +20,6 @@
 ### v0.3.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.2 / 2024-04-30
@@ -35,7 +33,6 @@
 ### v0.2.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.1 / 2023-01-14

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.9.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.8.1 / 2025-09-30
@@ -25,7 +24,6 @@
 ### v0.5.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.4.9 / 2025-01-07
@@ -80,7 +78,6 @@
 ### v0.3.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.2.3 / 2023-03-24

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -75,13 +75,13 @@
 
 ### v0.3.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.3.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.2.3 / 2023-03-24
 
@@ -89,8 +89,8 @@
 
 ### v0.2.2 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.2.1 / 2022-11-14
 

--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.28.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-09-30
@@ -21,7 +20,6 @@
 ### v0.26.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.7 / 2024-07-23
@@ -55,7 +53,6 @@
 ### v0.25.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.1 / 2023-01-14
@@ -101,7 +98,6 @@
 ### v0.20.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.19.0 / 2021-05-28
@@ -160,14 +156,12 @@ test: split redis instrumentation test [#754](https://github.com/open-telemetry/
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Redis attribute propagation
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07

--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -50,41 +50,41 @@
 
 ### v0.25.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.25.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.24.0 / 2022-09-14
 
-* ADDED: Redis-rb 5.0 and redis-client support 
+* ADDED: Redis-rb 5.0 and redis-client support
 
 ### v0.23.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.22.1 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.22.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
-* FIXED: Add appraisals for redis 4.2-4.6 
+* ADDED: Validate Using Enums
+* FIXED: Add appraisals for redis 4.2-4.6
 
 ### v0.21.3 / 2022-02-02
 
-* FIXED: Prevent redis instrumentation from mutating the command 
+* FIXED: Prevent redis instrumentation from mutating the command
 
 ### v0.21.2 / 2021-12-01
 
@@ -96,13 +96,13 @@
 
 ### v0.21.0 / 2021-08-12
 
-* ADDED: Add toggle for redis db.statement attribute 
+* ADDED: Add toggle for redis db.statement attribute
 
 ### v0.20.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status= 
+* BREAKING CHANGE: Total order constraint on span.status=
 
-* FIXED: Total order constraint on span.status= 
+* FIXED: Total order constraint on span.status=
 
 ### v0.19.0 / 2021-05-28
 

--- a/instrumentation/resque/CHANGELOG.md
+++ b/instrumentation/resque/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.8.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.7.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.6.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.5.2 / 2024-04-30
@@ -43,7 +41,6 @@
 ### v0.4.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 * ADDED: Add :force_flush option to Resque instrumentation
 * FIXED: Fix flaky tests for resque.

--- a/instrumentation/resque/CHANGELOG.md
+++ b/instrumentation/resque/CHANGELOG.md
@@ -38,29 +38,29 @@
 
 ### v0.4.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.4.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
-* ADDED: Add :force_flush option to Resque instrumentation 
-* FIXED: Fix flaky tests for resque. 
+* ADDED: Drop support for EoL Ruby 2.7
+* ADDED: Add :force_flush option to Resque instrumentation
+* FIXED: Fix flaky tests for resque.
 
 ### v0.3.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.3.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.2.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
+* ADDED: Validate Using Enums
 
 ### v0.1.3 / 2021-12-02
 

--- a/instrumentation/restclient/CHANGELOG.md
+++ b/instrumentation/restclient/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.26.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
@@ -21,7 +20,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
@@ -59,7 +57,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
@@ -92,7 +89,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
@@ -118,7 +114,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -140,13 +135,11 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Move context/span methods to Trace module
-
 * FIXED: Move context/span methods to Trace module
 
 ### v0.7.0 / 2020-10-07

--- a/instrumentation/restclient/README.md
+++ b/instrumentation/restclient/README.md
@@ -3,7 +3,7 @@
 The OpenTelemetry RestClient gem is a community maintained instrumentation for the [RestClient][restclient-home] library.
 
 > [!IMPORTANT]
-> 
+>
 > **Deprecation Notice:**
 > This gem is deprecated due to the upstream dependency it relies on no longer being maintained. The code remains available for reference, but no further updates or fixes will be provided. Users should consider migrating to actively supported alternatives.
 

--- a/instrumentation/rspec/CHANGELOG.md
+++ b/instrumentation/rspec/CHANGELOG.md
@@ -35,25 +35,25 @@
 
 ### v0.3.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.3.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
-* DOCS: Fix typo in rspec example 
+* ADDED: Drop support for EoL Ruby 2.7
+* DOCS: Fix typo in rspec example
 
 ### v0.2.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.2.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Strip console codes from RSpec messages and better handle multiple failures 
-* FIXED: Broken test file requirements 
+* FIXED: Strip console codes from RSpec messages and better handle multiple failures
+* FIXED: Broken test file requirements
 
 ### v0.1.0 / 2021-12-01
 

--- a/instrumentation/rspec/CHANGELOG.md
+++ b/instrumentation/rspec/CHANGELOG.md
@@ -8,7 +8,6 @@
 ### v0.6.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
@@ -22,7 +21,6 @@
 ### v0.4.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.3.3 / 2024-04-30
@@ -40,7 +38,6 @@
 ### v0.3.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 * DOCS: Fix typo in rspec example
 

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.3 / 2024-07-23
@@ -47,7 +45,6 @@
 ### v0.20.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
@@ -104,7 +101,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -42,27 +42,27 @@
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
 * Upgrading Base dependency version
-* FIXED: Broken test file requirements 
+* FIXED: Broken test file requirements
 
 ### v0.18.6 / 2022-05-02
 
-* FIXED: RubyGems Fallback 
+* FIXED: RubyGems Fallback
 
 ### v0.18.5 / 2021-12-02
 
@@ -74,11 +74,11 @@
 
 ### v0.18.3 / 2021-09-29
 
-* FIXED: Use Kafka::VERSION fallback for compatibility 
+* FIXED: Use Kafka::VERSION fallback for compatibility
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration 
+* DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 

--- a/instrumentation/ruby_kafka/README.md
+++ b/instrumentation/ruby_kafka/README.md
@@ -3,7 +3,7 @@
 The RubyKafka instrumentation is a community-maintained instrumentation for [RubyKafka][ruby_kafka-home], a client library for Apache Kafka.
 
 > [!IMPORTANT]
-> 
+>
 > **Deprecation Notice:**
 > This gem is deprecated due to the upstream dependency it relies on no longer being maintained. The code remains available for reference, but no further updates or fixes will be provided. Users should consider migrating to actively supported alternatives.
 

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -74,24 +74,24 @@
 
 ### v0.24.1 / 2023-06-05
 
-* FIXED: Base config options 
+* FIXED: Base config options
 
 ### v0.24.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.23.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support 
+* BREAKING CHANGE: Drop Rails 5 Support
 
-* ADDED: Drop Rails 5 Support 
+* ADDED: Drop Rails 5 Support
 
 ### v0.22.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.22.0 / 2022-06-09
 
@@ -99,13 +99,13 @@
 
 ### v0.21.1 / 2022-06-09
 
-* FIXED: Broken test file requirements 
-* FIXED: Make sidekiq instrumentation compatible with sidekiq 6.5.0 
+* FIXED: Broken test file requirements
+* FIXED: Make sidekiq instrumentation compatible with sidekiq 6.5.0
 
 ### v0.21.0 / 2022-05-02
 
-* ADDED: Validate Using Enums 
-* FIXED: RubyGems Fallback 
+* ADDED: Validate Using Enums
+* FIXED: RubyGems Fallback
 
 ### v0.20.2 / 2021-12-02
 
@@ -117,7 +117,7 @@
 
 ### v0.20.0 / 2021-08-18
 
-* ADDED: Gracefully flush provider on sidekiq shutdown event 
+* ADDED: Gracefully flush provider on sidekiq shutdown event
 
 ### v0.19.1 / 2021-08-12
 
@@ -125,13 +125,13 @@
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Sidekiq propagation config 
+* BREAKING CHANGE: Sidekiq propagation config
   - Config option enable_job_class_span_names renamed to span_naming and now expects a symbol of value :job_class, or :queue
   - The default behavior is no longer to have one continuous trace for the enqueue and process spans, using links is the new default.  To maintain the previous behavior the config option propagation_style must be set to :child.
-* BREAKING CHANGE: Total order constraint on span.status= 
+* BREAKING CHANGE: Total order constraint on span.status=
 
-* FIXED: Sidekiq propagation config 
-* FIXED: Total order constraint on span.status= 
+* FIXED: Sidekiq propagation config
+* FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### v0.28.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-09-30
@@ -25,7 +24,6 @@
 ### v0.26.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.7 / 2024-07-23
@@ -79,13 +77,11 @@
 ### v0.24.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.23.0 / 2023-02-01
 
 * BREAKING CHANGE: Drop Rails 5 Support
-
 * ADDED: Drop Rails 5 Support
 
 ### v0.22.1 / 2023-01-14
@@ -129,7 +125,6 @@
   - Config option enable_job_class_span_names renamed to span_naming and now expects a symbol of value :job_class, or :queue
   - The default behavior is no longer to have one continuous trace for the enqueue and process spans, using links is the new default.  To maintain the previous behavior the config option propagation_style must be set to :child.
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Sidekiq propagation config
 * FIXED: Total order constraint on span.status=
 
@@ -138,7 +133,6 @@
 * ADDED: Updated API dependency for 1.0.0.rc1
 * TEST: update test for redis instrumentation refactor [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
 * BREAKING CHANGE: Remove optional parent_context from in_span
-
 * FIXED: Remove optional parent_context from in_span
 * FIXED: Instrument Redis more thoroughly by patching Client#process.
 
@@ -158,7 +152,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -182,7 +175,6 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27

--- a/instrumentation/sinatra/CHANGELOG.md
+++ b/instrumentation/sinatra/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.28.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-10-07
@@ -21,7 +20,6 @@
 ### v0.25.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.24.1 / 2024-07-23
@@ -60,7 +58,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.5 / 2023-02-13
@@ -113,14 +110,12 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Total order constraint on span.status=
-
 * FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
 * ADDED: Updated API dependency for 1.0.0.rc1
 * BREAKING CHANGE: Remove optional parent_context from in_span
-
 * FIXED: Remove optional parent_context from in_span
 * FIXED: Removed http.status_text attribute #750
 
@@ -140,7 +135,6 @@
 ### v0.14.0 / 2021-02-03
 
 * BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-
 * ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
@@ -162,13 +156,11 @@
 ### v0.9.0 / 2020-11-27
 
 * BREAKING CHANGE: Add timeout for force_flush and shutdown
-
 * ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
 * BREAKING CHANGE: Remove 'canonical' from status codes
-
 * FIXED: Remove 'canonical' from status codes
 
 ### v0.7.1 / 2020-10-08

--- a/instrumentation/trilogy/CHANGELOG.md
+++ b/instrumentation/trilogy/CHANGELOG.md
@@ -15,7 +15,6 @@
 ### v0.64.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.63.1 / 2025-09-30
@@ -37,7 +36,6 @@
 ### v0.61.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.60.0 / 2024-09-12

--- a/processor/baggage/CHANGELOG.md
+++ b/processor/baggage/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
@@ -14,7 +13,6 @@
 ### v0.3.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-11-26
@@ -24,7 +22,6 @@
 ### v0.2.0 / 2024-06-18
 
 * BREAKING CHANGE: Add baggage key predicate func to baggage span processor
-
 * ADDED: Add baggage key predicate func to baggage span processor
 
 ### v0.1.0 / 2024-04-18

--- a/propagator/google_cloud_trace_context/CHANGELOG.md
+++ b/propagator/google_cloud_trace_context/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.2.0 / 2025-09-30

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.24.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.23.0 / 2025-09-30
@@ -13,7 +12,6 @@
 ### v0.22.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-11-26
@@ -35,7 +33,6 @@
 ### v0.21.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 * DOCS: Update URLs to rubydocs
 
@@ -63,7 +60,6 @@
 ### v0.19.0 / 2021-06-23
 
 * BREAKING CHANGE: Refactor Baggage to remove Noop*
-
 * ADDED: Add Tracer.non_recording_span to API
 * FIXED: Support Case Insensitive Trace and Span IDs
 * FIXED: Refactor Baggage to remove Noop*

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -36,13 +36,13 @@
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
-* DOCS: Update URLs to rubydocs 
+* ADDED: Drop support for EoL Ruby 2.7
+* DOCS: Update URLs to rubydocs
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
@@ -50,7 +50,7 @@
 
 ### v0.19.3 / 2021-10-29
 
-* FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags 
+* FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags
 
 ### v0.19.2 / 2021-09-29
 
@@ -62,11 +62,11 @@
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Refactor Baggage to remove Noop* 
+* BREAKING CHANGE: Refactor Baggage to remove Noop*
 
-* ADDED: Add Tracer.non_recording_span to API 
-* FIXED: Support Case Insensitive Trace and Span IDs 
-* FIXED: Refactor Baggage to remove Noop* 
+* ADDED: Add Tracer.non_recording_span to API
+* FIXED: Support Case Insensitive Trace and Span IDs
+* FIXED: Refactor Baggage to remove Noop*
 
 ### v0.18.0 / 2021-05-21
 

--- a/propagator/vitess/CHANGELOG.md
+++ b/propagator/vitess/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.4.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.3.0 / 2025-09-30
@@ -13,7 +12,6 @@
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26

--- a/propagator/xray/CHANGELOG.md
+++ b/propagator/xray/CHANGELOG.md
@@ -34,14 +34,14 @@
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7 
+* BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7 
+* ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage 
-* DOCS: More gem documentation fixes 
+* DOCS: Fix gem homepage
+* DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-06-09
 
@@ -53,12 +53,12 @@
 
 ### v0.20.0 / 2021-08-12
 
-* ADDED: Xray compliant ids 
+* ADDED: Xray compliant ids
 
 ### v0.19.0 / 2021-06-23
 
 * FIXED: XRay propagator null exception (#833)
-* ADDED: Add Tracer.non_recording_span to API 
+* ADDED: Add Tracer.non_recording_span to API
 
 ### v0.18.0 / 2021-05-21
 

--- a/propagator/xray/CHANGELOG.md
+++ b/propagator/xray/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.26.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 
 ### v0.25.0 / 2025-09-30
@@ -17,7 +16,6 @@
 ### v0.23.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.3 / 2024-11-26
@@ -35,7 +33,6 @@
 ### v0.22.0 / 2023-04-17
 
 * BREAKING CHANGE: Drop support for EoL Ruby 2.7
-
 * ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14

--- a/resources/aws/CHANGELOG.md
+++ b/resources/aws/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.5.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 

--- a/resources/azure/CHANGELOG.md
+++ b/resources/azure/CHANGELOG.md
@@ -3,14 +3,12 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26

--- a/resources/container/CHANGELOG.md
+++ b/resources/container/CHANGELOG.md
@@ -3,14 +3,12 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.2 / 2024-11-26

--- a/resources/google_cloud_platform/CHANGELOG.md
+++ b/resources/google_cloud_platform/CHANGELOG.md
@@ -3,14 +3,12 @@
 ### v0.3.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
 * BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-
 * ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26

--- a/sampler/xray/CHANGELOG.md
+++ b/sampler/xray/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### v0.2.0 / 2025-10-22
 
 * BREAKING CHANGE: Min Ruby Version 3.2
-
 * ADDED: Min Ruby Version 3.2
 * ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 


### PR DESCRIPTION
This remedies the whitespace issue with toys-release which has since been resolved with #1997

This also removes empty lines from lists