### PR TITLE
chore: Run latest linter

### DIFF
--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -386,7 +386,8 @@ describe OpenTelemetry::Instrumentation::Base do
 
   describe 'minimal_instrumentation' do
     before do
-      MinimalBase = Class.new(OpenTelemetry::Instrumentation::Base)
+      class MinimalBase < OpenTelemetry::Instrumentation::Base
+      end
     end
 
     after do

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
@@ -435,7 +435,9 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::EventHandler' 
 
     describe 'response propagators that raise errors' do
       class EventMockPropagator < OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator
-        CustomError = Class.new(StandardError)
+        class CustomError < StandardError
+        end
+
         def inject(carrier)
           raise CustomError, 'Injection failed'
         end
@@ -453,7 +455,8 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::EventHandler' 
   end
 
   describe '#call with error' do
-    EventHandlerError = Class.new(StandardError)
+    class EventHandlerError < StandardError
+    end
 
     let(:service) do
       ->(_env) { raise EventHandlerError }

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/tracer_middleware_test.rb
@@ -401,7 +401,8 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::TracerMiddlewar
   end
 
   describe '#call with error' do
-    SimulatedError = Class.new(StandardError)
+    class SimulatedError < StandardError
+    end
 
     let(:app) do
       ->(_env) { raise SimulatedError }

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
@@ -409,7 +409,9 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler' 
 
     describe 'response propagators that raise errors' do
       class EventMockPropagator < OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator
-        CustomError = Class.new(StandardError)
+        class CustomError < StandardError
+        end
+
         def inject(carrier)
           raise CustomError, 'Injection failed'
         end
@@ -427,7 +429,8 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler' 
   end
 
   describe '#call with error' do
-    EventHandlerError = Class.new(StandardError)
+    class EventHandlerError < StandardError
+    end
 
     let(:service) do
       ->(_env) { raise EventHandlerError }

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/tracer_middleware_test.rb
@@ -371,7 +371,8 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Old::TracerMiddlewar
   end
 
   describe '#call with error' do
-    SimulatedError = Class.new(StandardError)
+    class SimulatedError < StandardError
+    end
 
     let(:app) do
       ->(_env) { raise SimulatedError }

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
@@ -412,7 +412,9 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandle
 
     describe 'response propagators that raise errors' do
       class EventMockPropagator < OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator
-        CustomError = Class.new(StandardError)
+        class CustomError < StandardError
+        end
+
         def inject(carrier)
           raise CustomError, 'Injection failed'
         end
@@ -430,7 +432,8 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandle
   end
 
   describe '#call with error' do
-    EventHandlerError = Class.new(StandardError)
+    class EventHandlerError < StandardError
+    end
 
     let(:service) do
       ->(_env) { raise EventHandlerError }

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/tracer_middleware_test.rb
@@ -374,7 +374,8 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::TracerMiddle
   end
 
   describe '#call with error' do
-    SimulatedError = Class.new(StandardError)
+    class SimulatedError < StandardError
+    end
 
     let(:app) do
       ->(_env) { raise SimulatedError }


### PR DESCRIPTION
Unblocks #1993

I manually updated rubocop in my local environment and ran the fix command on the project. What is commited is the changes made via rubocop auto correction.