### PR TITLE
chore: docker version maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,7 +68,7 @@
       versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
       extractVersionTemplate: "^(?<version>[0-9.]+)-alpine{{alpineVersion}}$",
-      autoReplaceStringTemplate: "FROM {{packageName}}:{{newVersion}}-alpine{{alpineVersion}}@{{newDigest}}"
+      autoReplaceStringTemplate: "FROM {{packageName}}:{{newVersion}}-alpine{{alpineVersion}}@{{newDigest}}",
     },
     {
       customType: "regex",
@@ -86,7 +86,7 @@
       currentValueTemplate: "{{alpineVersion}}",
       extractVersionTemplate: "^{{depVersion}}-alpine(?<version>[0-9.]+)$",
       depNameTemplate: "{{packageName}}-alpine",
-      autoReplaceStringTemplate: "FROM {{packageName}}:{{depVersion}}-alpine{{newVersion}}@{{newDigest}}"
+      autoReplaceStringTemplate: "FROM {{packageName}}:{{depVersion}}-alpine{{newVersion}}@{{newDigest}}",
     },
     {
       customType: "regex",
@@ -101,7 +101,7 @@
       datasourceTemplate: "docker",
       versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
-      autoReplaceStringTemplate: "entrypoint sh {{packageName}}:{{newVersion}}@{{newDigest}} -c"
+      autoReplaceStringTemplate: "entrypoint sh {{packageName}}:{{newVersion}}@{{newDigest}} -c",
     },
   ],
   lockFileMaintenance: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,12 +61,14 @@
         "/(^|/)Dockerfile\\.[^/]*$/",
       ],
       matchStrings: [
-        "FROM\\s+(?<packageName>.+?):(?<depVersion>[^\\s@]+?)-alpine(?<alpineVersion>\\d+(?:\\.\\d+)?(?:\\.\\d+)?(?:-\\w+)?)(?:(@(?<currentDigest>[sha256:]?\\s+)))?.*\\s",
+        "FROM\\s+(?<packageName>.+):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{40,64})\\s",
+        "FROM\\s+(?<packageName>.+):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)\\s",
       ],
       datasourceTemplate: "docker",
-      versioningTemplate: "loose",
+      versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
-      extractVersionTemplate: "^(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)-alpine{{alpineVersion}}$",
+      extractVersionTemplate: "^(?<version>[0-9.]+)-alpine{{alpineVersion}}$",
+      autoReplaceStringTemplate: "FROM {{packageName}}:{{newVersion}}-alpine{{alpineVersion}}@{{newDigest}}"
     },
     {
       customType: "regex",
@@ -76,13 +78,30 @@
         "/(^|/)Dockerfile\\.[^/]*$/",
       ],
       matchStrings: [
-        "FROM\\s+(?<packageName>.+?):(?<depVersion>[^\\s@]+?)-alpine(?<alpineVersion>\\d+(?:\\.\\d+)?(?:\\.\\d+)?(?:-\\w+)?)(?:(@(?<currentDigest>[sha256:]?\\s+)))?.*\\s",
+        "FROM\\s+(?<packageName>.+):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{40,64})\\s",
+        "FROM\\s+(?<packageName>.+):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)\\s",
       ],
       datasourceTemplate: "docker",
-      versioningTemplate: "loose",
+      versioningTemplate: "docker",
       currentValueTemplate: "{{alpineVersion}}",
-      extractVersionTemplate: "^{{depVersion}}-alpine(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)$",
+      extractVersionTemplate: "^{{depVersion}}-alpine(?<version>[0-9.]+)$",
       depNameTemplate: "{{packageName}}-alpine",
+      autoReplaceStringTemplate: "FROM {{packageName}}:{{depVersion}}-alpine{{newVersion}}@{{newDigest}}"
+    },
+    {
+      customType: "regex",
+      description: "Update entrypoint docker versions in services",
+      managerFilePatterns: [
+        ".github/workflows/ci-instrumentation-with-services.yml",
+      ],
+      matchStrings: [
+        "entrypoint sh (?<packageName>.+?):(?<depVersion>[0-9.]+?)@(?<currentDigest>sha256:[a-f0-9]{40,64})\\s-c",
+        "entrypoint sh (?<packageName>.+?):(?<depVersion>[0-9.]+?)\\s-c",
+      ],
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker",
+      currentValueTemplate: "{{depVersion}}",
+      autoReplaceStringTemplate: "entrypoint sh {{packageName}}:{{newVersion}}@{{newDigest}} -c"
     },
   ],
   lockFileMaintenance: {

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -239,14 +239,16 @@ jobs:
           build: true
     services:
       redis:
-        image: redis:8.2.5@sha256:615e9c2c0b63102224f5a2d90cea0ece47b413c93e0faaf87d8d413e41a8c7c2
+        image: redis:8.2.5@sha256:d15219c8d079378028a0e6a4c37cdd1edb4526acecf24f3c12e5b6122e786f60
         ports:
           - 6379:6379
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "redis-cli -a \"$REDIS_PASSWORD\" ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          -e REDIS_PASSWORD=passw0rd
+          --entrypoint sh redis:8.2.5@sha256:d15219c8d079378028a0e6a4c37cdd1edb4526acecf24f3c12e5b6122e786f60 -c "exec redis-server --requirepass \"$REDIS_PASSWORD\""
         env:
           REDIS_PASSWORD: "passw0rd"
 

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -91,7 +91,7 @@ jobs:
         ports:
           - 11211:11211
       mongodb:
-        image: mongo:5.0@sha256:5e3e87afd24d75e722884d777c5713d254f7e88ba65381b5d6484f75a21b73e3
+        image: mongo:5.0.32@sha256:5e3e87afd24d75e722884d777c5713d254f7e88ba65381b5d6484f75a21b73e3
         ports:
           - 27017:27017
 
@@ -239,7 +239,7 @@ jobs:
           build: true
     services:
       redis:
-        image: bitnamilegacy/redis:8.2@sha256:25bf63f3caf75af4628c0dfcf39859ad1ac8abe135be85e99699f9637b16dc28
+        image: redis:8.2.5@sha256:615e9c2c0b63102224f5a2d90cea0ece47b413c93e0faaf87d8d413e41a8c7c2
         ports:
           - 6379:6379
         options: >-
@@ -290,7 +290,7 @@ jobs:
           build: true
     services:
       postgres:
-        image: postgres:13@sha256:4689940c683801b4ab839ab3b0a0a3555a5fe425371422310944e89eca7d8068
+        image: postgres:13.23@sha256:4689940c683801b4ab839ab3b0a0a3555a5fe425371422310944e89eca7d8068
         env:
           POSTGRES_PASSWORD: postgres
         ports:
@@ -338,6 +338,6 @@ jobs:
           build: true
     services:
       rabbitmq:
-        image: rabbitmq:3.13-alpine@sha256:d7af1c87c5f1eda13fcfca06db452bf3aeab6619fc3358b68535c0c02c4e52bc
+        image: rabbitmq:3.13.7-alpine@sha256:d7af1c87c5f1eda13fcfca06db452bf3aeab6619fc3358b68535c0c02c4e52bc
         ports:
           - "5672:5672"

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -136,7 +136,7 @@ jobs:
     services:
       mysql:
         image: mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
 
   instrumentation_kafka:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -135,8 +135,8 @@ jobs:
           build: true
     services:
       mysql:
-        image: mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
+        image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
   instrumentation_kafka:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -136,7 +136,7 @@ jobs:
     services:
       mysql:
         image: mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.0.31 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3 -e MYSQL_DATABASE=mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_PASSWORD=mysql -e MYSQL_USER=mysql -p 3306:3306 --entrypoint sh mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
   instrumentation_kafka:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
       - postgres_socket:/var/run/postgresql
 
   redis:
-    image: redis:8.2.5@sha256:ab119e78560f3817a26ce21325d1b14b8a3278237fcbc1afaa2013dfa0420000
+    image: redis:8.2.5@sha256:d15219c8d079378028a0e6a4c37cdd1edb4526acecf24f3c12e5b6122e786f60
     command: ["redis-server", "--requirepass", "passw0rd"]
     volumes:
       - redis_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
 
   mysql:
     image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614
-    command: mysqld --mysql-native-password=ON
+    command: mysqld --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_DATABASE=mysql
       - MYSQL_ROOT_PASSWORD=root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
       - zookeeper
 
   jaeger:
-    image: jaegertracing/all-in-one:1.7.6@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.15.1@sha256:a7dd965687d45507072676db81e6903706ba334dfc92f0c248125cfd9a70c483
     ports:
       - "16686:16686"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,8 +203,7 @@ services:
 
   redis:
     image: redis:8.2.5@sha256:ab119e78560f3817a26ce21325d1b14b8a3278237fcbc1afaa2013dfa0420000
-    environment:
-      - REDIS_PASSWORD=passw0rd
+    command: ["redis-server", "--requirepass", "passw0rd"]
     volumes:
       - redis_data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - "27017:27017"
 
   mysql:
-    image: mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb
+    image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614
     command: mysqld --mysql-native-password=ON
     environment:
       - MYSQL_DATABASE=mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
 
   mysql:
     image: mysql:8.4.8@sha256:a2d126916bc2ba79a890a4bf62d305eb8b68fcbdd35c6e582d529df18faf5ebb
-    command: mysqld --default-authentication-plugin=mysql_native_password
+    command: mysqld --mysql-native-password=ON
     environment:
       - MYSQL_DATABASE=mysql
       - MYSQL_ROOT_PASSWORD=root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       bash -c "bundle install && rake"
 
   mongo:
-    image: mongo:5.0@sha256:5e3e87afd24d75e722884d777c5713d254f7e88ba65381b5d6484f75a21b73e3
+    image: mongo:5.0.32@sha256:5e3e87afd24d75e722884d777c5713d254f7e88ba65381b5d6484f75a21b73e3
     expose:
       - "27017"
     ports:
@@ -191,7 +191,7 @@ services:
       - "3306:3306"
 
   postgres:
-    image: postgres:13@sha256:4689940c683801b4ab839ab3b0a0a3555a5fe425371422310944e89eca7d8068
+    image: postgres:13.23@sha256:4689940c683801b4ab839ab3b0a0a3555a5fe425371422310944e89eca7d8068
     environment:
       - POSTGRES_PASSWORD=postgres
     expose:
@@ -202,7 +202,7 @@ services:
       - postgres_socket:/var/run/postgresql
 
   redis:
-    image: bitnamilegacy/redis:8.2@sha256:25bf63f3caf75af4628c0dfcf39859ad1ac8abe135be85e99699f9637b16dc28
+    image: redis:8.2.5@sha256:ab119e78560f3817a26ce21325d1b14b8a3278237fcbc1afaa2013dfa0420000
     environment:
       - REDIS_PASSWORD=passw0rd
     volumes:
@@ -211,7 +211,7 @@ services:
       - "16379:6379"
 
   rabbitmq:
-    image: rabbitmq:3.13-alpine@sha256:d7af1c87c5f1eda13fcfca06db452bf3aeab6619fc3358b68535c0c02c4e52bc
+    image: rabbitmq:3.13.7-alpine@sha256:d7af1c87c5f1eda13fcfca06db452bf3aeab6619fc3358b68535c0c02c4e52bc
     ports:
       - "5672:5672"
 
@@ -245,7 +245,7 @@ services:
       - zookeeper
 
   jaeger:
-    image: jaegertracing/all-in-one@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/all-in-one:1.7.6@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
     ports:
       - "16686:16686"
 

--- a/instrumentation/ruby_kafka/example/docker-compose.yml
+++ b/instrumentation/ruby_kafka/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   app:
-    image: ruby:3.4-slim@sha256:dcc535e858eeeac1f70eaf8c39ef7ee257b183a9e495cc5a9ef3e340eadf2d3d
+    image: ruby:3.4.8-slim@sha256:dcc535e858eeeac1f70eaf8c39ef7ee257b183a9e495cc5a9ef3e340eadf2d3d
     volumes:
       - ../.:/app
     working_dir: /app/example
@@ -29,7 +29,7 @@ services:
     depends_on:
       - zookeeper
   jaeger:
-    image: jaegertracing/all-in-one@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.15.1@sha256:a7dd965687d45507072676db81e6903706ba334dfc92f0c248125cfd9a70c483
     ports:
       - "16686:16686"
       - "4318:4318"


### PR DESCRIPTION
This increases the verbosity of docker tags used where possible to improve readability.

While at it redis has been switched to the official image. Note the currently used image is affected by https://community.broadcom.com/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

And Jaeger has also been updated to v2.

One thing observed is that the entry point versions were not being maintained hence they have now been added to renovate. This sync has meant that mysql now appears to be using an explicitly older version however this is the version that was actually being used due to being specified as the entrypoint.

Changes to renovate enables us to ensure that the version within the entrypoint matches the image.