### PR TITLE
chore: Improve renovate rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,17 +21,13 @@
     {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
-      matchFileNames: [
-        "!.github/workflows/ci-markdown-checks.yml",
-      ],
+      matchFileNames: ["!.github/workflows/ci-markdown-checks.yml"],
       schedule: ["before 8am every weekday"],
     },
     {
       groupName: "Min-Ruby-sdk",
       matchDepNames: ["ruby"],
-      matchFileNames: [
-        ".github/workflows/ci-markdown-checks.yml",
-      ],
+      matchFileNames: [".github/workflows/ci-markdown-checks.yml"],
       dependencyDashboardApproval: true,
       separateMultipleMinor: true,
       separateMinorPatch: true,
@@ -39,9 +35,7 @@
     {
       matchUpdateTypes: ["minor"],
       matchDepNames: ["!ruby"],
-      matchFileNames: [
-        "!.github/workflows/ci-markdown-checks.yml",
-      ],
+      matchFileNames: ["!.github/workflows/ci-markdown-checks.yml"],
       schedule: ["before 8am on Monday"],
     },
     {
@@ -55,10 +49,7 @@
       dependencyDashboardApproval: true,
     },
     {
-      matchDepNames: [
-        "setup-node",
-        "setup-ruby",
-      ],
+      matchDepNames: ["setup-node", "setup-ruby"],
       schedule: ["before 7am every weekday"],
       prConcurrentLimit: 0,
       automerge: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,21 +21,53 @@
     {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
+      matchFileNames: [
+        "!.github/workflows/ci-markdown-checks.yml",
+      ],
       schedule: ["before 8am every weekday"],
     },
     {
-      matchUpdateTypes: ["minor"],
-      schedule: ["before 8am on Monday"],
-    },
-    {
-      matchUpdateTypes: ["major"],
-      matchCategories: ["ci", "js", "docker"],
-      schedule: ["before 8am on Monday"],
-    },
-    {
-      matchUpdateTypes: ["major"],
-      matchCategories: ["ruby"],
+      groupName: "Min-Ruby-sdk",
+      matchDepNames: ["ruby"],
+      matchFileNames: [
+        ".github/workflows/ci-markdown-checks.yml",
+      ],
       dependencyDashboardApproval: true,
+      separateMultipleMinor: true,
+      separateMinorPatch: true,
+    },
+    {
+      matchUpdateTypes: ["minor"],
+      matchDepNames: ["!ruby"],
+      matchFileNames: [
+        "!.github/workflows/ci-markdown-checks.yml",
+      ],
+      schedule: ["before 8am on Monday"],
+    },
+    {
+      matchUpdateTypes: ["major"],
+      matchCategories: ["ci", "js"],
+      schedule: ["before 8am on Monday"],
+    },
+    {
+      matchUpdateTypes: ["major"],
+      matchCategories: ["ruby", "docker"],
+      dependencyDashboardApproval: true,
+    },
+    {
+      matchDepNames: [
+        "setup-node",
+        "setup-ruby",
+      ],
+      schedule: ["before 7am every weekday"],
+      prConcurrentLimit: 0,
+      automerge: true,
+    },
+    {
+      allowedVersions: "<={{add major 1}}",
+      matchDepTypes: ["service"],
+      schedule: ["before 8am on Monday"],
+      dependencyDashboardApproval: false,
     },
     {
       allowedVersions: "<={{add major 1}}",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     },
     {
       matchUpdateTypes: ["major"],
-      matchCategories: ["!ruby"],
+      matchCategories: ["ci", "js", "docker"],
       schedule: ["before 8am on Monday"],
     },
     {
@@ -61,10 +61,10 @@
         "/(^|/)Dockerfile\\.[^/]*$/",
       ],
       matchStrings: [
-        "FROM\\s+(?<packageName>.+?):(?<depVersion>[^\\s@]+?)-alpine(?<alpineVersion>\\d+(?:\\.\\d+)?(?:\\.\\d+)?(?:-\\w+)?)(?:(@(?<currentDigest>[sha256:]?\\s+)))?.*\\s",
+        "FROM\\s+(?<packageName>.+?):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{40,64})",
       ],
       datasourceTemplate: "docker",
-      versioningTemplate: "loose",
+      versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
       extractVersionTemplate: "^(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)-alpine{{alpineVersion}}$",
     },
@@ -76,10 +76,10 @@
         "/(^|/)Dockerfile\\.[^/]*$/",
       ],
       matchStrings: [
-        "FROM\\s+(?<packageName>.+?):(?<depVersion>[^\\s@]+?)-alpine(?<alpineVersion>\\d+(?:\\.\\d+)?(?:\\.\\d+)?(?:-\\w+)?)(?:(@(?<currentDigest>[sha256:]?\\s+)))?.*\\s",
+        "FROM\\s+(?<packageName>.+?):(?<depVersion>[0-9.]+)-alpine(?<alpineVersion>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{40,64})",
       ],
       datasourceTemplate: "docker",
-      versioningTemplate: "loose",
+      versioningTemplate: "docker",
       currentValueTemplate: "{{alpineVersion}}",
       extractVersionTemplate: "^{{depVersion}}-alpine(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)$",
       depNameTemplate: "{{packageName}}-alpine",


### PR DESCRIPTION
This splits out min ruby sdk bump into a seperate update group requring approval to run.

The setup actions are prioritized for updates as these will need to be done before the sdk.

While looking at it, docker services defined in ci files are now treated the same as docker files.