### PR TITLE
fix: replace return with implicit block value in compatible block

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -24,10 +24,10 @@ module OpenTelemetry
         compatible do
           if gem_version > MAX_VERSION
             OpenTelemetry.logger.info("Dalli #{gem_version} has native OpenTelemetry support. Skipping community instrumentation.")
-            return false
+            false
+          else
+            true
           end
-
-          true
         end
 
         option :peer_service, default: nil, validate: :string


### PR DESCRIPTION
The `return` keyword inside a block passed to `instance_exec` causes a LocalJumpError ("unexpected return"). Replace with an if/else expression that uses implicit block return values instead.

Fixes #2027