### PR TITLE
ci: Manage min sdk using renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,8 +26,6 @@
     },
     {
       description: "Separate ruby updates so that patches can be installed after new minor has been released.",
-      groupName: "Min-Ruby-sdk",
-      dependencyDashboardCategory: "Min Ruby SDK",
       matchDepNames: ["ruby"],
       separateMultipleMinor: true,
       separateMinorPatch: true,
@@ -83,14 +81,6 @@
       matchUpdateTypes: ["major"],
       matchDepNames: ["mysql"],
       minimumReleaseAge: "1765 days",
-    },
-    {
-      groupName: "Min-Ruby-sdk",
-      dependencyDashboardCategory: "Min Ruby SDK",
-      matchCategories: ["custom"],
-      matchDepTypes: ["gemspec.required_ruby_version"],
-      separateMultipleMinor: true,
-      dependencyDashboardApproval: true,
     },
   ],
   customManagers: [
@@ -149,7 +139,7 @@
       description: "Update min sdk in gemspec",
       managerFilePatterns: ["**/*.gemspec"],
       matchStrings: [
-        "required_ruby_version = \'>= (?<depVersion>[0-9]+.[0-9]+)\'",
+        "required_ruby_version\\s=\\s\'.+\\s(?<depVersion>[0-9]+.[0-9]+)\'",
       ],
       datasourceTemplate: "ruby-version",
       versioningTemplate: "ruby",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -149,13 +149,11 @@
         "required_ruby_version = \'>= (?<depVersion>[0-9]+.[0-9]+)\'",
       ],
       datasourceTemplate: "ruby-version",
-      packageNameTemplate: "ruby/ruby",
       versioningTemplate: "ruby",
       currentValueTemplate: "{{depVersion}}",
       extractVersionTemplate: "(?<version>[0-9]+.[0-9]+).0",
       depNameTemplate: "ruby",
       depTypeTemplate: "gemspec.required_ruby_version",
-      packageNameTemplate: "Min.Required.Ruby",
     },
   ],
   lockFileMaintenance: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,11 +44,11 @@
       matchUpdateTypes: ["minor", "major"],
       dependencyDashboardApproval: true,
       minimumReleaseAge: "820 days",
+      prBodyNotes: [":exclamation: The old min version needs to be removed from the versions being tested."],
+      draftPR: true,
     },
     {
       matchUpdateTypes: ["minor"],
-      matchDepNames: ["!ruby"],
-      matchFileNames: ["!.github/workflows/ci-markdown-checks.yml"],
       schedule: ["before 7am on Monday"],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,7 @@
       ],
       matchUpdateTypes: ["minor", "major"],
       dependencyDashboardApproval: true,
+      minimumReleaseAge: "820 days",
     },
     {
       matchUpdateTypes: ["minor"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,8 @@
     },
     {
       description: "Separate ruby updates so that patches can be installed after new minor has been released.",
+      groupName: "Min-Ruby-sdk",
+      dependencyDashboardCategory: "Min Ruby SDK",
       matchDepNames: ["ruby"],
       separateMultipleMinor: true,
       separateMinorPatch: true,
@@ -79,6 +81,14 @@
       matchDepNames: ["mysql"],
       minimumReleaseAge: "1765 days",
     },
+    {
+      groupName: "Min-Ruby-sdk",
+      dependencyDashboardCategory: "Min Ruby SDK",
+      matchCategories: ["custom"],
+      matchDepTypes: ["gemspec.required_ruby_version"],
+      separateMultipleMinor: true,
+      dependencyDashboardApproval: true,
+    },
   ],
   customManagers: [
     {
@@ -130,6 +140,22 @@
       versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
       autoReplaceStringTemplate: "entrypoint sh {{packageName}}:{{newVersion}}@{{newDigest}} -c",
+    },
+    {
+      customType: "regex",
+      description: "Update min sdk in gemspec",
+      managerFilePatterns: ["**/*.gemspec"],
+      matchStrings: [
+        "required_ruby_version = \'>= (?<depVersion>[0-9]+.[0-9]+)\'",
+      ],
+      datasourceTemplate: "ruby-version",
+      packageNameTemplate: "ruby/ruby",
+      versioningTemplate: "ruby",
+      currentValueTemplate: "{{depVersion}}",
+      extractVersionTemplate: "(?<version>[0-9]+.[0-9]+).0",
+      depNameTemplate: "ruby",
+      depTypeTemplate: "gemspec.required_ruby_version",
+      packageNameTemplate: "Min.Required.Ruby",
     },
   ],
   lockFileMaintenance: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,9 @@
       matchUpdateTypes: ["minor", "major"],
       dependencyDashboardApproval: true,
       minimumReleaseAge: "820 days",
-      prBodyNotes: [":exclamation: The old min version needs to be removed from the versions being tested."],
+      prBodyNotes: [
+        ":exclamation: The old min version needs to be removed from the versions being tested in .github/actions/test_gem/action.yml.",
+      ],
       draftPR: true,
     },
     {


### PR DESCRIPTION
Bump min gemspec ruby sdk version on approval within renovate. This ensures the gemspec and github actions are mantained.

This also improves the renovate dashboard by grouping the min sdk updates into the pending status check before moving to approval once previous is EoL.