### PR TITLE
feat!: Default to stable HTTP semantic conventions

### DIFF
--- a/instrumentation/action_pack/README.md
+++ b/instrumentation/action_pack/README.md
@@ -96,6 +96,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/action_pack/README.md
+++ b/instrumentation/action_pack/README.md
@@ -90,18 +90,12 @@ The `opentelemetry-instrumentation-action_pack` gem is distributed under the Apa
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Rack instrumentation, which Action Pack relies on, was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
-
-Sinatra instrumentation installs Rack middleware, but the middleware version it installs depends on which `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set.
+This instrumentation relies on Rack instrumentation which by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Rack instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Rack instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
@@ -37,7 +37,11 @@ module OpenTelemetry
               OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => String(payload[:action])
             }
             attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_ROUTE] = http_route if http_route
-            attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET] = request.filtered_path if request.filtered_path != request.fullpath
+
+            if request.filtered_path != request.fullpath
+              filtered_query = request.filtered_path.split('?', 2)[1]
+              attributes['url.query'] = filtered_query if filtered_query
+            end
 
             if @span_naming == :semconv
               span.name = if http_route

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -42,11 +42,11 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
     _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-    _(span.attributes['http.method']).must_equal 'GET'
-    _(span.attributes['http.host']).must_equal 'example.org'
-    _(span.attributes['http.scheme']).must_equal 'http'
-    _(span.attributes['http.target']).must_equal '/ok'
-    _(span.attributes['http.status_code']).must_equal 200
+    _(span.attributes['http.request.method']).must_equal 'GET'
+    _(span.attributes['server.address']).must_equal 'example.org'
+    _(span.attributes['url.scheme']).must_equal 'http'
+    _(span.attributes['url.path']).must_equal '/ok'
+    _(span.attributes['http.response.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_equal 'ExampleController'
     _(span.attributes['code.function']).must_equal 'ok'
@@ -77,11 +77,11 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
     _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-    _(span.attributes['http.method']).must_equal 'GET'
-    _(span.attributes['http.host']).must_equal 'example.org'
-    _(span.attributes['http.scheme']).must_equal 'http'
-    _(span.attributes['http.target']).must_equal '/items/new'
-    _(span.attributes['http.status_code']).must_equal 200
+    _(span.attributes['http.request.method']).must_equal 'GET'
+    _(span.attributes['server.address']).must_equal 'example.org'
+    _(span.attributes['url.scheme']).must_equal 'http'
+    _(span.attributes['url.path']).must_equal '/items/new'
+    _(span.attributes['http.response.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_equal 'ExampleController'
     _(span.attributes['code.function']).must_equal 'new_item'
@@ -97,11 +97,11 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
       _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
       _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.host']).must_equal 'example.org'
-      _(span.attributes['http.scheme']).must_equal 'http'
-      _(span.attributes['http.target']).must_equal '/internal_server_error'
-      _(span.attributes['http.status_code']).must_equal 500
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['server.address']).must_equal 'example.org'
+      _(span.attributes['url.scheme']).must_equal 'http'
+      _(span.attributes['url.path']).must_equal '/internal_server_error'
+      _(span.attributes['http.response.status_code']).must_equal 500
       _(span.attributes['http.user_agent']).must_be_nil
       _(span.attributes['code.namespace']).must_equal 'ExampleController'
       _(span.attributes['code.function']).must_equal 'internal_server_error'
@@ -111,18 +111,18 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
   it 'does not set the span name when an exception is raised in middleware' do
     get '/ok?raise_in_middleware'
 
-    _(span.name).must_equal 'HTTP GET'
+    _(span.name).must_equal 'GET'
     _(span.kind).must_equal :server
     _(span.status.ok?).must_equal false
 
     _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
     _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-    _(span.attributes['http.method']).must_equal 'GET'
-    _(span.attributes['http.host']).must_equal 'example.org'
-    _(span.attributes['http.scheme']).must_equal 'http'
-    _(span.attributes['http.target']).must_equal '/ok?raise_in_middleware'
-    _(span.attributes['http.status_code']).must_equal 500
+    _(span.attributes['http.request.method']).must_equal 'GET'
+    _(span.attributes['server.address']).must_equal 'example.org'
+    _(span.attributes['url.scheme']).must_equal 'http'
+    _(span.attributes['url.path']).must_equal '/ok?raise_in_middleware'
+    _(span.attributes['http.response.status_code']).must_equal 500
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_be_nil
     _(span.attributes['code.function']).must_be_nil
@@ -131,15 +131,15 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
   it 'does not set the span name when the request is redirected in middleware' do
     get '/ok?redirect_in_middleware'
 
-    _(span.name).must_equal 'HTTP GET'
+    _(span.name).must_equal 'GET'
     _(span.kind).must_equal :server
     _(span.status.ok?).must_equal true
 
-    _(span.attributes['http.method']).must_equal 'GET'
-    _(span.attributes['http.host']).must_equal 'example.org'
-    _(span.attributes['http.scheme']).must_equal 'http'
-    _(span.attributes['http.target']).must_equal '/ok?redirect_in_middleware'
-    _(span.attributes['http.status_code']).must_equal 307
+    _(span.attributes['http.request.method']).must_equal 'GET'
+    _(span.attributes['server.address']).must_equal 'example.org'
+    _(span.attributes['url.scheme']).must_equal 'http'
+    _(span.attributes['url.path']).must_equal '/ok?redirect_in_middleware'
+    _(span.attributes['http.response.status_code']).must_equal 307
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_be_nil
     _(span.attributes['code.function']).must_be_nil
@@ -195,11 +195,11 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
       _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
       _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.host']).must_equal 'example.org'
-      _(span.attributes['http.scheme']).must_equal 'http'
-      _(span.attributes['http.target']).must_equal '/internal_server_error'
-      _(span.attributes['http.status_code']).must_equal 500
+      _(span.attributes['http.request.method']).must_equal 'GET'
+      _(span.attributes['server.address']).must_equal 'example.org'
+      _(span.attributes['url.scheme']).must_equal 'http'
+      _(span.attributes['url.path']).must_equal '/internal_server_error'
+      _(span.attributes['http.response.status_code']).must_equal 500
       _(span.attributes['http.user_agent']).must_be_nil
       _(span.attributes['code.namespace']).must_equal 'ExceptionsController'
       _(span.attributes['code.function']).must_equal 'show'
@@ -216,7 +216,7 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     get '/ok?param_to_be_filtered=bar&unfiltered_param=baz', {}
     _(last_response.body).must_equal 'actually ok'
     _(last_response.ok?).must_equal true
-    _(span.attributes['http.target']).must_equal '/ok?param_to_be_filtered=[FILTERED]&unfiltered_param=baz'
+    _(span.attributes['url.path']).must_equal '/ok?param_to_be_filtered=[FILTERED]&unfiltered_param=baz'
   end
 
   describe 'when the application does not have the tracing rack middleware' do

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -121,7 +121,8 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.attributes['http.request.method']).must_equal 'GET'
     _(span.attributes['server.address']).must_equal 'example.org'
     _(span.attributes['url.scheme']).must_equal 'http'
-    _(span.attributes['url.path']).must_equal '/ok?raise_in_middleware'
+    _(span.attributes['url.path']).must_equal '/ok'
+    _(span.attributes['url.query']).must_equal 'raise_in_middleware'
     _(span.attributes['http.response.status_code']).must_equal 500
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_be_nil
@@ -138,7 +139,8 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.attributes['http.request.method']).must_equal 'GET'
     _(span.attributes['server.address']).must_equal 'example.org'
     _(span.attributes['url.scheme']).must_equal 'http'
-    _(span.attributes['url.path']).must_equal '/ok?redirect_in_middleware'
+    _(span.attributes['url.path']).must_equal '/ok'
+    _(span.attributes['url.query']).must_equal 'redirect_in_middleware'
     _(span.attributes['http.response.status_code']).must_equal 307
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_be_nil
@@ -216,7 +218,8 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     get '/ok?param_to_be_filtered=bar&unfiltered_param=baz', {}
     _(last_response.body).must_equal 'actually ok'
     _(last_response.ok?).must_equal true
-    _(span.attributes['url.path']).must_equal '/ok?param_to_be_filtered=[FILTERED]&unfiltered_param=baz'
+    _(span.attributes['url.path']).must_equal '/ok'
+    _(span.attributes['url.query']).must_equal 'param_to_be_filtered=[FILTERED]&unfiltered_param=baz'
   end
 
   describe 'when the application does not have the tracing rack middleware' do

--- a/instrumentation/anthropic/test/opentelemetry/instrumentation/anthropic/patches/pooled_net_requester_test.rb
+++ b/instrumentation/anthropic/test/opentelemetry/instrumentation/anthropic/patches/pooled_net_requester_test.rb
@@ -38,7 +38,7 @@ describe OpenTelemetry::Instrumentation::Anthropic::Patches::PooledNetRequester 
       end
 
       test_span = spans.find { |span| span.name == 'test' }
-      http_span = spans.find { |span| span.name == 'HTTP POST' }
+      http_span = spans.find { |span| span.name == 'POST' }
 
       _(test_span.span_id).must_equal(http_span.parent_span_id)
     end

--- a/instrumentation/ethon/README.md
+++ b/instrumentation/ethon/README.md
@@ -61,6 +61,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/ethon/README.md
+++ b/instrumentation/ethon/README.md
@@ -55,16 +55,12 @@ The `opentelemetry-instrumentation-all` gem is distributed under the Apache 2.0 
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Ethon instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Ethon instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Ethon instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/instrumentation.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/instrumentation.rb
@@ -29,12 +29,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def require_dependencies_dup

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
 
     # this is currently a noop but this will future proof the test
@@ -30,6 +31,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'tracing' do

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
 
     # this is currently a noop but this will future proof the test

--- a/instrumentation/excon/README.md
+++ b/instrumentation/excon/README.md
@@ -51,16 +51,12 @@ The `opentelemetry-instrumentation-all` gem is distributed under the Apache 2.0 
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Excon instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Excon instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Excon instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/excon/README.md
+++ b/instrumentation/excon/README.md
@@ -57,6 +57,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/instrumentation.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/instrumentation.rb
@@ -34,12 +34,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def require_dependencies_dup

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/old/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/old/instrumentation_test.rb
@@ -18,6 +18,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/failure').to_return(status: 500)
@@ -34,6 +35,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'tracing' do

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/stable/instrumentation_test.rb
@@ -18,7 +18,6 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/success?hello=there').to_return(status: 200)

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -70,6 +70,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -64,16 +64,12 @@ Apache 2.0 license. See [LICENSE][license-github] for more information.
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Faraday instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Faraday instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Faraday instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -42,12 +42,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def require_dependencies_dup

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
@@ -28,6 +28,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddle
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
 
     # this is currently a noop but this will future proof the test
@@ -40,6 +41,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddle
 
   after do
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'first span' do

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
@@ -247,7 +247,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddle
       end
 
       it 'only adds the middleware once' do
-        tracers = client.builder.handlers.count(OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddleware)
+        tracers = client.builder.handlers.count(OpenTelemetry::Instrumentation::Faraday::Middlewares::Stable::TracerMiddleware)
         _(tracers).must_equal 1
       end
     end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/old/tracer_middleware_test.rb
@@ -247,7 +247,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddle
       end
 
       it 'only adds the middleware once' do
-        tracers = client.builder.handlers.count(OpenTelemetry::Instrumentation::Faraday::Middlewares::Stable::TracerMiddleware)
+        tracers = client.builder.handlers.count(OpenTelemetry::Instrumentation::Faraday::Middlewares::Old::TracerMiddleware)
         _(tracers).must_equal 1
       end
     end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/stable/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/stable/tracer_middleware_test.rb
@@ -28,7 +28,6 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::Stable::TracerMid
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
 
     # this is currently a noop but this will future proof the test

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday_test.rb
@@ -13,8 +13,13 @@ describe OpenTelemetry::Instrumentation::Faraday do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     instrumentation.install
     exporter.reset
+  end
+
+  after do
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'tracing' do

--- a/instrumentation/grape/README.md
+++ b/instrumentation/grape/README.md
@@ -77,6 +77,18 @@ The `opentelemetry-instrumentation-grape` gem source is [on github][repo-github]
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
+## HTTP semantic convention stability
+
+Grape instrumentation installs Rack middleware which by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
+
+When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
+
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+
+For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).
+
 ## License
 
 The `opentelemetry-instrumentation-grape` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.

--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -63,7 +63,7 @@ module OpenTelemetry
           private
 
           def span_name(endpoint)
-            "HTTP #{request_method(endpoint)} #{path(endpoint)}"
+            "#{request_method(endpoint)} #{path(endpoint)}"
           end
 
           def attributes_from_grape_endpoint(endpoint)

--- a/instrumentation/grape/test/opentelemetry/instrumentation/grape_test.rb
+++ b/instrumentation/grape/test/opentelemetry/instrumentation/grape_test.rb
@@ -34,7 +34,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(BasicAPI) }
       let(:request_path) { '/hello' }
-      let(:expected_span_name) { 'HTTP GET /hello' }
+      let(:expected_span_name) { 'GET /hello' }
 
       before { app.get request_path }
 
@@ -88,7 +88,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(RouteParamAPI) }
       let(:request_path) { '/users/1' }
-      let(:expected_span_name) { 'HTTP GET /users/:id' }
+      let(:expected_span_name) { 'GET /users/:id' }
 
       before { app.get request_path }
 
@@ -109,7 +109,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(VersionedWithPrefixAPI) }
       let(:request_path) { '/api/v1/hello' }
-      let(:expected_span_name) { 'HTTP GET /api/v1/hello' }
+      let(:expected_span_name) { 'GET /api/v1/hello' }
 
       before { app.get request_path }
 
@@ -133,7 +133,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(NestedAPI) }
       let(:request_path) { '/internal/users' }
-      let(:expected_span_name) { 'HTTP GET /internal/users' }
+      let(:expected_span_name) { 'GET /internal/users' }
 
       before { app.get request_path }
 
@@ -154,7 +154,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(FilteredAPI) }
       let(:request_path) { '/filtered' }
-      let(:expected_span_name) { 'HTTP GET /filtered' }
+      let(:expected_span_name) { 'GET /filtered' }
 
       before { app.get request_path }
 
@@ -196,7 +196,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(CustomFormatterAPI) }
       let(:request_path) { '/hello' }
-      let(:expected_span_name) { 'HTTP GET /hello' }
+      let(:expected_span_name) { 'GET /hello' }
 
       before { app.get request_path }
 
@@ -225,7 +225,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(ValidationErrorAPI) }
       let(:request_path) { '/new' }
-      let(:expected_span_name) { 'HTTP POST /new' }
+      let(:expected_span_name) { 'POST /new' }
       let(:headers) { { 'Content-Type' => 'application/json' } }
       let(:expected_error_type) { 'Grape::Exceptions::ValidationErrors' }
 
@@ -262,7 +262,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(RaisedErrorAPI) }
       let(:request_path) { '/failure' }
-      let(:expected_span_name) { 'HTTP GET /failure' }
+      let(:expected_span_name) { 'GET /failure' }
       let(:expected_error_type) { 'StandardError' }
 
       before do
@@ -300,7 +300,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(ErrorInFilterAPI) }
       let(:request_path) { '/filtered' }
-      let(:expected_span_name) { 'HTTP GET /filtered' }
+      let(:expected_span_name) { 'GET /filtered' }
       let(:expected_error_type) { 'StandardError' }
 
       before do
@@ -338,7 +338,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(ErrorInFormatterAPI) }
       let(:request_path) { '/bad_format' }
-      let(:expected_span_name) { 'HTTP GET /bad_format' }
+      let(:expected_span_name) { 'GET /bad_format' }
       let(:expected_error_type) { 'Grape::Exceptions::InvalidFormatter' }
 
       before { app.get request_path }
@@ -366,7 +366,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(ErrorResponseAPI) }
       let(:request_path) { '/error_response' }
-      let(:expected_span_name) { 'HTTP GET /error_response' }
+      let(:expected_span_name) { 'GET /error_response' }
 
       before { app.get request_path }
 
@@ -385,7 +385,7 @@ describe OpenTelemetry::Instrumentation::Grape do
 
       let(:app) { build_rack_app(ErrorResponseAPI) }
       let(:request_path) { '/error_response' }
-      let(:expected_span_name) { 'HTTP GET /error_response' }
+      let(:expected_span_name) { 'GET /error_response' }
 
       before { app.get request_path }
 
@@ -405,7 +405,7 @@ describe OpenTelemetry::Instrumentation::Grape do
       let(:config) { { ignored_events: [:endpoint_render] } }
       let(:app) { build_rack_app(IgnoredEventAPI) }
       let(:request_path) { '/success' }
-      let(:expected_span_name) { 'HTTP GET /success' }
+      let(:expected_span_name) { 'GET /success' }
 
       before { app.get request_path }
 
@@ -437,7 +437,7 @@ describe OpenTelemetry::Instrumentation::Grape do
       end
 
       let(:request_path) { '/hello' }
-      let(:expected_span_name) { 'HTTP GET /hello' }
+      let(:expected_span_name) { 'GET /hello' }
 
       describe 'missing rack installation' do
         it 'disables tracing' do
@@ -458,13 +458,13 @@ describe OpenTelemetry::Instrumentation::Grape do
         it 'creates a span' do
           app.get request_path
           _(exporter.finished_spans.first.attributes).must_equal(
+            'http.request.method' => 'GET',
+            'server.address' => 'unknown',
+            'url.scheme' => 'http',
+            'url.path' => '/hello',
             'code.namespace' => 'BasicAPI',
-            'http.method' => 'GET',
-            'http.host' => 'unknown',
-            'http.scheme' => 'http',
-            'http.target' => '/hello',
             'http.route' => '/hello',
-            'http.status_code' => 200
+            'http.response.status_code' => 200
           )
         end
       end

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -73,6 +73,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -67,16 +67,12 @@ The `opentelemetry-instrumentation-http` gem is distributed under the Apache 2.0
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial HTTP instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, HTTP instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to HTTP instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -26,12 +26,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def patch_old

--- a/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
+++ b/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
@@ -58,9 +58,9 @@ describe OpenTelemetry::Instrumentation::HTTP do
       end
     end
 
-    it 'returns "old" when OTEL_SEMCONV_STABILITY_OPT_IN is empty' do
+    it 'returns "stable" when OTEL_SEMCONV_STABILITY_OPT_IN is empty' do
       OpenTelemetry::TestHelpers.with_env('OTEL_SEMCONV_STABILITY_OPT_IN' => '') do
-        _(instrumentation.determine_semconv).must_equal('old')
+        _(instrumentation.determine_semconv).must_equal('stable')
       end
     end
   end

--- a/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
+++ b/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
@@ -9,7 +9,7 @@ require 'test_helper'
 require_relative '../../../lib/opentelemetry/instrumentation/http'
 
 describe OpenTelemetry::Instrumentation::HTTP do
-  before { skip unless ENV['BUNDLE_GEMFILE'].include?('old') }
+  before { skip unless ENV['BUNDLE_GEMFILE'].include?('stable') }
 
   let(:instrumentation) { OpenTelemetry::Instrumentation::HTTP::Instrumentation.instance }
 

--- a/instrumentation/http/test/instrumentation/http/patches/old/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/old/client_test.rb
@@ -23,6 +23,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Old::Client do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     @orig_propagation = OpenTelemetry.propagation
     propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
@@ -40,6 +41,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Old::Client do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe '#perform' do

--- a/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
@@ -23,7 +23,6 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     @orig_propagation = OpenTelemetry.propagation
     propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
@@ -39,7 +38,6 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
   end
 
   after do
-    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
     # Force re-install of instrumentation
     instrumentation.instance_variable_set(:@installed, false)
 

--- a/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
@@ -17,14 +17,12 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Connection do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     instrumentation.install({})
   end
 
   # Force re-install of instrumentation
   after do
-    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
     instrumentation.instance_variable_set(:@installed, false)
   end
 

--- a/instrumentation/http_client/README.md
+++ b/instrumentation/http_client/README.md
@@ -61,6 +61,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/http_client/README.md
+++ b/instrumentation/http_client/README.md
@@ -55,16 +55,12 @@ The `opentelemetry-instrumentation-http_client` gem is distributed under the Apa
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial HttpClient instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, HttpClient instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to HttpClient instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/instrumentation.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/instrumentation.rb
@@ -28,12 +28,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def patch_dup

--- a/instrumentation/http_client/test/instrumentation/http_client/instrumentation_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/instrumentation_test.rb
@@ -11,7 +11,7 @@ require_relative '../../../lib/opentelemetry/instrumentation/http_client'
 describe OpenTelemetry::Instrumentation::HttpClient do
   let(:instrumentation) { OpenTelemetry::Instrumentation::HttpClient::Instrumentation.instance }
 
-  before { skip unless ENV['BUNDLE_GEMFILE'].include?('old') }
+  before { skip unless ENV['BUNDLE_GEMFILE'].include?('stable') }
 
   it 'has #name' do
     _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::HttpClient'

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/old/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/old/client_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Old::Client do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     @orig_propagation = OpenTelemetry.propagation
     propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
@@ -32,6 +33,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Old::Client do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe '#do_request' do

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/old/session_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/old/session_test.rb
@@ -17,12 +17,16 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Old::Session do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     instrumentation.install({})
   end
 
   # Force re-install of instrumentation
-  after { instrumentation.instance_variable_set(:@installed, false) }
+  after do
+    instrumentation.instance_variable_set(:@installed, false)
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
+  end
 
   describe '#connect' do
     it 'emits span on connect' do

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/stable/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/stable/client_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Stable::Client do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     @orig_propagation = OpenTelemetry.propagation
     propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/stable/session_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/stable/session_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Stable::Session do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     instrumentation.install({})
   end

--- a/instrumentation/httpx/README.md
+++ b/instrumentation/httpx/README.md
@@ -51,16 +51,12 @@ The `opentelemetry-instrumentation-httpx` gem is distributed under the Apache 2.
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial HTTPX instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, HTTPX instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to HTTPX instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/httpx/README.md
+++ b/instrumentation/httpx/README.md
@@ -57,6 +57,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/httpx/lib/opentelemetry/instrumentation/httpx/instrumentation.rb
+++ b/instrumentation/httpx/lib/opentelemetry/instrumentation/httpx/instrumentation.rb
@@ -30,12 +30,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def patch_old

--- a/instrumentation/httpx/test/instrumentation/httpx/instrumentation_test.rb
+++ b/instrumentation/httpx/test/instrumentation/httpx/instrumentation_test.rb
@@ -9,7 +9,7 @@ require 'test_helper'
 require_relative '../../../lib/opentelemetry/instrumentation/httpx'
 
 describe OpenTelemetry::Instrumentation::HTTPX do
-  before { skip unless ENV['BUNDLE_GEMFILE'].include?('old') }
+  before { skip unless ENV['BUNDLE_GEMFILE'].include?('stable') }
 
   let(:instrumentation) { OpenTelemetry::Instrumentation::HTTPX::Instrumentation.instance }
 

--- a/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::HTTPX::Old::Plugin do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/failure').to_return(status: 500)
@@ -24,7 +25,10 @@ describe OpenTelemetry::Instrumentation::HTTPX::Old::Plugin do
   end
 
   # Force re-install of instrumentation
-  after { instrumentation.instance_variable_set(:@installed, false) }
+  after do
+    instrumentation.instance_variable_set(:@installed, false)
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
+  end
 
   describe 'tracing' do
     before do

--- a/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::HTTPX::Stable::Plugin do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/failure').to_return(status: 500)

--- a/instrumentation/net_http/README.md
+++ b/instrumentation/net_http/README.md
@@ -61,6 +61,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/net_http/README.md
+++ b/instrumentation/net_http/README.md
@@ -55,16 +55,12 @@ Apache 2.0 license. See [LICENSE][license-github] for more information.
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Net::HTTP instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Net::HTTP instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Net::HTTP instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
@@ -36,12 +36,18 @@ module OpenTelemetry
             values = stability_opt_in.split(',').map(&:strip)
 
             if values.include?('http/dup')
+              emit_old_semconv_deprecation_warning('http/dup')
               'dup'
-            elsif values.include?('http')
-              'stable'
-            else
+            elsif values.include?('old')
+              emit_old_semconv_deprecation_warning('old')
               'old'
+            else
+              'stable'
             end
+          end
+
+          def emit_old_semconv_deprecation_warning(option)
+            OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
           end
 
           def require_dependencies_dup

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:post, 'http://example.com/failure').to_return(status: 500)
@@ -34,6 +35,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe '#request' do

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/success?hello=there').to_return(status: 200)

--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -104,16 +104,12 @@ The `opentelemetry-instrumentation-rack` gem is distributed under the Apache 2.0
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Rack instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Rack instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Rack instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -110,6 +110,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -76,12 +76,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def require_dependencies_old

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_old_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/instrumentation_old_test.rb
@@ -14,9 +14,14 @@ describe OpenTelemetry::Instrumentation::Rack::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     # simulate a fresh install:
     instrumentation.instance_variable_set(:@installed, false)
     instrumentation.config.clear
+  end
+
+  after do
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'given default config options' do

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
@@ -62,11 +62,16 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler' 
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
 
     # simulate a fresh install:
     instrumentation.instance_variable_set(:@installed, false)
     instrumentation.install(config)
+  end
+
+  after do
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   # Simulating buggy instrumentation that starts a span, sets the ctx

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/tracer_middleware_test.rb
@@ -35,6 +35,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Old::TracerMiddlewar
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     # clear captured spans:
     exporter.reset
 
@@ -54,6 +55,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Old::TracerMiddlewar
     # installation is 'global', so it should be reset:
     instrumentation.instance_variable_set(:@installed, false)
     instrumentation.install(default_config)
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe '#call' do

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
@@ -62,8 +62,6 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandle
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
-
     exporter.reset
 
     # simulate a fresh install:

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/tracer_middleware_test.rb
@@ -35,8 +35,6 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::TracerMiddle
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
-
     # clear captured spans:
     exporter.reset
 

--- a/instrumentation/rails/README.md
+++ b/instrumentation/rails/README.md
@@ -72,6 +72,18 @@ The `opentelemetry-instrumentation-rails` gem source is [on github][repo-github]
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry Ruby special interest group (SIG). You can get involved by joining us on our [GitHub Discussions][discussions-url], [Slack Channel][slack-channel] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
+## HTTP semantic convention stability
+
+Rails instrumentation installs Rack middleware which by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
+
+When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
+
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+
+For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).
+
 ## License
 
 The `opentelemetry-instrumentation-rails` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.

--- a/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/instrumentation/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -29,11 +29,11 @@ describe OpenTelemetry::Instrumentation::Rails do
     _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
     _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
 
-    _(span.attributes['http.method']).must_equal 'GET'
-    _(span.attributes['http.host']).must_equal 'example.org'
-    _(span.attributes['http.scheme']).must_equal 'http'
-    _(span.attributes['http.target']).must_equal '/ok'
-    _(span.attributes['http.status_code']).must_equal 200
+    _(span.attributes['http.request.method']).must_equal 'GET'
+    _(span.attributes['server.address']).must_equal 'example.org'
+    _(span.attributes['url.scheme']).must_equal 'http'
+    _(span.attributes['url.path']).must_equal '/ok'
+    _(span.attributes['http.response.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
     _(span.attributes['code.namespace']).must_equal 'ExampleController'
     _(span.attributes['code.function']).must_equal 'ok'

--- a/instrumentation/restclient/README.md
+++ b/instrumentation/restclient/README.md
@@ -56,16 +56,12 @@ Apache 2.0 license. See [LICENSE][license-github] for more information.
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Faraday instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
+This instrumentation by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, RestClient instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to RestClient instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/restclient/README.md
+++ b/instrumentation/restclient/README.md
@@ -62,6 +62,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/instrumentation.rb
+++ b/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/instrumentation.rb
@@ -29,12 +29,18 @@ module OpenTelemetry
           values = stability_opt_in.split(',').map(&:strip)
 
           if values.include?('http/dup')
+            emit_old_semconv_deprecation_warning('http/dup')
             'dup'
-          elsif values.include?('http')
-            'stable'
-          else
+          elsif values.include?('old')
+            emit_old_semconv_deprecation_warning('old')
             'old'
+          else
+            'stable'
           end
+        end
+
+        def emit_old_semconv_deprecation_warning(option)
+          OpenTelemetry.logger.warn("The `#{option}` option for OTEL_SEMCONV_STABILITY_OPT_IN is deprecated and will be removed on April 15, 2026. Please migrate to the stable HTTP semantic conventions.")
         end
 
         def require_dependencies_dup

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/old/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/old/instrumentation_test.rb
@@ -17,6 +17,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/failure').to_return(status: 500)
@@ -32,6 +33,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
     instrumentation.instance_variable_set(:@installed, false)
 
     OpenTelemetry.propagation = @orig_propagation
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'tracing' do

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/stable/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/stable/instrumentation_test.rb
@@ -17,7 +17,6 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
     exporter.reset
     stub_request(:get, 'http://example.com/success').to_return(status: 200)
     stub_request(:get, 'http://example.com/failure').to_return(status: 500)

--- a/instrumentation/sinatra/README.md
+++ b/instrumentation/sinatra/README.md
@@ -81,6 +81,6 @@ When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify whic
 
 - `http` - Emits the stable HTTP and networking conventions.
 - `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
-- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
+- `old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/sinatra/README.md
+++ b/instrumentation/sinatra/README.md
@@ -75,18 +75,12 @@ The `opentelemetry-instrumentation-sinatra` gem is distributed under the Apache 
 
 ## HTTP semantic convention stability
 
-In the OpenTelemetry ecosystem, HTTP semantic conventions have now reached a stable state. However, the initial Rack instrumentation was introduced before this stability was achieved, which resulted in HTTP attributes being based on an older version of the semantic conventions.
-
-To facilitate the migration to stable semantic conventions, you can use the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This variable allows you to opt-in to the new stable conventions, ensuring compatibility and future-proofing your instrumentation.
-
-Sinatra instrumentation installs Rack middleware, but the middleware version it installs depends on which `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set.
+Sinatra instrumentation installs Rack middleware which by default emits the stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to opt-in to the old or duplicate (both old and stable) semantic conventions.
 
 When setting the value for `OTEL_SEMCONV_STABILITY_OPT_IN`, you can specify which conventions you wish to adopt:
 
-- `http` - Emits the stable HTTP and networking conventions and ceases emitting the old conventions previously emitted by the instrumentation.
-- `http/dup` - Emits both the old and stable HTTP and networking conventions, enabling a phased rollout of the stable semantic conventions.
-- Default behavior (in the absence of either value) is to continue emitting the old HTTP and networking conventions the instrumentation previously emitted.
-
-During the transition from old to stable conventions, Rack instrumentation code comes in three patch versions: `dup`, `old`, and `stable`. These versions are identical except for the attributes they send. Any changes to Rack instrumentation should consider all three patches.
+- `http` - Emits the stable HTTP and networking conventions.
+- `http/dup` - **DEPRECATED: Will be removed on April 15, 2026.** Emits both the old and stable HTTP and networking conventions.
+- `http/old` - **DEPRECATED: Will be removed on April 15, 2026.** Emits the old HTTP and networking conventions.
 
 For additional information on migration, please refer to our [documentation](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/).

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
@@ -69,8 +69,9 @@ describe OpenTelemetry::Instrumentation::Sinatra do
   end
 
   before do
-    skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
+    skip unless ENV['BUNDLE_GEMFILE'].include?('old')
 
+    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'old'
     Sinatra::Base.reset!
 
     OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.instance_variable_set(:@installed, false)
@@ -80,6 +81,10 @@ describe OpenTelemetry::Instrumentation::Sinatra do
     instrumentation.config.clear
     instrumentation.install(config)
     exporter.reset
+  end
+
+  after do
+    ENV.delete('OTEL_SEMCONV_STABILITY_OPT_IN')
   end
 
   describe 'tracing' do

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
@@ -69,7 +69,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
   end
 
   before do
-    skip unless ENV['BUNDLE_GEMFILE'].include?('old')
+    skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
 
     Sinatra::Base.reset!
 

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_stable_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_stable_http_test.rb
@@ -70,7 +70,6 @@ describe OpenTelemetry::Instrumentation::Sinatra do
 
   before do
     skip unless ENV['BUNDLE_GEMFILE'].include?('stable')
-    ENV['OTEL_SEMCONV_STABILITY_OPT_IN'] = 'http'
 
     Sinatra::Base.reset!
 


### PR DESCRIPTION
Use stable HTTP semantic conventions by default for HTTP instrumentations and update README:
- http
- http_client
- httpx
- net_http
- rack  
- restclient
- excon
- faraday
- ethon

Emit warnings for users who have set `http/dup` or `old` as the value for `OTEL_SEMCONV_STABILITY_OPT_IN`.

Set the final transition date as **April 15, 2026**

Update README documentation for action_pack and sinatra, which depend on rack.