### PR TITLE
chore: linting changelog

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -10,3 +10,4 @@ line-length:
   line_length: 500
 no-inline-html: false
 custom-rules-below-this-point: false
+no-bare-urls: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,1 @@
-**/CHANGELOG.md
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
-**/CHANGELOG.md
 **/README.md
 **/sql_obfuscation.json

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -14,6 +14,9 @@ update_existing_requests: true
 git_user_name: otelbot
 git_user_email: 197425009+otelbot@users.noreply.github.com
 
+# Sets the list symbol used for bullet points in the generated changelog to be "-" which complies with markdownlint and prettier. Note The default is "*".
+changelog_bullet: "-"
+
 # List of all releasable gems. Each gem should include:
 #  *  name: The name of the gem. (Required.)
 #  *  directory: Gem directory relative to the repo root.

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -17,6 +17,8 @@ git_user_email: 197425009+otelbot@users.noreply.github.com
 # Sets the list symbol used for bullet points in the generated changelog to be "-" which complies with markdownlint and prettier. Note The default is "*".
 changelog_bullet: "-"
 
+changelog_release_header_format: "## v%v / %Y-%m-%d"
+
 # List of all releasable gems. Each gem should include:
 #  *  name: The name of the gem. (Required.)
 #  *  directory: Gem directory relative to the repo root.

--- a/helpers/mysql/CHANGELOG.md
+++ b/helpers/mysql/CHANGELOG.md
@@ -6,26 +6,26 @@
 
 ### v0.4.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.3.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.2 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.1 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.1.0 / 2024-02-08
 
-Initial release.
+- Initial release.

--- a/helpers/mysql/CHANGELOG.md
+++ b/helpers/mysql/CHANGELOG.md
@@ -1,31 +1,31 @@
 # Release History: opentelemetry-helpers-mysql
 
-### v0.5.0 / 2026-03-17
+## v0.5.0 / 2026-03-17
 
-* ADDED: Optimize extract_statement_type regex and encoding in helpers-mysql (#2088)
+- ADDED: Optimize extract_statement_type regex and encoding in helpers-mysql (#2088)
 
-### v0.4.0 / 2025-10-22
+## v0.4.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.3.0 / 2025-09-30
+## v0.3.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.2 / 2024-11-26
+## v0.1.2 / 2024-11-26
 
 - (No significant changes)
 
-### v0.1.1 / 2024-06-18
+## v0.1.1 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.1.0 / 2024-02-08
+## v0.1.0 / 2024-02-08
 
 - Initial release.

--- a/helpers/sql-obfuscation/CHANGELOG.md
+++ b/helpers/sql-obfuscation/CHANGELOG.md
@@ -2,25 +2,25 @@
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.4.0 / 2025-10-08
 
 #### Deprecation Notice
 
-* **DEPRECATED:** This gem, `opentelemetry-helpers-sql-obfuscation`, has been replaced by `opentelemetry-helpers-sql-processor`. This is the final release and serves as a transitional package.
-* **ACTION REQUIRED:** No action is needed unless you use this gem directly. If you use this gem directly, update your `Gemfile` to use `gem 'opentelemetry-helpers-sql-processor'` instead.
-* **SUPPORT ENDING:** `opentelemetry-helpers-sql-obfuscation` will no longer receive updates.
+- **DEPRECATED:** This gem, `opentelemetry-helpers-sql-obfuscation`, has been replaced by `opentelemetry-helpers-sql-processor`. This is the final release and serves as a transitional package.
+- **ACTION REQUIRED:** No action is needed unless you use this gem directly. If you use this gem directly, update your `Gemfile` to use `gem 'opentelemetry-helpers-sql-processor'` instead.
+- **SUPPORT ENDING:** `opentelemetry-helpers-sql-obfuscation` will no longer receive updates.
 
 ### v0.3.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.2.0 / 2024-09-12
 
@@ -32,4 +32,4 @@
 
 ### v0.1.0 / 2024-02-08
 
-Initial release.
+- Initial release.

--- a/helpers/sql-obfuscation/CHANGELOG.md
+++ b/helpers/sql-obfuscation/CHANGELOG.md
@@ -1,35 +1,35 @@
 # Release History: opentelemetry-helpers-sql-obfuscation
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.4.0 / 2025-10-08
+## v0.4.0 / 2025-10-08
 
-#### Deprecation Notice
+### Deprecation Notice
 
 - **DEPRECATED:** This gem, `opentelemetry-helpers-sql-obfuscation`, has been replaced by `opentelemetry-helpers-sql-processor`. This is the final release and serves as a transitional package.
 - **ACTION REQUIRED:** No action is needed unless you use this gem directly. If you use this gem directly, update your `Gemfile` to use `gem 'opentelemetry-helpers-sql-processor'` instead.
 - **SUPPORT ENDING:** `opentelemetry-helpers-sql-obfuscation` will no longer receive updates.
 
-### v0.3.0 / 2025-01-16
+## v0.3.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.2.1 / 2024-11-26
+## v0.2.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.2.0 / 2024-09-12
+## v0.2.0 / 2024-09-12
 
 - BREAKING CHANGE: Return message when sql is over the obfuscation limit. Fixes a bug where sql statements with prepended comments that hit the obfuscation limit would be sent raw.
 
-### v0.1.1 / 2024-06-18
+## v0.1.1 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.1.0 / 2024-02-08
+## v0.1.0 / 2024-02-08
 
 - Initial release.

--- a/helpers/sql-processor/CHANGELOG.md
+++ b/helpers/sql-processor/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 ### v0.4.0 / 2026-01-13
 
-* ADDED: Add SQL Comment Propagator
+- ADDED: Add SQL Comment Propagator
 
 ### v0.3.1 / 2025-11-11
 
-* DOCS: Update example to match new gem namespace (sql-processor)
+- DOCS: Update example to match new gem namespace (sql-processor)
 
 ### v0.3.0 / 2025-11-04
 
-* ADDED: Refactor SQL processor file structure for clarity
+- ADDED: Refactor SQL processor file structure for clarity
 
 ### v0.2.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.1.0 / 2025-10-08
 
-Initial release.
+- Initial release.

--- a/helpers/sql-processor/CHANGELOG.md
+++ b/helpers/sql-processor/CHANGELOG.md
@@ -1,22 +1,22 @@
 # Release History: opentelemetry-helpers-sql-processor
 
-### v0.4.0 / 2026-01-13
+## v0.4.0 / 2026-01-13
 
 - ADDED: Add SQL Comment Propagator
 
-### v0.3.1 / 2025-11-11
+## v0.3.1 / 2025-11-11
 
 - DOCS: Update example to match new gem namespace (sql-processor)
 
-### v0.3.0 / 2025-11-04
+## v0.3.0 / 2025-11-04
 
 - ADDED: Refactor SQL processor file structure for clarity
 
-### v0.2.0 / 2025-10-22
+## v0.2.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.1.0 / 2025-10-08
+## v0.1.0 / 2025-10-08
 
 - Initial release.

--- a/helpers/sql/CHANGELOG.md
+++ b/helpers/sql/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.2.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.1.1 / 2025-04-14
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2025-01-24
 
-Initial release.
+- Initial release.

--- a/helpers/sql/CHANGELOG.md
+++ b/helpers/sql/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Release History: opentelemetry-helpers-sql
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.2.0 / 2025-09-30
+## v0.2.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.1.1 / 2025-04-14
+## v0.1.1 / 2025-04-14
 
 - (No significant changes)
 
-### v0.1.0 / 2025-01-24
+## v0.1.0 / 2025-01-24
 
 - Initial release.

--- a/instrumentation/action_mailer/CHANGELOG.md
+++ b/instrumentation/action_mailer/CHANGELOG.md
@@ -1,33 +1,33 @@
 # Release History: opentelemetry-instrumentation-action_mailer
 
-### v0.6.1 / 2025-10-22
+## v0.6.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.6.0 / 2025-10-21
+## v0.6.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.5.0 / 2025-09-30
+## v0.5.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.4.0 / 2025-01-16
+## v0.4.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.3.0 / 2024-12-19
+## v0.3.0 / 2024-12-19
 
 - ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
-### v0.2.0 / 2024-10-22
+## v0.2.0 / 2024-10-22
 
 - ADDED: Subscribe to process.action_mailer notifications
 
-### v0.1.0 / 2024-05-13
+## v0.1.0 / 2024-05-13
 
 - Initial release.

--- a/instrumentation/action_mailer/CHANGELOG.md
+++ b/instrumentation/action_mailer/CHANGELOG.md
@@ -2,32 +2,32 @@
 
 ### v0.6.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.6.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.5.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.4.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.3.0 / 2024-12-19
 
-* ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
+- ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
 ### v0.2.0 / 2024-10-22
 
-* ADDED: Subscribe to process.action_mailer notifications
+- ADDED: Subscribe to process.action_mailer notifications
 
 ### v0.1.0 / 2024-05-13
 
-Initial release.
+- Initial release.

--- a/instrumentation/action_pack/CHANGELOG.md
+++ b/instrumentation/action_pack/CHANGELOG.md
@@ -7,130 +7,130 @@
 
 ### v0.15.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.15.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.14.1 / 2025-10-07
 
-* FIXED: Unify rack middleware_args
+- FIXED: Unify rack middleware_args
 
 ### v0.14.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.13.0 / 2025-08-19
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
 ### v0.12.3 / 2025-06-16
 
-* FIXED: Action_pack always assuming sdk spans
+- FIXED: Action_pack always assuming sdk spans
 
 ### v0.12.2 / 2025-06-04
 
-* FIXED: Rack span class naming
+- FIXED: Rack span class naming
 
 ### v0.12.1 / 2025-05-07
 
-* FIXED: Account for `nil` routes
+- FIXED: Account for `nil` routes
 
 ### v0.12.0 / 2025-02-04
 
-* ADDED: Strip Rails `(.:format)` suffix from `http.route`
+- ADDED: Strip Rails `(.:format)` suffix from `http.route`
 
 ### v0.11.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.10.0 / 2024-11-19
 
-* ADDED: Use Semconv Naming For ActionPack
+- ADDED: Use Semconv Naming For ActionPack
 
 ### v0.9.0 / 2024-01-09
 
-* BREAKING CHANGE: Use ActiveSupport instead of patches #703
+- BREAKING CHANGE: Use ActiveSupport instead of patches #703
 
 ### v0.8.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
 
 ### v0.7.1 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.7.0 / 2023-06-05
 
-* ADDED: Use Rack Middleware Helper
-* FIXED: Base config options
+- ADDED: Use Rack Middleware Helper
+- FIXED: Base config options
 
 ### v0.6.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.5.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
+- FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.4.1 / 2023-01-14
 
-* FIXED: String-ify code.function Span attribute
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- FIXED: String-ify code.function Span attribute
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.4.0 / 2022-12-06
 
-* BREAKING CHANGE: Remove enable_recognize_route and span_naming options
-* FIXED: Remove enable_recognize_route and span_naming options
+- BREAKING CHANGE: Remove enable_recognize_route and span_naming options
+- FIXED: Remove enable_recognize_route and span_naming options
 
 ### v0.3.2 / 2022-11-16
 
-* FIXED: Loosen dependency on Rack
+- FIXED: Loosen dependency on Rack
 
 ### v0.3.1 / 2022-10-27
 
-* FIXED: Declare span_naming option in action_pack instrumentation
+- FIXED: Declare span_naming option in action_pack instrumentation
 
 ### v0.3.0 / 2022-10-14
 
-* ADDED: Name ActionPack spans with the HTTP method and route
+- ADDED: Name ActionPack spans with the HTTP method and route
 
 ### v0.2.1 / 2022-10-04
 
-* FIXED: Ensures the correct route is add to http.route span attribute
+- FIXED: Ensures the correct route is add to http.route span attribute
 
 ### v0.2.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.1.4 / 2022-05-02
 
-* FIXED: Use rails request's filtered path as http.target attribute
-* FIXED: RubyGems Fallback
+- FIXED: Use rails request's filtered path as http.target attribute
+- FIXED: RubyGems Fallback
 
 ### v0.1.3 / 2021-12-01
 
-* FIXED: Instrumentation of Rails 7
+- FIXED: Instrumentation of Rails 7
 
 ### v0.1.2 / 2021-10-06
 
-* FIXED: Prevent high cardinality rack span name as a default
+- FIXED: Prevent high cardinality rack span name as a default
 
 ### v0.1.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2021-08-12
 
-* Initial release.
+- Initial release.

--- a/instrumentation/action_pack/CHANGELOG.md
+++ b/instrumentation/action_pack/CHANGELOG.md
@@ -1,136 +1,136 @@
 # Release History: opentelemetry-instrumentation-action_pack
 
-### v0.16.0 / 2026-03-17
+## v0.16.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.15.1 / 2025-10-22
+## v0.15.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.15.0 / 2025-10-21
+## v0.15.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.14.1 / 2025-10-07
+## v0.14.1 / 2025-10-07
 
 - FIXED: Unify rack middleware_args
 
-### v0.14.0 / 2025-09-30
+## v0.14.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.13.0 / 2025-08-19
+## v0.13.0 / 2025-08-19
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
-### v0.12.3 / 2025-06-16
+## v0.12.3 / 2025-06-16
 
 - FIXED: Action_pack always assuming sdk spans
 
-### v0.12.2 / 2025-06-04
+## v0.12.2 / 2025-06-04
 
 - FIXED: Rack span class naming
 
-### v0.12.1 / 2025-05-07
+## v0.12.1 / 2025-05-07
 
 - FIXED: Account for `nil` routes
 
-### v0.12.0 / 2025-02-04
+## v0.12.0 / 2025-02-04
 
 - ADDED: Strip Rails `(.:format)` suffix from `http.route`
 
-### v0.11.0 / 2025-01-16
+## v0.11.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.10.0 / 2024-11-19
+## v0.10.0 / 2024-11-19
 
 - ADDED: Use Semconv Naming For ActionPack
 
-### v0.9.0 / 2024-01-09
+## v0.9.0 / 2024-01-09
 
 - BREAKING CHANGE: Use ActiveSupport instead of patches #703
 
-### v0.8.0 / 2023-11-22
+## v0.8.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 
-### v0.7.1 / 2023-10-16
+## v0.7.1 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.7.0 / 2023-06-05
+## v0.7.0 / 2023-06-05
 
 - ADDED: Use Rack Middleware Helper
 - FIXED: Base config options
 
-### v0.6.0 / 2023-04-17
+## v0.6.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.5.0 / 2023-02-01
+## v0.5.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 - FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
-### v0.4.1 / 2023-01-14
+## v0.4.1 / 2023-01-14
 
 - FIXED: String-ify code.function Span attribute
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.4.0 / 2022-12-06
+## v0.4.0 / 2022-12-06
 
 - BREAKING CHANGE: Remove enable_recognize_route and span_naming options
 - FIXED: Remove enable_recognize_route and span_naming options
 
-### v0.3.2 / 2022-11-16
+## v0.3.2 / 2022-11-16
 
 - FIXED: Loosen dependency on Rack
 
-### v0.3.1 / 2022-10-27
+## v0.3.1 / 2022-10-27
 
 - FIXED: Declare span_naming option in action_pack instrumentation
 
-### v0.3.0 / 2022-10-14
+## v0.3.0 / 2022-10-14
 
 - ADDED: Name ActionPack spans with the HTTP method and route
 
-### v0.2.1 / 2022-10-04
+## v0.2.1 / 2022-10-04
 
 - FIXED: Ensures the correct route is add to http.route span attribute
 
-### v0.2.0 / 2022-06-09
+## v0.2.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.1.4 / 2022-05-02
+## v0.1.4 / 2022-05-02
 
 - FIXED: Use rails request's filtered path as http.target attribute
 - FIXED: RubyGems Fallback
 
-### v0.1.3 / 2021-12-01
+## v0.1.3 / 2021-12-01
 
 - FIXED: Instrumentation of Rails 7
 
-### v0.1.2 / 2021-10-06
+## v0.1.2 / 2021-10-06
 
 - FIXED: Prevent high cardinality rack span name as a default
 
-### v0.1.1 / 2021-09-29
+## v0.1.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.1.0 / 2021-08-12
+## v0.1.0 / 2021-08-12
 
 - Initial release.

--- a/instrumentation/action_view/CHANGELOG.md
+++ b/instrumentation/action_view/CHANGELOG.md
@@ -1,100 +1,100 @@
 # Release History: opentelemetry-instrumentation-action_view
 
-### v0.11.2 / 2026-01-06
+## v0.11.2 / 2026-01-06
 
 - DOCS: Update ActionView Documentation
 
-### v0.11.1 / 2025-10-22
+## v0.11.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.11.0 / 2025-10-21
+## v0.11.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.10.0 / 2025-09-30
+## v0.10.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.9.0 / 2025-01-16
+## v0.9.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.8.0 / 2024-12-19
+## v0.8.0 / 2024-12-19
 
 - ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
-### v0.7.3 / 2024-08-23
+## v0.7.3 / 2024-08-23
 
 - FIXED: ActionView Support Legacy Formats
 
-### v0.7.2 / 2024-08-15
+## v0.7.2 / 2024-08-15
 
 - (No Significant Changes)
 
-### v0.7.1 / 2024-07-23
+## v0.7.1 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.7.0 / 2023-11-22
+## v0.7.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 
-### v0.6.1 / 2023-10-16
+## v0.6.1 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.6.0 / 2023-06-05
+## v0.6.0 / 2023-06-05
 
 - ADDED: Render layout for action view
 - FIXED: Base config options
 
-### v0.5.0 / 2023-04-17
+## v0.5.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.4.0 / 2023-02-01
+## v0.4.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 
-### v0.3.1 / 2023-01-14
+## v0.3.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.3.0 / 2022-06-09
+## v0.3.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.2.1 / 2022-05-02
+## v0.2.1 / 2022-05-02
 
 - FIXED: RubyGems Fallback
 
-### v0.2.0 / 2021-12-01
+## v0.2.0 / 2021-12-01
 
 - ADDED: Move activesupport notification subscriber out of action_view gem
 - FIXED: Instrumentation of Rails 7
 
-### v0.1.3 / 2021-10-06
+## v0.1.3 / 2021-10-06
 
 - FIXED: Do not replace fan-out
 
-### v0.1.2 / 2021-09-29
+## v0.1.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.1.1 / 2021-09-09
+## v0.1.1 / 2021-09-09
 
 - FIXED: Keep Active Support subscriptions intact when patching
 
-### v0.1.0 / 2021-08-12
+## v0.1.0 / 2021-08-12
 
 - Initial release.

--- a/instrumentation/action_view/CHANGELOG.md
+++ b/instrumentation/action_view/CHANGELOG.md
@@ -2,99 +2,99 @@
 
 ### v0.11.2 / 2026-01-06
 
-* DOCS: Update ActionView Documentation
+- DOCS: Update ActionView Documentation
 
 ### v0.11.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.11.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.9.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.8.0 / 2024-12-19
 
-* ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
+- ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
 ### v0.7.3 / 2024-08-23
 
-* FIXED: ActionView Support Legacy Formats
+- FIXED: ActionView Support Legacy Formats
 
 ### v0.7.2 / 2024-08-15
 
-* (No Significant Changes)
+- (No Significant Changes)
 
 ### v0.7.1 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.7.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
 
 ### v0.6.1 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.6.0 / 2023-06-05
 
-* ADDED: Render layout for action view
-* FIXED: Base config options
+- ADDED: Render layout for action view
+- FIXED: Base config options
 
 ### v0.5.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.4.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
 
 ### v0.3.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.3.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.2.1 / 2022-05-02
 
-* FIXED: RubyGems Fallback
+- FIXED: RubyGems Fallback
 
 ### v0.2.0 / 2021-12-01
 
-* ADDED: Move activesupport notification subscriber out of action_view gem
-* FIXED: Instrumentation of Rails 7
+- ADDED: Move activesupport notification subscriber out of action_view gem
+- FIXED: Instrumentation of Rails 7
 
 ### v0.1.3 / 2021-10-06
 
-* FIXED: Do not replace fan-out
+- FIXED: Do not replace fan-out
 
 ### v0.1.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.1 / 2021-09-09
 
-* FIXED: Keep Active Support subscriptions intact when patching
+- FIXED: Keep Active Support subscriptions intact when patching
 
 ### v0.1.0 / 2021-08-12
 
-* Initial release.
+- Initial release.

--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -65,7 +65,7 @@
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 - BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Monkey Patches
-- CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
+- CHANGED: Use ActiveSupport Instrumentation instead of Monkey Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
 
 ## v0.6.1 / 2023-10-16
 

--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -2,135 +2,135 @@
 
 ### v0.10.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.10.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.9.2 / 2025-10-07
 
-* DOCS: Enhance README
+- DOCS: Enhance README
 
 ### v0.9.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.9.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.8.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.7.8 / 2024-10-24
 
-* FIXED: ActiveJob Propagate baggage information properly when performing
+- FIXED: ActiveJob Propagate baggage information properly when performing
 
 ### v0.7.7 / 2024-08-21
 
-* FIXED: Propagate context between enqueue and perform
+- FIXED: Propagate context between enqueue and perform
 
 ### v0.7.6 / 2024-08-15
 
-* FIXED: Prefix ::ActiveSupport when installing the instrumentation
+- FIXED: Prefix ::ActiveSupport when installing the instrumentation
 
 ### v0.7.5 / 2024-08-15
 
-* FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
+- FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
 
 ### v0.7.4 / 2024-07-30
 
-* FIXED: Honour dynamic changes in configuration
+- FIXED: Honour dynamic changes in configuration
 
 ### v0.7.3 / 2024-07-22
 
-* FIXED: ActiveJob::Handlers.unsubscribe
+- FIXED: ActiveJob::Handlers.unsubscribe
 
 ### v0.7.2 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.7.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.7.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
-* BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Monkey Patches
-* CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Monkey Patches
+- CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
 
 ### v0.6.1 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.6.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.5.2 / 2023-08-03
 
-* FIXED: Add code semconv attributes
-* FIXED: Remove inline linter rules
+- FIXED: Add code semconv attributes
+- FIXED: Remove inline linter rules
 
 ### v0.5.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.5.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.4.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
 
 ### v0.3.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.3.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.2.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* ADDED: Make the context available in ActiveJob notifications
-* FIXED: Fix deserialization of jobs that are missing metadata
-* FIXED: RubyGems Fallback
+- ADDED: Validate Using Enums
+- ADDED: Make the context available in ActiveJob notifications
+- FIXED: Fix deserialization of jobs that are missing metadata
+- FIXED: RubyGems Fallback
 
 ### v0.1.5 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.4 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.3 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.2 / 2021-07-01
 
-* FIXED: Support Active Jobs with keyword args across ruby versions  
+- FIXED: Support Active Jobs with keyword args across ruby versions
 
 ### v0.1.1 / 2021-06-29
 
-* FIXED: Compatibility with RC2 span status api changes [845](https://github.com/open-telemetry/opentelemetry-ruby/pull/845)
+- FIXED: Compatibility with RC2 span status api changes [845](https://github.com/open-telemetry/opentelemetry-ruby/pull/845)
 
 ### v0.1.0 / 2021-06-23
 
-* Initial release.
+- Initial release.

--- a/instrumentation/active_job/CHANGELOG.md
+++ b/instrumentation/active_job/CHANGELOG.md
@@ -1,136 +1,136 @@
 # Release History: opentelemetry-instrumentation-active_job
 
-### v0.10.1 / 2025-10-22
+## v0.10.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.10.0 / 2025-10-21
+## v0.10.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.9.2 / 2025-10-07
+## v0.9.2 / 2025-10-07
 
 - DOCS: Enhance README
 
-### v0.9.1 / 2025-09-30
+## v0.9.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.9.0 / 2025-09-30
+## v0.9.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.8.0 / 2025-01-16
+## v0.8.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.7.8 / 2024-10-24
+## v0.7.8 / 2024-10-24
 
 - FIXED: ActiveJob Propagate baggage information properly when performing
 
-### v0.7.7 / 2024-08-21
+## v0.7.7 / 2024-08-21
 
 - FIXED: Propagate context between enqueue and perform
 
-### v0.7.6 / 2024-08-15
+## v0.7.6 / 2024-08-15
 
 - FIXED: Prefix ::ActiveSupport when installing the instrumentation
 
-### v0.7.5 / 2024-08-15
+## v0.7.5 / 2024-08-15
 
 - FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
 
-### v0.7.4 / 2024-07-30
+## v0.7.4 / 2024-07-30
 
 - FIXED: Honour dynamic changes in configuration
 
-### v0.7.3 / 2024-07-22
+## v0.7.3 / 2024-07-22
 
 - FIXED: ActiveJob::Handlers.unsubscribe
 
-### v0.7.2 / 2024-07-02
+## v0.7.2 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.7.1 / 2023-11-23
+## v0.7.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.7.0 / 2023-11-22
+## v0.7.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 - BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Monkey Patches
 - CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
 
-### v0.6.1 / 2023-10-16
+## v0.6.1 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.6.0 / 2023-09-07
+## v0.6.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.5.2 / 2023-08-03
+## v0.5.2 / 2023-08-03
 
 - FIXED: Add code semconv attributes
 - FIXED: Remove inline linter rules
 
-### v0.5.1 / 2023-06-05
+## v0.5.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.5.0 / 2023-04-17
+## v0.5.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.4.0 / 2023-02-01
+## v0.4.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 
-### v0.3.1 / 2023-01-14
+## v0.3.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.3.0 / 2022-06-09
+## v0.3.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.2.0 / 2022-05-02
+## v0.2.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - ADDED: Make the context available in ActiveJob notifications
 - FIXED: Fix deserialization of jobs that are missing metadata
 - FIXED: RubyGems Fallback
 
-### v0.1.5 / 2021-12-02
+## v0.1.5 / 2021-12-02
 
 - (No significant changes)
 
-### v0.1.4 / 2021-09-29
+## v0.1.4 / 2021-09-29
 
 - (No significant changes)
 
-### v0.1.3 / 2021-08-12
+## v0.1.3 / 2021-08-12
 
 - (No significant changes)
 
-### v0.1.2 / 2021-07-01
+## v0.1.2 / 2021-07-01
 
 - FIXED: Support Active Jobs with keyword args across ruby versions
 
-### v0.1.1 / 2021-06-29
+## v0.1.1 / 2021-06-29
 
 - FIXED: Compatibility with RC2 span status api changes [845](https://github.com/open-telemetry/opentelemetry-ruby/pull/845)
 
-### v0.1.0 / 2021-06-23
+## v0.1.0 / 2021-06-23
 
 - Initial release.

--- a/instrumentation/active_model_serializers/CHANGELOG.md
+++ b/instrumentation/active_model_serializers/CHANGELOG.md
@@ -1,117 +1,117 @@
 # Release History: opentelemetry-instrumentation-active_model_serializers
 
-### v0.24.0 / 2025-10-22
+## v0.24.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.23.0 / 2025-09-30
+## v0.23.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.1 / 2025-01-07
+## v0.21.1 / 2025-01-07
 
 - DOCS: Update action for link check and fix one broken link
 
-### v0.21.0 / 2024-12-19
+## v0.21.0 / 2024-12-19
 
 - ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
-### v0.20.3 / 2024-12-04
+## v0.20.3 / 2024-12-04
 
 - FIXED: Use ActiveSupport::Notifications subscriber to serialize events.
 
-### v0.20.2 / 2024-07-23
+## v0.20.2 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.20.1 / 2023-06-05
+## v0.20.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.20.0 / 2023-04-17
+## v0.20.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.19.1 / 2023-01-14
+## v0.19.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.19.0 / 2022-06-09
+## v0.19.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.18.5 / 2022-05-02
+## v0.18.5 / 2022-05-02
 
 - FIXED: `ActiveSupport` constant conflict in Active Model Serializers instrumentation
 - FIXED: RubyGems Fallback
 
-### v0.18.4 / 2021-12-02
+## v0.18.4 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - (No significant changes)
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.1 / 2020-12-09
+## v0.10.1 / 2020-12-09
 
 - FIXED: Active_model_serializers installer
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-03
+## v0.9.0 / 2020-11-03
 
 - Initial release of Active Model Serializers Instrumentation (ported from Datadog)

--- a/instrumentation/active_model_serializers/CHANGELOG.md
+++ b/instrumentation/active_model_serializers/CHANGELOG.md
@@ -2,116 +2,116 @@
 
 ### v0.24.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.23.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.1 / 2025-01-07
 
-* DOCS: Update action for link check and fix one broken link
+- DOCS: Update action for link check and fix one broken link
 
 ### v0.21.0 / 2024-12-19
 
-* ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
+- ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
 ### v0.20.3 / 2024-12-04
 
-* FIXED: Use ActiveSupport::Notifications subscriber to serialize events.
+- FIXED: Use ActiveSupport::Notifications subscriber to serialize events.
 
 ### v0.20.2 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-02
 
-* FIXED: `ActiveSupport` constant conflict in Active Model Serializers instrumentation
-* FIXED: RubyGems Fallback
+- FIXED: `ActiveSupport` constant conflict in Active Model Serializers instrumentation
+- FIXED: RubyGems Fallback
 
 ### v0.18.4 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.1 / 2020-12-09
 
-* FIXED: Active_model_serializers installer
+- FIXED: Active_model_serializers installer
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-03
 
-* Initial release of Active Model Serializers Instrumentation (ported from Datadog)
+- Initial release of Active Model Serializers Instrumentation (ported from Datadog)

--- a/instrumentation/active_record/CHANGELOG.md
+++ b/instrumentation/active_record/CHANGELOG.md
@@ -2,112 +2,112 @@
 
 ### v0.11.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.11.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.10.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.9.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.8.1 / 2024-11-21
 
-* FIXED: Pass block argument in ActiveRecord `find_by_sql` patch.
+- FIXED: Pass block argument in ActiveRecord `find_by_sql` patch.
 
 ### v0.8.0 / 2024-10-22
 
-* BREAKING CHANGE: Rename Active Record find_by_sql spans to query
-* FIXED: Emit Active Record query spans for Rails 7.0+
+- BREAKING CHANGE: Rename Active Record find_by_sql spans to query
+- FIXED: Emit Active Record query spans for Rails 7.0+
 
 ### v0.7.4 / 2024-08-19
 
-* FIXED: Use ActiveSupport from top-level namespace (NoMethodError on_load)
+- FIXED: Use ActiveSupport from top-level namespace (NoMethodError on_load)
 
 ### v0.7.3 / 2024-08-15
 
-* FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
+- FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
 
 ### v0.7.2 / 2024-04-30
 
-* FIXED: Resolve active_record testing issue
+- FIXED: Resolve active_record testing issue
 
 ### v0.7.1 / 2024-04-05
 
-* FIXED: Instrumentation/active_record: add `:allow_retry` option to `find_by_sql` patch
+- FIXED: Instrumentation/active_record: add `:allow_retry` option to `find_by_sql` patch
 
 ### v0.7.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
 
 ### v0.6.3 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.6.2 / 2023-08-14
 
-* FIXED: Ensure that transaction name property is used, rather than self
+- FIXED: Ensure that transaction name property is used, rather than self
 
 ### v0.6.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.6.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.5.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
 
 ### v0.4.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.4.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.3.0 / 2022-05-02
 
-* ADDED: Make ActiveRecord 7 compatible
-* FIXED: RubyGems Fallback
+- ADDED: Make ActiveRecord 7 compatible
+- FIXED: RubyGems Fallback
 
 ### v0.2.2 / 2021-12-01
 
-* FIXED: Add max supported version for active record
+- FIXED: Add max supported version for active record
 
 ### v0.2.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.2.0 / 2021-09-29
 
-* ADDED: Trace update_all and delete_all calls in ActiveRecord
-* FIXED: Remove Active Record instantiation patch
+- ADDED: Trace update_all and delete_all calls in ActiveRecord
+- FIXED: Remove Active Record instantiation patch
 
 ### v0.1.1 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2021-07-08
 
-* Initial release, adds instrumentation patches to querying and persistence methods.
+- Initial release, adds instrumentation patches to querying and persistence methods.

--- a/instrumentation/active_record/CHANGELOG.md
+++ b/instrumentation/active_record/CHANGELOG.md
@@ -1,113 +1,113 @@
 # Release History: opentelemetry-instrumentation-active_record
 
-### v0.11.1 / 2025-10-22
+## v0.11.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.11.0 / 2025-10-21
+## v0.11.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.10.1 / 2025-09-30
+## v0.10.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.10.0 / 2025-09-30
+## v0.10.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.9.0 / 2025-01-16
+## v0.9.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.8.1 / 2024-11-21
+## v0.8.1 / 2024-11-21
 
 - FIXED: Pass block argument in ActiveRecord `find_by_sql` patch.
 
-### v0.8.0 / 2024-10-22
+## v0.8.0 / 2024-10-22
 
 - BREAKING CHANGE: Rename Active Record find_by_sql spans to query
 - FIXED: Emit Active Record query spans for Rails 7.0+
 
-### v0.7.4 / 2024-08-19
+## v0.7.4 / 2024-08-19
 
 - FIXED: Use ActiveSupport from top-level namespace (NoMethodError on_load)
 
-### v0.7.3 / 2024-08-15
+## v0.7.3 / 2024-08-15
 
 - FIXED: Use Active Support Lazy Load Hooks to avoid prematurely initializing ActiveRecord::Base and ActiveJob::Base
 
-### v0.7.2 / 2024-04-30
+## v0.7.2 / 2024-04-30
 
 - FIXED: Resolve active_record testing issue
 
-### v0.7.1 / 2024-04-05
+## v0.7.1 / 2024-04-05
 
 - FIXED: Instrumentation/active_record: add `:allow_retry` option to `find_by_sql` patch
 
-### v0.7.0 / 2023-11-22
+## v0.7.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 
-### v0.6.3 / 2023-10-16
+## v0.6.3 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.6.2 / 2023-08-14
+## v0.6.2 / 2023-08-14
 
 - FIXED: Ensure that transaction name property is used, rather than self
 
-### v0.6.1 / 2023-06-05
+## v0.6.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.6.0 / 2023-04-17
+## v0.6.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.5.0 / 2023-02-01
+## v0.5.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 
-### v0.4.1 / 2023-01-14
+## v0.4.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.4.0 / 2022-06-09
+## v0.4.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.3.0 / 2022-05-02
+## v0.3.0 / 2022-05-02
 
 - ADDED: Make ActiveRecord 7 compatible
 - FIXED: RubyGems Fallback
 
-### v0.2.2 / 2021-12-01
+## v0.2.2 / 2021-12-01
 
 - FIXED: Add max supported version for active record
 
-### v0.2.1 / 2021-09-29
+## v0.2.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.2.0 / 2021-09-29
+## v0.2.0 / 2021-09-29
 
 - ADDED: Trace update_all and delete_all calls in ActiveRecord
 - FIXED: Remove Active Record instantiation patch
 
-### v0.1.1 / 2021-08-12
+## v0.1.1 / 2021-08-12
 
 - (No significant changes)
 
-### v0.1.0 / 2021-07-08
+## v0.1.0 / 2021-07-08
 
 - Initial release, adds instrumentation patches to querying and persistence methods.

--- a/instrumentation/active_storage/CHANGELOG.md
+++ b/instrumentation/active_storage/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 ### v0.3.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.3.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.2.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.1.1 / 2025-03-05
 
-* FIXED: ActiveStorage OTel API Constraints
+- FIXED: ActiveStorage OTel API Constraints
 
 ### v0.1.0 / 2025-01-29
 
-Initial release!
+- Initial release!

--- a/instrumentation/active_storage/CHANGELOG.md
+++ b/instrumentation/active_storage/CHANGELOG.md
@@ -1,22 +1,22 @@
 # Release History: opentelemetry-instrumentation-active_storage
 
-### v0.3.1 / 2025-10-22
+## v0.3.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.3.0 / 2025-10-21
+## v0.3.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.2.0 / 2025-09-30
+## v0.2.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.1.1 / 2025-03-05
+## v0.1.1 / 2025-03-05
 
 - FIXED: ActiveStorage OTel API Constraints
 
-### v0.1.0 / 2025-01-29
+## v0.1.0 / 2025-01-29
 
 - Initial release!

--- a/instrumentation/active_support/CHANGELOG.md
+++ b/instrumentation/active_support/CHANGELOG.md
@@ -2,61 +2,61 @@
 
 ### v0.10.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.10.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.9.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.9.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.8.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.7.0 / 2024-12-19
 
-* ADDED: Enable support for `Regexp` patterns when subscribing to Active Support's instrumentation Events
+- ADDED: Enable support for `Regexp` patterns when subscribing to Active Support's instrumentation Events
 
 ### v0.6.0 / 2024-07-02
 
-* BREAKING CHANGE: Custom ActiveSupport Span Names
-* ADDED: Custom ActiveSupport Span Names
+- BREAKING CHANGE: Custom ActiveSupport Span Names
+- ADDED: Custom ActiveSupport Span Names
 
 ### v0.5.3 / 2024-06-20
 
-* FIXED: Include span kind in ActiveSupport Instrumentation helper
+- FIXED: Include span kind in ActiveSupport Instrumentation helper
 
 ### v0.5.2 / 2024-06-20
 
-* ADDED: ActiveSupport user specified span kind
+- ADDED: ActiveSupport user specified span kind
 
 ### v0.5.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.5.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
 
 ### v0.4.4 / 2023-10-31
 
-* FIXED: Remove call to ActiveSupport::Notifications.notifier#synchronize deprecated in Rails 7.2
+- FIXED: Remove call to ActiveSupport::Notifications.notifier#synchronize deprecated in Rails 7.2
 
 ### v0.4.3 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.4.2 / 2023-09-07
 
@@ -64,40 +64,40 @@ FIXED: Reduce Object allocation
 
 ### v0.4.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.4.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.3.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
 
 ### v0.2.2 / 2023-01-14
 
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
+- FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.2.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.2.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.1.2 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.1 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2021-11-09
 
-* Initial release.
+- Initial release.

--- a/instrumentation/active_support/CHANGELOG.md
+++ b/instrumentation/active_support/CHANGELOG.md
@@ -1,103 +1,103 @@
 # Release History: opentelemetry-instrumentation-active_support
 
-### v0.10.1 / 2025-10-22
+## v0.10.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.10.0 / 2025-10-21
+## v0.10.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.9.1 / 2025-09-30
+## v0.9.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.9.0 / 2025-09-30
+## v0.9.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.8.0 / 2025-01-16
+## v0.8.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.7.0 / 2024-12-19
+## v0.7.0 / 2024-12-19
 
 - ADDED: Enable support for `Regexp` patterns when subscribing to Active Support's instrumentation Events
 
-### v0.6.0 / 2024-07-02
+## v0.6.0 / 2024-07-02
 
 - BREAKING CHANGE: Custom ActiveSupport Span Names
 - ADDED: Custom ActiveSupport Span Names
 
-### v0.5.3 / 2024-06-20
+## v0.5.3 / 2024-06-20
 
 - FIXED: Include span kind in ActiveSupport Instrumentation helper
 
-### v0.5.2 / 2024-06-20
+## v0.5.2 / 2024-06-20
 
 - ADDED: ActiveSupport user specified span kind
 
-### v0.5.1 / 2023-11-23
+## v0.5.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.5.0 / 2023-11-22
+## v0.5.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 
-### v0.4.4 / 2023-10-31
+## v0.4.4 / 2023-10-31
 
 - FIXED: Remove call to ActiveSupport::Notifications.notifier#synchronize deprecated in Rails 7.2
 
-### v0.4.3 / 2023-10-16
+## v0.4.3 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.4.2 / 2023-09-07
+## v0.4.2 / 2023-09-07
 
 FIXED: Reduce Object allocation
 
-### v0.4.1 / 2023-06-05
+## v0.4.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.4.0 / 2023-04-17
+## v0.4.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.3.0 / 2023-02-01
+## v0.3.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 
-### v0.2.2 / 2023-01-14
+## v0.2.2 / 2023-01-14
 
 - FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
-### v0.2.1 / 2023-01-14
+## v0.2.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.2.0 / 2022-06-09
+## v0.2.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.1.2 / 2022-05-05
+## v0.1.2 / 2022-05-05
 
 - (No significant changes)
 
-### v0.1.1 / 2021-12-02
+## v0.1.1 / 2021-12-02
 
 - (No significant changes)
 
-### v0.1.0 / 2021-11-09
+## v0.1.0 / 2021-11-09
 
 - Initial release.

--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -1,41 +1,41 @@
 # Release History: opentelemetry-instrumentation-all
 
-### v0.91.0 / 2026-03-17
+## v0.91.0 / 2026-03-17
 
-* ADDED: Upgrade opentelemetry-instrumentation-anthropic to 0.4.0
-* ADDED: Upgrade opentelemetry-instrumentation-dalli to 0.29.2
-* ADDED: Upgrade opentelemetry-instrumentation-ethon to 0.28.0
-* ADDED: Upgrade opentelemetry-instrumentation-excon to 0.28.0
-* ADDED: Upgrade opentelemetry-instrumentation-faraday to 0.32.0
-* ADDED: Upgrade opentelemetry-instrumentation-grape to 0.6.0
-* ADDED: Upgrade opentelemetry-instrumentation-graphql to 0.31.2
-* ADDED: Upgrade opentelemetry-instrumentation-http to 0.29.0
-* ADDED: Upgrade opentelemetry-instrumentation-http_client to 0.28.0
-* ADDED: Upgrade opentelemetry-instrumentation-httpx to 0.7.0
-* ADDED: Upgrade opentelemetry-instrumentation-net_http to 0.28.0
-* ADDED: Upgrade opentelemetry-instrumentation-racecar to 0.6.1
-* ADDED: Upgrade opentelemetry-instrumentation-rack to 0.30.0
-* ADDED: Upgrade opentelemetry-instrumentation-rails to 0.40.0
-* ADDED: Upgrade opentelemetry-instrumentation-restclient to 0.27.0
-* ADDED: Upgrade opentelemetry-instrumentation-sinatra to 0.29.0
-* ADDED: Upgrade opentelemetry-instrumentation-trilogy to 0.67.0
+- ADDED: Upgrade opentelemetry-instrumentation-anthropic to 0.4.0
+- ADDED: Upgrade opentelemetry-instrumentation-dalli to 0.29.2
+- ADDED: Upgrade opentelemetry-instrumentation-ethon to 0.28.0
+- ADDED: Upgrade opentelemetry-instrumentation-excon to 0.28.0
+- ADDED: Upgrade opentelemetry-instrumentation-faraday to 0.32.0
+- ADDED: Upgrade opentelemetry-instrumentation-grape to 0.6.0
+- ADDED: Upgrade opentelemetry-instrumentation-graphql to 0.31.2
+- ADDED: Upgrade opentelemetry-instrumentation-http to 0.29.0
+- ADDED: Upgrade opentelemetry-instrumentation-http_client to 0.28.0
+- ADDED: Upgrade opentelemetry-instrumentation-httpx to 0.7.0
+- ADDED: Upgrade opentelemetry-instrumentation-net_http to 0.28.0
+- ADDED: Upgrade opentelemetry-instrumentation-racecar to 0.6.1
+- ADDED: Upgrade opentelemetry-instrumentation-rack to 0.30.0
+- ADDED: Upgrade opentelemetry-instrumentation-rails to 0.40.0
+- ADDED: Upgrade opentelemetry-instrumentation-restclient to 0.27.0
+- ADDED: Upgrade opentelemetry-instrumentation-sinatra to 0.29.0
+- ADDED: Upgrade opentelemetry-instrumentation-trilogy to 0.67.0
 
-### v0.90.1 / 2026-01-13
+## v0.90.1 / 2026-01-13
 
 - ADDED: Fixed release version
 
-### v0.90.0 / 2025-01-13
+## v0.90.0 / 2025-01-13
 
 - ADDED: Add SQL Comment Propagator
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.89.1 / 2025-12-03
+## v0.89.1 / 2025-12-03
 
 - ADDED: Upgrade trilogy instrumentation to 0.65.1
 - ADDED: Upgrade mysql2 instrumentation to 0.32.1
 - ADDED: Upgrade pg instrumentation to 0.34.1
 
-### v0.89.0 / 2025-12-02
+## v0.89.0 / 2025-12-02
 
 - ADDED: Upgrade trilogy instrumentation to 0.65.0
 - ADDED: Upgrade mysql2 instrumentation to 0.32.0
@@ -43,51 +43,51 @@
 - ADDED: Upgrade que instrumentation to 0.12.0
 - ADDED: Upgrade sidekiq instrumentation to 0.28.1
 
-### v0.88.0 / 2025-11-26
+## v0.88.0 / 2025-11-26
 
 - BREAKING CHANGE: Update Ethon span name when unknown method
 - ADDED: Update Ethon span name when unknown method
 
-### v0.87.0 / 2025-11-05
+## v0.87.0 / 2025-11-05
 
 - ADDED: upgrade opentelemetry-instrumentation-pg to 0.33.0
 
-### v0.86.1 / 2025-10-22
+## v0.86.1 / 2025-10-22
 
 - ADDED: Updated minimum gem versions for dependent instrumentations
 
-### v0.86.0 / 2025-10-21
+## v0.86.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Version Support For Ruby 3.2 and Rails 7.1
 - ADDED: Min Version Support For Ruby 3.2 and Rails 7.1
 
-### v0.85.0 / 2025-10-11
+## v0.85.0 / 2025-10-11
 
 - BREAKING CHANGE: aws_sdk Suppress internal spans by default
 
-### v0.84.0 / 2025-09-27
+## v0.84.0 / 2025-09-27
 
 - ADDED: Minimum version of opentelemetry-api v1.7.0
 
-### v0.83.0 / 2025-09-27
+## v0.83.0 / 2025-09-27
 
 - ADDED: Update trilogy instrumentation to v0.62.0
 
-### v0.82.0 / 2025-09-18
+## v0.82.0 / 2025-09-18
 
 - BREAKING CHANGE: AWS Lambda: Check if span has the attributes method to avoid internal error
 - FIXED: AWS Lambda: Check if span has the attributes method to avoid internal error
 
-### v0.81.0 / 2025-09-16
+## v0.81.0 / 2025-09-16
 
 - ADDED: Anthropic initial instrumentation
 - ADDED: Add Net::HTTP `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
 
-### v0.80.0 / 2025-08-19
+## v0.80.0 / 2025-08-19
 
 ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack. This includes an integration with Action Pack (Rails) and Sinatra instrumentation libraries. [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
-### v0.79.0 / 2025-08-18
+## v0.79.0 / 2025-08-18
 
 - ADDED: Add HTTPX instrumentation to all
 - ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
@@ -97,144 +97,144 @@ ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility fo
 - ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
 - ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
 
-### v0.78.0 / 2025-06-17
+## v0.78.0 / 2025-06-17
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to HTTP.rb instrumentation [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
 
-### v0.77.0 / 2025-06-03
+## v0.77.0 / 2025-06-03
 
 - ADDED: Suppress internal spans with Faraday instrumentation
 - FIXED: Handle force_flush for rake task with arguments
 
-### v0.76.0 / 2025-05-06
+## v0.76.0 / 2025-05-06
 
 - ADDED: Update minimum required version of rdkafka to 0.18.0
 
-### v0.75.1 / 2025-04-16
+## v0.75.1 / 2025-04-16
 
 - (No significant changes)
 
-### v0.75.0 / 2025-04-15
+## v0.75.0 / 2025-04-15
 
 - ADDED: Add `opentelemetry-instrumentation-grpc` to `-all`
 - ADDED: Support meta protocol instrumentation for Dalli
 
-### v0.74.0 / 2025-02-11
+## v0.74.0 / 2025-02-11
 
 - ADDED: Rdkafka support to v0.19 including
 
-### v0.73.1 / 2025-02-05
+## v0.73.1 / 2025-02-05
 
 - FIXED: Add require active_storage instrumentation to `all`
 
-### v0.73.0 / 2025-02-04
+## v0.73.0 / 2025-02-04
 
 - CHANGED: opentelemetry-instrumentation-redis v0.26.1
 - CHANGED: opentelemetry-instrumentation-rails v0.36.0
 - CHANGED: opentelemetry-instrumentation-aws_lambda v0.3.0
 - CHANGED: opentelemetry-instrumentation-action_pack v0.12.0
 
-### v0.72.0 / 2025-01-16
+## v0.72.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.71.1 / 2025-01-14
+## v0.71.1 / 2025-01-14
 
 - No Significant Changes
 
-### v0.71.0 / 2025-01-07
+## v0.71.0 / 2025-01-07
 
 - ADDED: Faraday Minimum v1.0
 
-### v0.70.0 / 2024-12-19
+## v0.70.0 / 2024-12-19
 
 - ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
-### v0.69.1 / 2024-11-26
+## v0.69.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.69.0 / 2024-11-19
+## v0.69.0 / 2024-11-19
 
 - ADDED: Use Semconv Naming For ActionPack
 
-### v0.68.0 / 2024-10-23
+## v0.68.0 / 2024-10-23
 
 - ADDED: Set span error only for 5xx response range
 
-### v0.67.0 / 2024-10-22
+## v0.67.0 / 2024-10-22
 
 - BREAKING CHANGE: Rename Active Record find_by_sql spans to query
 - FIXED: Emit Active Record query spans for Rails 7.0+
 - ADDED: Subscribe to process.action_mailer notifications
 
-### v0.66.0 / 2024-10-08
+## v0.66.0 / 2024-10-08
 
 - ADDED: Integration with V3 telemetry provider for the aws-sdk
 
-### v0.65.0 / 2024-09-19
+## v0.65.0 / 2024-09-19
 
 - ADDED: All AWS services emit traces
 
-### v0.64.0 / 2024-09-12
+## v0.64.0 / 2024-09-12
 
 - BREAKING CHANGE: Return message when sql is over the obfuscation limit. Fixes a bug where sql statements with prepended comments that hit the obfuscation limit would be sent raw.
 
-### v0.63.0 / 2024-08-15
+## v0.63.0 / 2024-08-15
 
 - ADDED: Collect pg db.collection_name attribute
 
-### v0.62.1 / 2024-07-23
+## v0.62.1 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.62.0 / 2024-07-02
+## v0.62.0 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 - CHANGED: Update Rails Instrumentation
 - CHANGED: Update Grape Instrumentation
 - CHANGED: Update Sinatra Instrumentation
 
-### v0.61.0 / 2024-06-04
+## v0.61.0 / 2024-06-04
 
 - ADDED: Add aws lambda to instrumentation-all
 - FIXED: Add action_mailer to rails and all
 
-### v0.60.0 / 2024-02-20
+## v0.60.0 / 2024-02-20
 
 - ADDED: Add support gruf 2.19
 - ADDED: Faraday add support for internal spans
 
-### v0.59.0 / 2024-02-16
+## v0.59.0 / 2024-02-16
 
 - BREAKING CHANGE: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
 
-### v0.58.0 / 2024-02-15
+## v0.58.0 / 2024-02-15
 
 - CHANGED: upgrade mysql2 instrumentation
 
-### v0.57.0 / 2024-02-08
+## v0.57.0 / 2024-02-08
 
 - BREAKING CHANGE: Move shared sql behavior to helper gems
 
-### v0.56.0 / 2024-01-09
+## v0.56.0 / 2024-01-09
 
 - BREAKING CHANGE: Use ActiveSupport instead of patches #703
 
-### v0.55.0 / 2024-01-06
+## v0.55.0 / 2024-01-06
 
 - CHANGED: Upgrade Trilogy and Rack [#796](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/796)
 
-### v0.54.0 / 2023-11-28
+## v0.54.0 / 2023-11-28
 
 - ADDED: Updated excon to include connect spans
 
-### v0.53.0 / 2023-11-28
+## v0.53.0 / 2023-11-28
 
 - CHANGED: Performance optimization cache attribute hashes [#723](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/723)
 
-### v0.52.0 / 2023-11-21
+## v0.52.0 / 2023-11-21
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.0 [#680](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/680)
 - BREAKING CHANGE: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
@@ -242,70 +242,70 @@ ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility fo
 - CHANGED: Drop Support for EoL Rails 6.0 [#680](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/680)
 - CHANGED: Use ActiveSupport Instrumentation instead of Money Patches [#677](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/677)
 
-### v0.51.1 / 2023-10-27
+## v0.51.1 / 2023-10-27
 
 - ADDED: Instrument connect and ping (Trilogy)
 
-### v0.51.0 / 2023-10-16
+## v0.51.0 / 2023-10-16
 
 - CHANGED: See [#695](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/695) for details
 
-### v0.50.1 / 2023-09-07
+## v0.50.1 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names (Resque)
 
-### v0.50.0 / 2023-09-07
+## v0.50.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.40.0 / 2023-08-07
+## v0.40.0 / 2023-08-07
 
 - ADDED: Add Gruf instrumentation
 
-### v0.39.1 / 2023-06-05
+## v0.39.1 / 2023-06-05
 
 - FIXED: Use latest bug fix version for all dependencies
 
-### v0.39.0 / 2023-06-02
+## v0.39.0 / 2023-06-02
 
 - BREAKING CHANGE: Separate logical MySQL host from connected host
 - ADDED: Separate logical MySQL host from connected host
 
-### v0.38.0 / 2023-05-31
+## v0.38.0 / 2023-05-31
 
 - BREAKING CHANGE: Add database name for trilogy traces
 
 - ADDED: Add database name for trilogy traces
 
-### v0.37.0 / 2023-05-25
+## v0.37.0 / 2023-05-25
 
 - ADDED: Add config[:obfuscation_limit] to pg and mysql2
 - ADDED: Add Obfuscation Limit Option to Trilogy
 
-### v0.36.0 / 2023-05-18
+## v0.36.0 / 2023-05-18
 
 - ADDED: GraphQL instrumentation: support new tracing API (#453)
 - ADDED: Add span_preprocessor hook (#456)
 - ADDED: add db.operation attribute for dalli (#458)
 
-### v0.35.0 / 2023-04-21
+## v0.35.0 / 2023-04-21
 
 - ADDED: Re-add Grape instrumentation to opentelemetry-instrumentation-all
 
-### v0.34.0 / 2023-04-17
+## v0.34.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
 - ADDED: Drop support for EoL Ruby 2.7
 - ADDED: Add Grape instrumentation
 
-### v0.33.0 / 2023-03-15
+## v0.33.0 / 2023-03-15
 
 - BREAKING CHANGE: Add support for GraphQL 2.0.19
 
 - FIXED: Add support for GraphQL 2.0.19
 
-### v0.32.0 / 2023-03-13
+## v0.32.0 / 2023-03-13
 
 - BREAKING CHANGE: Lock graphql max version to 2.0.17
 - FIXED: Lock graphql max version to 2.0.17
@@ -313,151 +313,151 @@ ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility fo
 - ADDED: Add option to configure span name for trilogy
 - FIXED: Ensure encoding errors handled during SQL obfuscation for Trilogy
 
-### v0.31.0 / 2023-02-09
+## v0.31.0 / 2023-02-09
 
 - BREAKING CHANGE: Drop Rails 5 support [#324](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/324)
 
-### v0.30.0 / 2023-01-31
+## v0.30.0 / 2023-01-31
 
 - BREAKING CHANGE: Updates instrumentations [#303](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/303)
 
-### v0.29.0 / 2023-01-14
+## v0.29.0 / 2023-01-14
 
 - BREAKING CHANGE: includes minor version updates in [#271](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/271)
 
-### v0.28.1 / 2023-01-14
+## v0.28.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.28.0 / 2022-11-09
+## v0.28.0 / 2022-11-09
 
 - ADDED: Bump minimum gem versions for opentelemetry-instrumentation-all
 - ADDED: Instrumentation for racecar
 - CHANGED: Update rails instrumentation
 
-### v0.27.0 / 2022-10-14
+## v0.27.0 / 2022-10-14
 
 - CHANGED: Update Rails instrumentation
 
-### v0.26.0 / 2022-10-12
+## v0.26.0 / 2022-10-12
 
 - ADDED: Upgrade min instrumentation versions See For Details https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/134
 
-### v0.25.0 / 2022-06-09
+## v0.25.0 / 2022-06-09
 
 - Bump all dependencies to use base 0.21.0
 
-### v0.24.1 / 2022-05-05
+## v0.24.1 / 2022-05-05
 
 - (No significant changes)
 
-### v0.24.0 / 2022-05-02
+## v0.24.0 / 2022-05-02
 
 - ADDED: Adds instrumentation for rdkafka
 - FIXED: Add rdkafka to all
 
-### v0.23.0 / 2022-01-26
+## v0.23.0 / 2022-01-26
 
 - ADDED: Add Trilogy Auto Instrumentation
 - FIXED: `ActiveSupport` constant conflict in Active Model Serializers instrumentation
 - FIXED: add missing require for aws_sdk instrumentation #1054
 
-### v0.22.0 / 2021-12-01
+## v0.22.0 / 2021-12-01
 
 - ADDED: Move activesupport notification subscriber out of action_view gem
 
-### v0.21.3 / 2021-10-07
+## v0.21.3 / 2021-10-07
 
 - (No significant changes)
 
-### v0.21.2 / 2021-09-29
+## v0.21.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.21.1 / 2021-09-29
+## v0.21.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.21.0 / 2021-09-15
+## v0.21.0 / 2021-09-15
 
 - ADDED: Add Que instrumentation
 
-### v0.20.2 / 2021-09-09
+## v0.20.2 / 2021-09-09
 
 - (No significant changes)
 
-### v0.20.1 / 2021-08-18
+## v0.20.1 / 2021-08-18
 
 - FIXED: Instrumentation all sidekiq
 
-### v0.20.0 / 2021-08-12
+## v0.20.0 / 2021-08-12
 
 - ADDED: Instrument active record
 - ADDED: Add ActionView instrumentation via ActiveSupport::Notifications
 
-### v0.19.0 / 2021-06-25
+## v0.19.0 / 2021-06-25
 
 - ADDED: Add resque instrumentation
 - ADDED: Add ActiveJob instrumentation
 - ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
 - FIXED: Broken instrumentation all release
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Add koala instrumentation
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Add instrumentation for postgresql (pg gem)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - ADDED: Instrument http gem
 - ADDED: Instrument lmdb gem
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Instrument http client gem
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.1 / 2021-01-13
+## v0.12.1 / 2021-01-13
 
 - ADDED: Instrument RubyKafka
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - ADDED: Instrument graphql
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - FIXED: Otel-instrumentation-all not installing all
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - ADDED: Add common helpers
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - (No significant changes)
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - Now depends on version 0.6.x of all the individual instrumentation gems.

--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -22,66 +22,66 @@
 
 ### v0.90.1 / 2026-01-13
 
-* ADDED: Fixed release version
+- ADDED: Fixed release version
 
 ### v0.90.0 / 2025-01-13
 
-* ADDED: Add SQL Comment Propagator
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: Add SQL Comment Propagator
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.89.1 / 2025-12-03
 
-* ADDED: Upgrade trilogy instrumentation to 0.65.1
-* ADDED: Upgrade mysql2 instrumentation to 0.32.1
-* ADDED: Upgrade pg instrumentation to 0.34.1
+- ADDED: Upgrade trilogy instrumentation to 0.65.1
+- ADDED: Upgrade mysql2 instrumentation to 0.32.1
+- ADDED: Upgrade pg instrumentation to 0.34.1
 
 ### v0.89.0 / 2025-12-02
 
-* ADDED: Upgrade trilogy instrumentation to 0.65.0
-* ADDED: Upgrade mysql2 instrumentation to 0.32.0
-* ADDED: Upgrade pg instrumentation to 0.34.0
-* ADDED: Upgrade que instrumentation to 0.12.0
-* ADDED: Upgrade sidekiq instrumentation to 0.28.1
+- ADDED: Upgrade trilogy instrumentation to 0.65.0
+- ADDED: Upgrade mysql2 instrumentation to 0.32.0
+- ADDED: Upgrade pg instrumentation to 0.34.0
+- ADDED: Upgrade que instrumentation to 0.12.0
+- ADDED: Upgrade sidekiq instrumentation to 0.28.1
 
 ### v0.88.0 / 2025-11-26
 
-* BREAKING CHANGE: Update Ethon span name when unknown method
-* ADDED: Update Ethon span name when unknown method
+- BREAKING CHANGE: Update Ethon span name when unknown method
+- ADDED: Update Ethon span name when unknown method
 
 ### v0.87.0 / 2025-11-05
 
-* ADDED: upgrade opentelemetry-instrumentation-pg to 0.33.0
+- ADDED: upgrade opentelemetry-instrumentation-pg to 0.33.0
 
 ### v0.86.1 / 2025-10-22
 
-* ADDED: Updated minimum gem versions for dependent instrumentations
+- ADDED: Updated minimum gem versions for dependent instrumentations
 
 ### v0.86.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Version Support For Ruby 3.2 and Rails 7.1
-* ADDED: Min Version Support For Ruby 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Version Support For Ruby 3.2 and Rails 7.1
+- ADDED: Min Version Support For Ruby 3.2 and Rails 7.1
 
 ### v0.85.0 / 2025-10-11
 
-* BREAKING CHANGE: aws_sdk Suppress internal spans by default
+- BREAKING CHANGE: aws_sdk Suppress internal spans by default
 
 ### v0.84.0 / 2025-09-27
 
-* ADDED: Minimum version of opentelemetry-api v1.7.0
+- ADDED: Minimum version of opentelemetry-api v1.7.0
 
 ### v0.83.0 / 2025-09-27
 
-* ADDED: Update trilogy instrumentation to v0.62.0
+- ADDED: Update trilogy instrumentation to v0.62.0
 
 ### v0.82.0 / 2025-09-18
 
-* BREAKING CHANGE: AWS Lambda: Check if span has the attributes method to avoid internal error
-* FIXED: AWS Lambda: Check if span has the attributes method to avoid internal error
+- BREAKING CHANGE: AWS Lambda: Check if span has the attributes method to avoid internal error
+- FIXED: AWS Lambda: Check if span has the attributes method to avoid internal error
 
 ### v0.81.0 / 2025-09-16
 
-* ADDED: Anthropic initial instrumentation
-* ADDED: Add Net::HTTP `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
+- ADDED: Anthropic initial instrumentation
+- ADDED: Add Net::HTTP `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
 
 ### v0.80.0 / 2025-08-19
 
@@ -89,93 +89,93 @@ ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility fo
 
 ### v0.79.0 / 2025-08-18
 
-* ADDED: Add HTTPX instrumentation to all
-* ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
-* ADDED: Add Excon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1569](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1569)
-* ADDED: Add Faraday `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1592](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1592)
-* ADDED: Add HTTPClient `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1588](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1588)
-* ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
-* ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
+- ADDED: Add HTTPX instrumentation to all
+- ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
+- ADDED: Add Excon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1569](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1569)
+- ADDED: Add Faraday `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1592](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1592)
+- ADDED: Add HTTPClient `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1588](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1588)
+- ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
+- ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
 
 ### v0.78.0 / 2025-06-17
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to HTTP.rb instrumentation [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to HTTP.rb instrumentation [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
 
 ### v0.77.0 / 2025-06-03
 
-* ADDED: Suppress internal spans with Faraday instrumentation
-* FIXED: Handle force_flush for rake task with arguments
+- ADDED: Suppress internal spans with Faraday instrumentation
+- FIXED: Handle force_flush for rake task with arguments
 
 ### v0.76.0 / 2025-05-06
 
-* ADDED: Update minimum required version of rdkafka to 0.18.0
+- ADDED: Update minimum required version of rdkafka to 0.18.0
 
 ### v0.75.1 / 2025-04-16
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.75.0 / 2025-04-15
 
-* ADDED: Add `opentelemetry-instrumentation-grpc` to `-all`
-* ADDED: Support meta protocol instrumentation for Dalli
+- ADDED: Add `opentelemetry-instrumentation-grpc` to `-all`
+- ADDED: Support meta protocol instrumentation for Dalli
 
 ### v0.74.0 / 2025-02-11
 
-* ADDED: Rdkafka support to v0.19 including
+- ADDED: Rdkafka support to v0.19 including
 
 ### v0.73.1 / 2025-02-05
 
-* FIXED: Add require active_storage instrumentation to `all`
+- FIXED: Add require active_storage instrumentation to `all`
 
 ### v0.73.0 / 2025-02-04
 
-* CHANGED: opentelemetry-instrumentation-redis v0.26.1
-* CHANGED: opentelemetry-instrumentation-rails v0.36.0
-* CHANGED: opentelemetry-instrumentation-aws_lambda v0.3.0
-* CHANGED: opentelemetry-instrumentation-action_pack v0.12.0
+- CHANGED: opentelemetry-instrumentation-redis v0.26.1
+- CHANGED: opentelemetry-instrumentation-rails v0.36.0
+- CHANGED: opentelemetry-instrumentation-aws_lambda v0.3.0
+- CHANGED: opentelemetry-instrumentation-action_pack v0.12.0
 
 ### v0.72.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.71.1 / 2025-01-14
 
-* No Significant Changes
+- No Significant Changes
 
 ### v0.71.0 / 2025-01-07
 
-* ADDED: Faraday Minimum v1.0
+- ADDED: Faraday Minimum v1.0
 
 ### v0.70.0 / 2024-12-19
 
-* ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
+- ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
 ### v0.69.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.69.0 / 2024-11-19
 
-* ADDED: Use Semconv Naming For ActionPack
+- ADDED: Use Semconv Naming For ActionPack
 
 ### v0.68.0 / 2024-10-23
 
-* ADDED: Set span error only for 5xx response range
+- ADDED: Set span error only for 5xx response range
 
 ### v0.67.0 / 2024-10-22
 
-* BREAKING CHANGE: Rename Active Record find_by_sql spans to query
-* FIXED: Emit Active Record query spans for Rails 7.0+
-* ADDED: Subscribe to process.action_mailer notifications
+- BREAKING CHANGE: Rename Active Record find_by_sql spans to query
+- FIXED: Emit Active Record query spans for Rails 7.0+
+- ADDED: Subscribe to process.action_mailer notifications
 
 ### v0.66.0 / 2024-10-08
 
-* ADDED: Integration with V3 telemetry provider for the aws-sdk
+- ADDED: Integration with V3 telemetry provider for the aws-sdk
 
 ### v0.65.0 / 2024-09-19
 
-* ADDED: All AWS services emit traces
+- ADDED: All AWS services emit traces
 
 ### v0.64.0 / 2024-09-12
 

--- a/instrumentation/anthropic/CHANGELOG.md
+++ b/instrumentation/anthropic/CHANGELOG.md
@@ -7,17 +7,17 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.2.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.2.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.1.0 / 2025-09-11
 
-Initial release.
+- Initial release.

--- a/instrumentation/anthropic/CHANGELOG.md
+++ b/instrumentation/anthropic/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Release History: opentelemetry-instrumentation-anthropic
 
-### v0.4.0 / 2026-03-17
+## v0.4.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.2.1 / 2025-09-30
+## v0.2.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.2.0 / 2025-09-30
+## v0.2.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.1.0 / 2025-09-11
+## v0.1.0 / 2025-09-11
 
 - Initial release.

--- a/instrumentation/aws_lambda/CHANGELOG.md
+++ b/instrumentation/aws_lambda/CHANGELOG.md
@@ -1,37 +1,37 @@
 # Release History: opentelemetry-instrumentation-aws_lambda
 
-### v0.6.0 / 2025-10-22
+## v0.6.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.5.1 / 2025-09-30
+## v0.5.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.5.0 / 2025-09-30
+## v0.5.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.4.0 / 2025-09-18
+## v0.4.0 / 2025-09-18
 
 - BREAKING CHANGE: Check if span has the attributes method to avoid internal error
 - FIXED: Check if span has the attributes method to avoid internal error
 
-### v0.3.0 / 2025-02-04
+## v0.3.0 / 2025-02-04
 
 - ADDED: AWS Lambda programmatic wrap
 - FIXED: AWS Lambda test fix
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.1 / 2024-07-30
+## v0.1.1 / 2024-07-30
 
 - FIXED: Register lambda span
 
-### v0.1.0 / 2024-05-11
+## v0.1.0 / 2024-05-11
 
 - Initial release.

--- a/instrumentation/aws_lambda/CHANGELOG.md
+++ b/instrumentation/aws_lambda/CHANGELOG.md
@@ -2,36 +2,36 @@
 
 ### v0.6.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.5.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.4.0 / 2025-09-18
 
-* BREAKING CHANGE: Check if span has the attributes method to avoid internal error
-* FIXED: Check if span has the attributes method to avoid internal error
+- BREAKING CHANGE: Check if span has the attributes method to avoid internal error
+- FIXED: Check if span has the attributes method to avoid internal error
 
 ### v0.3.0 / 2025-02-04
 
-* ADDED: AWS Lambda programmatic wrap
-* FIXED: AWS Lambda test fix
+- ADDED: AWS Lambda programmatic wrap
+- FIXED: AWS Lambda test fix
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-07-30
 
-* FIXED: Register lambda span
+- FIXED: Register lambda span
 
 ### v0.1.0 / 2024-05-11
 
-Initial release.
+- Initial release.

--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -1,107 +1,107 @@
 # Release History: opentelemetry-instrumentation-aws_sdk
 
-### v0.11.0 / 2025-10-22
+## v0.11.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.10.0 / 2025-10-11
+## v0.10.0 / 2025-10-11
 
 - BREAKING CHANGE: Suppress internal spans by default
 - ADDED: Suppress internal spans by default
 
-### v0.9.1 / 2025-09-30
+## v0.9.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.9.0 / 2025-09-30
+## v0.9.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.8.2 / 2025-08-13
+## v0.8.2 / 2025-08-13
 
 - FIXED: net_http and aws_sdk ci fix
 
-### v0.8.1 / 2025-05-13
+## v0.8.1 / 2025-05-13
 
 - DOCS: Use AWS SDK v3 in example
 
-### v0.8.0 / 2025-01-16
+## v0.8.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.7.0 / 2024-10-08
+## v0.7.0 / 2024-10-08
 
 - ADDED: Integration with V3 telemetry provider
 
-### v0.6.0 / 2024-09-19
+## v0.6.0 / 2024-09-19
 
 - ADDED: All AWS services emit traces
 
-### v0.5.4 / 2024-07-23
+## v0.5.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.5.3 / 2024-07-02
+## v0.5.3 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.5.2 / 2024-04-30
+## v0.5.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.5.1 / 2024-02-08
+## v0.5.1 / 2024-02-08
 
 - FIXED: Return nil for non-existent key in AwsSdk::MessageAttributeGetter
 
-### v0.5.0 / 2023-09-07
+## v0.5.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.4.2 / 2023-08-03
+## v0.4.2 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.4.1 / 2023-06-05
+## v0.4.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.4.0 / 2023-04-17
+## v0.4.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.3.2 / 2023-01-14
+## v0.3.2 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.3.1 / 2022-07-19
+## v0.3.1 / 2022-07-19
 
 - FIXED: Suppress invalid span attribute value type warning in aws-sdk instrumentation
 
-### v0.3.0 / 2022-06-09
+## v0.3.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.2.3 / 2022-05-02
+## v0.2.3 / 2022-05-02
 
 - FIXED: RubyGems Fallback
 
-### v0.2.2 / 2022-01-26
+## v0.2.2 / 2022-01-26
 
 - (No significant changes)
 
-### v0.2.1 / 2022-01-21
+## v0.2.1 / 2022-01-21
 
 - ADDED: attach HTTP status code to AWS spans
 
-### v0.2.0 / 2022-01-20
+## v0.2.0 / 2022-01-20
 
 - ADDED: SQS / SNS messaging attributes and context propagation
 
-### v0.1.0 / 2021-12-01
+## v0.1.0 / 2021-12-01
 
 - Initial release.

--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -2,106 +2,106 @@
 
 ### v0.11.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.10.0 / 2025-10-11
 
-* BREAKING CHANGE: Suppress internal spans by default
-* ADDED: Suppress internal spans by default
+- BREAKING CHANGE: Suppress internal spans by default
+- ADDED: Suppress internal spans by default
 
 ### v0.9.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.9.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.8.2 / 2025-08-13
 
-* FIXED: net_http and aws_sdk ci fix
+- FIXED: net_http and aws_sdk ci fix
 
 ### v0.8.1 / 2025-05-13
 
-* DOCS: Use AWS SDK v3 in example
+- DOCS: Use AWS SDK v3 in example
 
 ### v0.8.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.7.0 / 2024-10-08
 
-* ADDED: Integration with V3 telemetry provider
+- ADDED: Integration with V3 telemetry provider
 
 ### v0.6.0 / 2024-09-19
 
-* ADDED: All AWS services emit traces
+- ADDED: All AWS services emit traces
 
 ### v0.5.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.5.3 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.5.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.5.1 / 2024-02-08
 
-* FIXED: Return nil for non-existent key in AwsSdk::MessageAttributeGetter
+- FIXED: Return nil for non-existent key in AwsSdk::MessageAttributeGetter
 
 ### v0.5.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.4.2 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.4.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.4.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.3.2 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.3.1 / 2022-07-19
 
-* FIXED: Suppress invalid span attribute value type warning in aws-sdk instrumentation
+- FIXED: Suppress invalid span attribute value type warning in aws-sdk instrumentation
 
 ### v0.3.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.2.3 / 2022-05-02
 
-* FIXED: RubyGems Fallback
+- FIXED: RubyGems Fallback
 
 ### v0.2.2 / 2022-01-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.2.1 / 2022-01-21
 
-* ADDED: attach HTTP status code to AWS spans
+- ADDED: attach HTTP status code to AWS spans
 
 ### v0.2.0 / 2022-01-20
 
-* ADDED: SQS / SNS messaging attributes and context propagation
+- ADDED: SQS / SNS messaging attributes and context propagation
 
 ### v0.1.0 / 2021-12-01
 
-* Initial release.
+- Initial release.

--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -1,87 +1,87 @@
 # Release History: opentelemetry-instrumentation-base
 
-### v0.25.0 / 2025-10-22
+## v0.25.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 
 - ADDED: Min Ruby Version 3.2
 
-### v0.24.0 / 2025-09-30
+## v0.24.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.6 / 2024-08-15
+## v0.22.6 / 2024-08-15
 
 - FIXED: Fix the issue of wrong log msg
 
-### v0.22.5 / 2024-07-23
+## v0.22.5 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.4 / 2024-06-18
+## v0.22.4 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 - DOCS: Add function doc for config_overrides_from_env
 
-### v0.22.3 / 2023-11-23
+## v0.22.3 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.2 / 2023-08-03
+## v0.22.2 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.22.1 / 2023-06-02
+## v0.22.1 / 2023-06-02
 
 - feat: make config available to compatible blocks #453
 
-### v0.22.0 / 2023-04-16
+## v0.22.0 / 2023-04-16
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-05-26
+## v0.21.0 / 2022-05-26
 
 - BREAKING CHANGE: This requires upgrading both the SDK and Instrumentation gem in tandem
 
-### v0.20.0 / 2022-05-02
+## v0.20.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: RubyGems Fallback
 
-### v0.19.0 / 2021-12-01
+## v0.19.0 / 2021-12-01
 
 - ADDED: Add default options config helper + env var config option support
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - (No significant changes)
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Missing instrumentation classes during configuration
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - Initial release.

--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -2,86 +2,86 @@
 
 ### v0.25.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
 
-* ADDED: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.24.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 
-* ADDED: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.6 / 2024-08-15
 
-* FIXED: Fix the issue of wrong log msg
+- FIXED: Fix the issue of wrong log msg
 
 ### v0.22.5 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.4 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
-* DOCS: Add function doc for config_overrides_from_env
+- FIXED: Relax otel common gem constraints
+- DOCS: Add function doc for config_overrides_from_env
 
 ### v0.22.3 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.2 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.22.1 / 2023-06-02
 
-* feat: make config available to compatible blocks #453
+- feat: make config available to compatible blocks #453
 
 ### v0.22.0 / 2023-04-16
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
-* ADDED: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-05-26
 
-* BREAKING CHANGE: This requires upgrading both the SDK and Instrumentation gem in tandem
+- BREAKING CHANGE: This requires upgrading both the SDK and Instrumentation gem in tandem
 
 ### v0.20.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* FIXED: RubyGems Fallback
+- ADDED: Validate Using Enums
+- FIXED: RubyGems Fallback
 
 ### v0.19.0 / 2021-12-01
 
-* ADDED: Add default options config helper + env var config option support
+- ADDED: Add default options config helper + env var config option support
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Missing instrumentation classes during configuration
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Missing instrumentation classes during configuration
 
 ### v0.17.0 / 2021-04-22
 
-* Initial release.
+- Initial release.

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -2,81 +2,81 @@
 
 ### v0.24.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.23.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.21.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.21.2 / 2024-02-08
 
-* FIXED: Remove disable directives leftover from older version of Rubocop
+- FIXED: Remove disable directives leftover from older version of Rubocop
 
 ### v0.21.1 / 2023-09-27
 
-* FIXED: Headers property needs to exist
+- FIXED: Headers property needs to exist
 
 ### v0.21.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.4 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* FIXED: Add missing require to bunny instrumentation
+- FIXED: Add missing require to bunny instrumentation
 
 ### v0.18.0 / 2021-05-21
 
-* Initial release.
+- Initial release.

--- a/instrumentation/bunny/CHANGELOG.md
+++ b/instrumentation/bunny/CHANGELOG.md
@@ -1,82 +1,82 @@
 # Release History: opentelemetry-instrumentation-bunny
 
-### v0.24.0 / 2025-10-22
+## v0.24.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.23.1 / 2025-09-30
+## v0.23.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.23.0 / 2025-09-30
+## v0.23.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.4 / 2024-07-02
+## v0.21.4 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.21.3 / 2024-04-30
+## v0.21.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.21.2 / 2024-02-08
+## v0.21.2 / 2024-02-08
 
 - FIXED: Remove disable directives leftover from older version of Rubocop
 
-### v0.21.1 / 2023-09-27
+## v0.21.1 / 2023-09-27
 
 - FIXED: Headers property needs to exist
 
-### v0.21.0 / 2023-09-07
+## v0.21.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.20.1 / 2023-06-05
+## v0.20.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.20.0 / 2023-04-17
+## v0.20.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.19.1 / 2023-01-14
+## v0.19.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.19.0 / 2022-06-09
+## v0.19.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.18.5 / 2022-05-05
+## v0.18.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.18.4 / 2021-12-02
+## v0.18.4 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - FIXED: Add missing require to bunny instrumentation
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - Initial release.

--- a/instrumentation/concurrent_ruby/CHANGELOG.md
+++ b/instrumentation/concurrent_ruby/CHANGELOG.md
@@ -2,129 +2,129 @@
 
 ### v0.24.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.23.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.21.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.21.2 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.21.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.21.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.3 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-09-29
 
-* ADDED: Add support for `Concurrent::Promises::Future`
+- ADDED: Add support for `Concurrent::Promises::Future`
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module
-* FIXED: Move context/span methods to Trace module
+- BREAKING CHANGE: Move context/span methods to Trace module
+- FIXED: Move context/span methods to Trace module
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Added README for concurrent ruby
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Added README for concurrent ruby
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/concurrent_ruby/CHANGELOG.md
+++ b/instrumentation/concurrent_ruby/CHANGELOG.md
@@ -1,130 +1,130 @@
 # Release History: opentelemetry-instrumentation-concurrent_ruby
 
-### v0.24.0 / 2025-10-22
+## v0.24.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.23.1 / 2025-09-30
+## v0.23.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.23.0 / 2025-09-30
+## v0.23.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.4 / 2024-07-23
+## v0.21.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.21.3 / 2024-04-30
+## v0.21.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.21.2 / 2023-11-23
+## v0.21.2 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.21.1 / 2023-06-05
+## v0.21.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.21.0 / 2023-04-17
+## v0.21.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.20.1 / 2023-01-14
+## v0.20.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.3 / 2022-05-05
+## v0.19.3 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.2 / 2021-12-02
+## v0.19.2 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-09-29
+## v0.19.0 / 2021-09-29
 
 - ADDED: Add support for `Concurrent::Promises::Future`
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Move context/span methods to Trace module
 - FIXED: Move context/span methods to Trace module
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Added README for concurrent ruby
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/dalli/CHANGELOG.md
+++ b/instrumentation/dalli/CHANGELOG.md
@@ -2,173 +2,173 @@
 
 ### v0.29.2 / 2026-02-27
 
-* FIXED: Replace return with implicit block value in compatible block (#2029)
+- FIXED: Replace return with implicit block value in compatible block (#2029)
 
 ### v0.29.1 / 2026-02-24
 
-* FIXED: Skip instrumenting dalli 4.2.0 (#1982)
+- FIXED: Skip instrumenting dalli 4.2.0 (#1982)
 
 ### v0.29.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.28.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.28.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.27.3 / 2025-05-27
 
-* FIXED: Compact Dalli attributes
+- FIXED: Compact Dalli attributes
 
 ### v0.27.2 / 2025-04-30
 
-* FIXED: Do not pollute the `OpenTelemetry::Instrumentation` namespace
+- FIXED: Do not pollute the `OpenTelemetry::Instrumentation` namespace
 
 ### v0.27.1 / 2025-04-21
 
-* FIXED: Only prepend Dalli patch if binary protocol defined
+- FIXED: Only prepend Dalli patch if binary protocol defined
 
 ### v0.27.0 / 2025-04-15
 
-* ADDED: Support meta protocol instrumentation
+- ADDED: Support meta protocol instrumentation
 
 ### v0.26.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
-* FIXED: Format gat commands
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
+- FIXED: Format gat commands
 
 ### v0.25.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.25.3 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.25.2 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.25.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.25.0 / 2023-10-16
 
-* BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
-* ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
+- BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
+- ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
 ### v0.24.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.24.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.24.0 / 2023-05-15
 
-* ADDED: Add db.operation attribute for dalli
+- ADDED: Add db.operation attribute for dalli
 
 ### v0.23.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.22.2 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.22.1 / 2022-11-28
 
-* FIXED: `format_command`'s terrible performance
+- FIXED: `format_command`'s terrible performance
 
 ### v0.22.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.21.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
+- ADDED: Validate Using Enums
 
 ### v0.20.0 / 2021-12-01
 
-* ADDED: Add dalli obfuscation for db_statement
-* FIXED: Resolve Dalli::Server deprecation in 3.0+
+- ADDED: Add dalli obfuscation for db_statement
+- FIXED: Resolve Dalli::Server deprecation in 3.0+
 
 ### v0.19.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Add configuration options for dalli
-* DOCS: Update docs to rely more on environment variable configuration
+- ADDED: Add configuration options for dalli
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation
+- ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* ADDED: Add peer service config to dalli
-* ADDED: Move utf8 encoding to common utils
-* FIXED: Copyright comments to not reference year
+- ADDED: Add peer service config to dalli
+- ADDED: Move utf8 encoding to common utils
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* Initial release.
+- Initial release.

--- a/instrumentation/dalli/CHANGELOG.md
+++ b/instrumentation/dalli/CHANGELOG.md
@@ -1,174 +1,174 @@
 # Release History: opentelemetry-instrumentation-dalli
 
-### v0.29.2 / 2026-02-27
+## v0.29.2 / 2026-02-27
 
 - FIXED: Replace return with implicit block value in compatible block (#2029)
 
-### v0.29.1 / 2026-02-24
+## v0.29.1 / 2026-02-24
 
 - FIXED: Skip instrumenting dalli 4.2.0 (#1982)
 
-### v0.29.0 / 2025-10-22
+## v0.29.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.28.1 / 2025-09-30
+## v0.28.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.28.0 / 2025-09-30
+## v0.28.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.27.3 / 2025-05-27
+## v0.27.3 / 2025-05-27
 
 - FIXED: Compact Dalli attributes
 
-### v0.27.2 / 2025-04-30
+## v0.27.2 / 2025-04-30
 
 - FIXED: Do not pollute the `OpenTelemetry::Instrumentation` namespace
 
-### v0.27.1 / 2025-04-21
+## v0.27.1 / 2025-04-21
 
 - FIXED: Only prepend Dalli patch if binary protocol defined
 
-### v0.27.0 / 2025-04-15
+## v0.27.0 / 2025-04-15
 
 - ADDED: Support meta protocol instrumentation
 
-### v0.26.0 / 2025-01-16
+## v0.26.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 - FIXED: Format gat commands
 
-### v0.25.4 / 2024-07-23
+## v0.25.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.25.3 / 2024-06-18
+## v0.25.3 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.25.2 / 2024-05-09
+## v0.25.2 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.25.1 / 2024-04-30
+## v0.25.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.25.0 / 2023-10-16
+## v0.25.0 / 2023-10-16
 
 - BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 - ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
-### v0.24.2 / 2023-07-21
+## v0.24.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.24.1 / 2023-06-05
+## v0.24.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.24.0 / 2023-05-15
+## v0.24.0 / 2023-05-15
 
 - ADDED: Add db.operation attribute for dalli
 
-### v0.23.0 / 2023-04-17
+## v0.23.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.22.2 / 2023-01-14
+## v0.22.2 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.22.1 / 2022-11-28
+## v0.22.1 / 2022-11-28
 
 - FIXED: `format_command`'s terrible performance
 
-### v0.22.0 / 2022-06-09
+## v0.22.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.21.0 / 2022-05-02
+## v0.21.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 
-### v0.20.0 / 2021-12-01
+## v0.20.0 / 2021-12-01
 
 - ADDED: Add dalli obfuscation for db_statement
 - FIXED: Resolve Dalli::Server deprecation in 3.0+
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - ADDED: Add configuration options for dalli
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - ADDED: Add peer service config to dalli
 - ADDED: Move utf8 encoding to common utils
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - (No significant changes)
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - Initial release.

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -1,133 +1,133 @@
 # Release History: opentelemetry-instrumentation-delayed_job
 
-### v0.25.1 / 2025-10-22
+## v0.25.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.25.0 / 2025-10-21
+## v0.25.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.24.1 / 2025-09-30
+## v0.24.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.24.0 / 2025-09-30
+## v0.24.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.4 / 2024-07-23
+## v0.22.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.3 / 2024-07-02
+## v0.22.3 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.22.2 / 2024-04-30
+## v0.22.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.1 / 2023-11-23
+## v0.22.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.0 / 2023-10-16
+## v0.22.0 / 2023-10-16
 
 - BREAKING CHANGE: Drop DelayedJob ActiveRecord in Tests
 - FIXED: Drop DelayedJob ActiveRecord in Tests
 
-### v0.21.0 / 2023-09-07
+## v0.21.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.20.1 / 2023-06-05
+## v0.20.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.20.0 / 2023-04-17
+## v0.20.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.19.1 / 2023-01-14
+## v0.19.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.19.0 / 2022-06-09
+## v0.19.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Rails 7.0.3 test suite incompatibility
 - FIXED: Broken test file requirements
 
-### v0.18.5 / 2022-05-02
+## v0.18.5 / 2022-05-02
 
 - FIXED: RubyGems Fallback
 
-### v0.18.4 / 2021-12-02
+## v0.18.4 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - FIXED: Coerce message ID to string in span payload
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-10-07
+## v0.9.0 / 2020-10-07
 
 - Initial release of Delayed Job instrumentation (ported from Datadog)

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -2,132 +2,132 @@
 
 ### v0.25.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.25.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.24.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.24.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.3 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.22.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.0 / 2023-10-16
 
-* BREAKING CHANGE: Drop DelayedJob ActiveRecord in Tests
-* FIXED: Drop DelayedJob ActiveRecord in Tests
+- BREAKING CHANGE: Drop DelayedJob ActiveRecord in Tests
+- FIXED: Drop DelayedJob ActiveRecord in Tests
 
 ### v0.21.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Rails 7.0.3 test suite incompatibility
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Rails 7.0.3 test suite incompatibility
+- FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-02
 
-* FIXED: RubyGems Fallback
+- FIXED: RubyGems Fallback
 
 ### v0.18.4 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
+- ADDED: Updated API dependency for 1.0.0.rc1
+- BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Coerce message ID to string in span payload
+- FIXED: Coerce message ID to string in span payload
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-10-07
 
-* Initial release of Delayed Job instrumentation (ported from Datadog)
+- Initial release of Delayed Job instrumentation (ported from Datadog)

--- a/instrumentation/ethon/CHANGELOG.md
+++ b/instrumentation/ethon/CHANGELOG.md
@@ -1,186 +1,186 @@
 # Release History: opentelemetry-instrumentation-ethon
 
-### v0.28.0 / 2026-03-17
+## v0.28.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.27.0 / 2026-01-13
+## v0.27.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.26.0 / 2025-11-26
+## v0.26.0 / 2025-11-26
 
 - BREAKING CHANGE: Update Ethon span name when unknown method
 - ADDED: Update Ethon span name when unknown method
 
-### v0.25.1 / 2025-11-25
+## v0.25.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.25.0 / 2025-10-22
+## v0.25.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.24.2 / 2025-10-14
+## v0.24.2 / 2025-10-14
 
 - FIXED: Raise original Ethon error after span updates
 
-### v0.24.1 / 2025-09-30
+## v0.24.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.24.0 / 2025-09-30
+## v0.24.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.23.1 / 2025-09-02
+## v0.23.1 / 2025-09-02
 
 - FIXED: Improve Ethon exception handling
 
-### v0.23.0 / 2025-08-13
+## v0.23.0 / 2025-08-13
 
 - ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.9 / 2024-11-26
+## v0.21.9 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.21.8 / 2024-07-23
+## v0.21.8 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.21.7 / 2024-06-18
+## v0.21.7 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.21.6 / 2024-06-12
+## v0.21.6 / 2024-06-12
 
 - FIXED: Add net.peer.name to ethon
 
-### v0.21.5 / 2024-05-09
+## v0.21.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.21.4 / 2024-04-30
+## v0.21.4 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.21.3 / 2023-11-23
+## v0.21.3 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.21.2 / 2023-07-21
+## v0.21.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.21.1 / 2023-06-05
+## v0.21.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.21.0 / 2023-04-17
+## v0.21.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.20.1 / 2023-01-14
+## v0.20.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.5 / 2022-05-05
+## v0.19.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.4 / 2022-02-02
+## v0.19.4 / 2022-02-02
 
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-02
+## v0.19.3 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Ethon instrumentation accepts peer service config attribute.
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Remove passwords from http.url
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Move context/span methods to Trace module
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Move context/span methods to Trace module
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Add README for Ethon
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/ethon/CHANGELOG.md
+++ b/instrumentation/ethon/CHANGELOG.md
@@ -7,180 +7,180 @@
 
 ### v0.27.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.26.0 / 2025-11-26
 
-* BREAKING CHANGE: Update Ethon span name when unknown method
-* ADDED: Update Ethon span name when unknown method
+- BREAKING CHANGE: Update Ethon span name when unknown method
+- ADDED: Update Ethon span name when unknown method
 
 ### v0.25.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.25.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.24.2 / 2025-10-14
 
-* FIXED: Raise original Ethon error after span updates
+- FIXED: Raise original Ethon error after span updates
 
 ### v0.24.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.24.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.23.1 / 2025-09-02
 
-* FIXED: Improve Ethon exception handling
+- FIXED: Improve Ethon exception handling
 
 ### v0.23.0 / 2025-08-13
 
-* ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
+- ADDED: Add Ethon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1561](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1561)
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.9 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.21.8 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.21.7 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.21.6 / 2024-06-12
 
-* FIXED: Add net.peer.name to ethon
+- FIXED: Add net.peer.name to ethon
 
 ### v0.21.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.21.4 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.21.3 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.21.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.21.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.21.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Excessive hash creation on context attr merging
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Ethon instrumentation accepts peer service config attribute.
-* FIXED: Refactor propagators to add #fields
+- ADDED: Ethon instrumentation accepts peer service config attribute.
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Remove passwords from http.url
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Move context/span methods to Trace module
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Move context/span methods to Trace module
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Move context/span methods to Trace module
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Add README for Ethon
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Add README for Ethon
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/excon/CHANGELOG.md
+++ b/instrumentation/excon/CHANGELOG.md
@@ -1,178 +1,178 @@
 # Release History: opentelemetry-instrumentation-excon
 
-### v0.28.0 / 2026-03-17
+## v0.28.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.27.0 / 2026-01-13
+## v0.27.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.26.1 / 2025-11-25
+## v0.26.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.26.0 / 2025-10-22
+## v0.26.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.25.2 / 2025-10-11
+## v0.25.2 / 2025-10-11
 
 - FIXED: Fixing missing OpenTelemetry::Context detach on Excon instrumentation
 
-### v0.25.1 / 2025-09-30
+## v0.25.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.25.0 / 2025-09-30
+## v0.25.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.24.0 / 2025-08-13
+## v0.24.0 / 2025-08-13
 
 - ADDED: Add Excon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1569](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1569)
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.5 / 2024-11-26
+## v0.22.5 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.22.4 / 2024-07-23
+## v0.22.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.3 / 2024-06-18
+## v0.22.3 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 - FIXED: Add `http.url` to Excon instrumentation
 
-### v0.22.2 / 2024-05-09
+## v0.22.2 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.22.1 / 2024-04-30
+## v0.22.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.0 / 2023-11-28
+## v0.22.0 / 2023-11-28
 
 - BREAKING CHANGE: Add a connect span to excon
 - ADDED: Add a connect span to excon
 
-### v0.21.3 / 2023-11-23
+## v0.21.3 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.21.2 / 2023-07-21
+## v0.21.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.21.1 / 2023-06-05
+## v0.21.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.21.0 / 2023-04-17
+## v0.21.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.20.1 / 2023-01-14
+## v0.20.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.5 / 2022-05-05
+## v0.19.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.4 / 2022-02-02
+## v0.19.4 / 2022-02-02
 
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-02
+## v0.19.3 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Removed http.status_text attribute #750
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Excon instrumentation accepts peer service config attribute.
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Move context/span methods to Trace module
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Move context/span methods to Trace module
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/excon/CHANGELOG.md
+++ b/instrumentation/excon/CHANGELOG.md
@@ -7,172 +7,172 @@
 
 ### v0.27.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.26.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.26.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.25.2 / 2025-10-11
 
-* FIXED: Fixing missing OpenTelemetry::Context detach on Excon instrumentation
+- FIXED: Fixing missing OpenTelemetry::Context detach on Excon instrumentation
 
 ### v0.25.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.25.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.24.0 / 2025-08-13
 
-* ADDED: Add Excon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1569](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1569)
+- ADDED: Add Excon `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1569](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1569)
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.5 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.22.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.3 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
-* FIXED: Add `http.url` to Excon instrumentation
+- FIXED: Relax otel common gem constraints
+- FIXED: Add `http.url` to Excon instrumentation
 
 ### v0.22.2 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.22.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.0 / 2023-11-28
 
-* BREAKING CHANGE: Add a connect span to excon
-* ADDED: Add a connect span to excon
+- BREAKING CHANGE: Add a connect span to excon
+- ADDED: Add a connect span to excon
 
 ### v0.21.3 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.21.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.21.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.21.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Excessive hash creation on context attr merging
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Removed http.status_text attribute #750
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Excon instrumentation accepts peer service config attribute.
-* FIXED: Refactor propagators to add #fields
+- ADDED: Excon instrumentation accepts peer service config attribute.
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Move context/span methods to Trace module
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Move context/span methods to Trace module
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Move context/span methods to Trace module
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/factory_bot/CHANGELOG.md
+++ b/instrumentation/factory_bot/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History: opentelemetry-instrumentation-factory_bot
 
-### v0.1.0 / 2025-11-11
+## v0.1.0 / 2025-11-11
 
 - Initial release.

--- a/instrumentation/factory_bot/CHANGELOG.md
+++ b/instrumentation/factory_bot/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ### v0.1.0 / 2025-11-11
 
-Initial release.
+- Initial release.

--- a/instrumentation/faraday/CHANGELOG.md
+++ b/instrumentation/faraday/CHANGELOG.md
@@ -7,196 +7,196 @@
 
 ### v0.31.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.30.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.30.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.29.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.29.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.28.0 / 2025-08-13
 
-* ADDED: Add Faraday `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1592](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1592)
+- ADDED: Add Faraday `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1592](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1592)
 
 ### v0.27.0 / 2025-06-03
 
-* ADDED: Suppress internal spans with Faraday instrumentation
+- ADDED: Suppress internal spans with Faraday instrumentation
 
 ### v0.26.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.0 / 2025-01-07
 
-* ADDED: Faraday Minimum v1.0
+- ADDED: Faraday Minimum v1.0
 
 ### v0.24.8 / 2024-12-17
 
-* FIXED: Share Faraday Attrs with Adapter Spans
+- FIXED: Share Faraday Attrs with Adapter Spans
 
 ### v0.24.7 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.24.6 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.24.5 / 2024-06-20
 
-* FIXED: Compatibility with Faraday v1
+- FIXED: Compatibility with Faraday v1
 
 ### v0.24.4 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.24.3 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.24.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.24.1 / 2024-03-22
 
-* FIXED: Propagate response attributes on Faraday::Error.
+- FIXED: Propagate response attributes on Faraday::Error.
 
 ### v0.24.0 / 2024-02-20
 
-* ADDED: Faraday add support for internal spans
+- ADDED: Faraday add support for internal spans
 
 ### v0.23.4 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.23.3 / 2023-10-16
 
-* FIXED: Omit `nil` `net.peer.name` attributes
+- FIXED: Omit `nil` `net.peer.name` attributes
 
 ### v0.23.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.23.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.23.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.22.0 / 2023-01-14
 
-* ADDED: Add request/response hooks to more http clients
-* FIXED: Stop leaking basic authentication credentials in Faraday instrumentation
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- ADDED: Add request/response hooks to more http clients
+- FIXED: Stop leaking basic authentication credentials in Faraday instrumentation
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.20.1 / 2022-05-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.20.0 / 2022-02-02
 
-* ADDED: Add net.peer.name to faraday instrumentation
-* FIXED: Excessive hash creation on context attr merging
+- ADDED: Add net.peer.name to faraday instrumentation
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.1 / 2021-06-08
 
-* FIXED: Missing require to common in faraday
+- FIXED: Missing require to common in faraday
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Removed http.status_text attribute #750
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Fix Faraday gem dependencies.
-* FIXED: Refactor propagators to add #fields
+- FIXED: Fix Faraday gem dependencies.
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Remove passwords from http.url
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* FIXED: Include http.status_text only if reason_phrase is in the response
+- FIXED: Include http.status_text only if reason_phrase is in the response
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Faraday documentation
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Faraday documentation
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/faraday/CHANGELOG.md
+++ b/instrumentation/faraday/CHANGELOG.md
@@ -1,202 +1,202 @@
 # Release History: opentelemetry-instrumentation-faraday
 
-### v0.32.0 / 2026-03-17
+## v0.32.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.31.0 / 2026-01-13
+## v0.31.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.30.1 / 2025-11-25
+## v0.30.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.30.0 / 2025-10-22
+## v0.30.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.29.1 / 2025-09-30
+## v0.29.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.29.0 / 2025-09-30
+## v0.29.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.28.0 / 2025-08-13
+## v0.28.0 / 2025-08-13
 
 - ADDED: Add Faraday `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1592](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1592)
 
-### v0.27.0 / 2025-06-03
+## v0.27.0 / 2025-06-03
 
 - ADDED: Suppress internal spans with Faraday instrumentation
 
-### v0.26.0 / 2025-01-16
+## v0.26.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.25.0 / 2025-01-07
+## v0.25.0 / 2025-01-07
 
 - ADDED: Faraday Minimum v1.0
 
-### v0.24.8 / 2024-12-17
+## v0.24.8 / 2024-12-17
 
 - FIXED: Share Faraday Attrs with Adapter Spans
 
-### v0.24.7 / 2024-11-26
+## v0.24.7 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.24.6 / 2024-07-23
+## v0.24.6 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.24.5 / 2024-06-20
+## v0.24.5 / 2024-06-20
 
 - FIXED: Compatibility with Faraday v1
 
-### v0.24.4 / 2024-06-18
+## v0.24.4 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.24.3 / 2024-05-09
+## v0.24.3 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.24.2 / 2024-04-30
+## v0.24.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.24.1 / 2024-03-22
+## v0.24.1 / 2024-03-22
 
 - FIXED: Propagate response attributes on Faraday::Error.
 
-### v0.24.0 / 2024-02-20
+## v0.24.0 / 2024-02-20
 
 - ADDED: Faraday add support for internal spans
 
-### v0.23.4 / 2023-11-23
+## v0.23.4 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.23.3 / 2023-10-16
+## v0.23.3 / 2023-10-16
 
 - FIXED: Omit `nil` `net.peer.name` attributes
 
-### v0.23.2 / 2023-07-21
+## v0.23.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.23.1 / 2023-06-05
+## v0.23.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.23.0 / 2023-04-17
+## v0.23.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.22.0 / 2023-01-14
+## v0.22.0 / 2023-01-14
 
 - ADDED: Add request/response hooks to more http clients
 - FIXED: Stop leaking basic authentication credentials in Faraday instrumentation
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.20.1 / 2022-05-03
+## v0.20.1 / 2022-05-03
 
 - (No significant changes)
 
-### v0.20.0 / 2022-02-02
+## v0.20.0 / 2022-02-02
 
 - ADDED: Add net.peer.name to faraday instrumentation
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-02
+## v0.19.3 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.1 / 2021-06-08
+## v0.18.1 / 2021-06-08
 
 - FIXED: Missing require to common in faraday
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Removed http.status_text attribute #750
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Fix Faraday gem dependencies.
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Remove passwords from http.url
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - FIXED: Include http.status_text only if reason_phrase is in the response
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - (No significant changes)
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Faraday documentation
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/grape/CHANGELOG.md
+++ b/instrumentation/grape/CHANGELOG.md
@@ -7,58 +7,58 @@
 
 ### v0.5.1 / 2026-02-11
 
-* FIXED: Support Grape 3.1.0 (#1969)
+- FIXED: Support Grape 3.1.0 (#1969)
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.4.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.3.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.0 / 2024-07-02
 
-* ADDED: Make the install of rack instrumentation by grape instrumentation optional
+- ADDED: Make the install of rack instrumentation by grape instrumentation optional
 
 ### v0.1.8 / 2024-05-14
 
-* DOCS: Instrumentation Authors Guide
+- DOCS: Instrumentation Authors Guide
 
 ### v0.1.7 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.1.6 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.1.5 / 2023-10-31
 
-* FIXED: Remove dependency on ActiveSupport core extensions from Grape instrumentation
+- FIXED: Remove dependency on ActiveSupport core extensions from Grape instrumentation
 
 ### v0.1.4 / 2023-08-02
 
-* FIXED: Fix opentelemetry-api version constraint in grape gemspec
+- FIXED: Fix opentelemetry-api version constraint in grape gemspec
 
 ### v0.1.3 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.1.2 / 2023-05-02
 
-* FIXED: Grape Instrumentation handle status code symbol
+- FIXED: Grape Instrumentation handle status code symbol
 
 ### v0.1.1 / 2023-04-26
 
-* FIXED: Set grape.formatter.type to 'custom' for non-Grape formatters
+- FIXED: Set grape.formatter.type to 'custom' for non-Grape formatters
 
 ### v0.1.0 / 2023-04-17
 
-* Initial release.
+- Initial release.

--- a/instrumentation/grape/CHANGELOG.md
+++ b/instrumentation/grape/CHANGELOG.md
@@ -1,64 +1,64 @@
 # Release History: opentelemetry-instrumentation-grape
 
-### v0.6.0 / 2026-03-17
+## v0.6.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.5.1 / 2026-02-11
+## v0.5.1 / 2026-02-11
 
 - FIXED: Support Grape 3.1.0 (#1969)
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.4.0 / 2025-09-30
+## v0.4.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.3.0 / 2025-01-16
+## v0.3.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.2.0 / 2024-07-02
+## v0.2.0 / 2024-07-02
 
 - ADDED: Make the install of rack instrumentation by grape instrumentation optional
 
-### v0.1.8 / 2024-05-14
+## v0.1.8 / 2024-05-14
 
 - DOCS: Instrumentation Authors Guide
 
-### v0.1.7 / 2024-04-30
+## v0.1.7 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.1.6 / 2023-11-23
+## v0.1.6 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.1.5 / 2023-10-31
+## v0.1.5 / 2023-10-31
 
 - FIXED: Remove dependency on ActiveSupport core extensions from Grape instrumentation
 
-### v0.1.4 / 2023-08-02
+## v0.1.4 / 2023-08-02
 
 - FIXED: Fix opentelemetry-api version constraint in grape gemspec
 
-### v0.1.3 / 2023-06-05
+## v0.1.3 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.1.2 / 2023-05-02
+## v0.1.2 / 2023-05-02
 
 - FIXED: Grape Instrumentation handle status code symbol
 
-### v0.1.1 / 2023-04-26
+## v0.1.1 / 2023-04-26
 
 - FIXED: Set grape.formatter.type to 'custom' for non-Grape formatters
 
-### v0.1.0 / 2023-04-17
+## v0.1.0 / 2023-04-17
 
 - Initial release.

--- a/instrumentation/graphql/CHANGELOG.md
+++ b/instrumentation/graphql/CHANGELOG.md
@@ -2,173 +2,173 @@
 
 ### v0.31.2 / 2025-10-28
 
-* FIXED: Patch dataloader to propagate context to new fiber
-* FIXED: Does not trace resolve type unless enable
+- FIXED: Patch dataloader to propagate context to new fiber
+- FIXED: Does not trace resolve type unless enable
 
 ### v0.31.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.31.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.30.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.30.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.29.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.28.4 / 2024-07-30
 
-* FIXED: Add super calls to GraphqlTrace
+- FIXED: Add super calls to GraphqlTrace
 
 ### v0.28.3 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.28.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.28.1 / 2024-04-10
 
-* FIXED: Analyze span names in GraphQL instrumentation
+- FIXED: Analyze span names in GraphQL instrumentation
 
 ### v0.28.0 / 2024-02-16
 
-* BREAKING CHANGE: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
-* ADDED: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
+- BREAKING CHANGE: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
+- ADDED: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
 
 ### v0.27.0 / 2023-11-28
 
-* CHANGED: Performance optimization cache attribute hashes [#723](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/723)
+- CHANGED: Performance optimization cache attribute hashes [#723](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/723)
 
 ### v0.26.8 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.26.7 / 2023-09-27
 
-* FIXED: Micro optimization: build Hash w/ {} (https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/665)
+- FIXED: Micro optimization: build Hash w/ {} (https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/665)
 
 ### v0.26.6 / 2023-08-26
 
-* FIXED: Improve GraphQL tracing compatibility with other tracers
+- FIXED: Improve GraphQL tracing compatibility with other tracers
 
 ### v0.26.5 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.26.4 / 2023-08-01
 
-* FIXED: GraphQL tests and installation
+- FIXED: GraphQL tests and installation
 
 ### v0.26.3 / 2023-07-29
 
-* FIXED: GraphQL validate events
+- FIXED: GraphQL validate events
 
 ### v0.26.2 / 2023-06-05
 
-* FIXED: Base config options
-* FIXED: GraphQL resolve_type_lazy
+- FIXED: Base config options
+- FIXED: GraphQL resolve_type_lazy
 
 ### v0.26.1 / 2023-05-30
 
-* FIXED: GraphQL tracing
+- FIXED: GraphQL tracing
 
 ### v0.26.0 / 2023-05-17
 
-* BREAKING CHANGE: GraphQL instrumentation: support new tracing API
-* ADDED: GraphQL instrumentation: support new tracing API
+- BREAKING CHANGE: GraphQL instrumentation: support new tracing API
+- ADDED: GraphQL instrumentation: support new tracing API
 
 ### v0.25.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.0 / 2023-03-15
 
-* BREAKING CHANGE: Add support for GraphQL 2.0.19
-* FIXED: Add support for GraphQL 2.0.19
+- BREAKING CHANGE: Add support for GraphQL 2.0.19
+- FIXED: Add support for GraphQL 2.0.19
 
 ### v0.23.0 / 2023-03-13
 
-* BREAKING CHANGE: Lock graphql max version to 2.0.17
-* FIXED: Lock graphql max version to 2.0.17
+- BREAKING CHANGE: Lock graphql max version to 2.0.17
+- FIXED: Lock graphql max version to 2.0.17
 
 ### v0.22.0 / 2023-01-27
 
-* ADDED: Normalize GraphQL span names for easier aggregation analysis
+- ADDED: Normalize GraphQL span names for easier aggregation analysis
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-07-12
 
-* FIXED: Use semantic graphql attribute names
+- FIXED: Use semantic graphql attribute names
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.3 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Add support for graphql errors
-* DOCS: Update docs to rely more on environment variable configuration
+- ADDED: Add support for graphql errors
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation
+- ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* Initial release.
+- Initial release.

--- a/instrumentation/graphql/CHANGELOG.md
+++ b/instrumentation/graphql/CHANGELOG.md
@@ -1,174 +1,174 @@
 # Release History: opentelemetry-instrumentation-graphql
 
-### v0.31.2 / 2025-10-28
+## v0.31.2 / 2025-10-28
 
 - FIXED: Patch dataloader to propagate context to new fiber
 - FIXED: Does not trace resolve type unless enable
 
-### v0.31.1 / 2025-10-22
+## v0.31.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.31.0 / 2025-10-21
+## v0.31.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.30.1 / 2025-09-30
+## v0.30.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.30.0 / 2025-09-30
+## v0.30.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.29.0 / 2025-01-16
+## v0.29.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.28.4 / 2024-07-30
+## v0.28.4 / 2024-07-30
 
 - FIXED: Add super calls to GraphqlTrace
 
-### v0.28.3 / 2024-07-23
+## v0.28.3 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.28.2 / 2024-04-30
+## v0.28.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.28.1 / 2024-04-10
+## v0.28.1 / 2024-04-10
 
 - FIXED: Analyze span names in GraphQL instrumentation
 
-### v0.28.0 / 2024-02-16
+## v0.28.0 / 2024-02-16
 
 - BREAKING CHANGE: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
 - ADDED: GraphQL Legacy Tracer perf improvements [#867](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/867).
 
-### v0.27.0 / 2023-11-28
+## v0.27.0 / 2023-11-28
 
 - CHANGED: Performance optimization cache attribute hashes [#723](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/723)
 
-### v0.26.8 / 2023-11-23
+## v0.26.8 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.26.7 / 2023-09-27
+## v0.26.7 / 2023-09-27
 
 - FIXED: Micro optimization: build Hash w/ {} (https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/665)
 
-### v0.26.6 / 2023-08-26
+## v0.26.6 / 2023-08-26
 
 - FIXED: Improve GraphQL tracing compatibility with other tracers
 
-### v0.26.5 / 2023-08-03
+## v0.26.5 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.26.4 / 2023-08-01
+## v0.26.4 / 2023-08-01
 
 - FIXED: GraphQL tests and installation
 
-### v0.26.3 / 2023-07-29
+## v0.26.3 / 2023-07-29
 
 - FIXED: GraphQL validate events
 
-### v0.26.2 / 2023-06-05
+## v0.26.2 / 2023-06-05
 
 - FIXED: Base config options
 - FIXED: GraphQL resolve_type_lazy
 
-### v0.26.1 / 2023-05-30
+## v0.26.1 / 2023-05-30
 
 - FIXED: GraphQL tracing
 
-### v0.26.0 / 2023-05-17
+## v0.26.0 / 2023-05-17
 
 - BREAKING CHANGE: GraphQL instrumentation: support new tracing API
 - ADDED: GraphQL instrumentation: support new tracing API
 
-### v0.25.0 / 2023-04-17
+## v0.25.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.24.0 / 2023-03-15
+## v0.24.0 / 2023-03-15
 
 - BREAKING CHANGE: Add support for GraphQL 2.0.19
 - FIXED: Add support for GraphQL 2.0.19
 
-### v0.23.0 / 2023-03-13
+## v0.23.0 / 2023-03-13
 
 - BREAKING CHANGE: Lock graphql max version to 2.0.17
 - FIXED: Lock graphql max version to 2.0.17
 
-### v0.22.0 / 2023-01-27
+## v0.22.0 / 2023-01-27
 
 - ADDED: Normalize GraphQL span names for easier aggregation analysis
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-07-12
+## v0.21.0 / 2022-07-12
 
 - FIXED: Use semantic graphql attribute names
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.3 / 2022-05-05
+## v0.19.3 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.2 / 2021-12-02
+## v0.19.2 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - ADDED: Add support for graphql errors
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - Initial release.

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -2,44 +2,44 @@
 
 ### v0.4.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.4.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.3.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.3.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.2.1 / 2025-04-17
 
-* CHANGED: Fix ClientTracer: uninitialized constant GRPC (NameError) https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1471
+- CHANGED: Fix ClientTracer: uninitialized constant GRPC (NameError) https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1471
 
 ### v0.2.0 / 2025-04-02
 
-* ADDED: Add gRPC trace demonstration
-* ADDED: Migrate gRPC instrumentation to OpenTelemetry tooling
-* ADDED: Transferred ownership of the gem from @hibachrach to OpenTelemetry
+- ADDED: Add gRPC trace demonstration
+- ADDED: Migrate gRPC instrumentation to OpenTelemetry tooling
+- ADDED: Transferred ownership of the gem from @hibachrach to OpenTelemetry
 
 ### v0.1.3 / 2024-09-11
 
-* FIXED: Fix error in handling of non-gRPC errors
-* FIXED: Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
+- FIXED: Fix error in handling of non-gRPC errors
+- FIXED: Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
 
 ### v0.1.2 / 2024-06-26
 
-* FIXED: Align span naming with spec
+- FIXED: Align span naming with spec
 
 ### v0.1.1 / 2024-06-26
 
-* FIXED: Fix `uninitialized constant Interceptors` error
+- FIXED: Fix `uninitialized constant Interceptors` error
 
 ### v0.1.0 / 2024-06-18
 
-* Initial release
+- Initial release

--- a/instrumentation/grpc/CHANGELOG.md
+++ b/instrumentation/grpc/CHANGELOG.md
@@ -1,45 +1,45 @@
 # Release History: opentelemetry-instrumentation-grpc
 
-### v0.4.1 / 2025-10-22
+## v0.4.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.4.0 / 2025-10-21
+## v0.4.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.3.1 / 2025-09-30
+## v0.3.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.3.0 / 2025-09-30
+## v0.3.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.2.1 / 2025-04-17
+## v0.2.1 / 2025-04-17
 
 - CHANGED: Fix ClientTracer: uninitialized constant GRPC (NameError) https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1471
 
-### v0.2.0 / 2025-04-02
+## v0.2.0 / 2025-04-02
 
 - ADDED: Add gRPC trace demonstration
 - ADDED: Migrate gRPC instrumentation to OpenTelemetry tooling
 - ADDED: Transferred ownership of the gem from @hibachrach to OpenTelemetry
 
-### v0.1.3 / 2024-09-11
+## v0.1.3 / 2024-09-11
 
 - FIXED: Fix error in handling of non-gRPC errors
 - FIXED: Fix error in method signature for OpenTelemetry::Instrumentation::Grpc.client_interceptor [#1](https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/1)
 
-### v0.1.2 / 2024-06-26
+## v0.1.2 / 2024-06-26
 
 - FIXED: Align span naming with spec
 
-### v0.1.1 / 2024-06-26
+## v0.1.1 / 2024-06-26
 
 - FIXED: Fix `uninitialized constant Interceptors` error
 
-### v0.1.0 / 2024-06-18
+## v0.1.0 / 2024-06-18
 
 - Initial release

--- a/instrumentation/gruf/CHANGELOG.md
+++ b/instrumentation/gruf/CHANGELOG.md
@@ -1,35 +1,35 @@
 # Release History: opentelemetry-instrumentation-gruf
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.4.1 / 2025-09-30
+## v0.4.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.4.0 / 2025-09-30
+## v0.4.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.3.0 / 2025-01-16
+## v0.3.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.2.1 / 2024-04-30
+## v0.2.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.2.0 / 2024-02-20
+## v0.2.0 / 2024-02-20
 
 - ADDED: Add support gruf 2.19
 
-### v0.1.1 / 2023-10-16
+## v0.1.1 / 2023-10-16
 
 - FIXED: Remove activesupport dependency
 
-### v0.1.0 / 2023-08-07
+## v0.1.0 / 2023-08-07
 
 - Initial release!

--- a/instrumentation/gruf/CHANGELOG.md
+++ b/instrumentation/gruf/CHANGELOG.md
@@ -2,34 +2,34 @@
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.4.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.3.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.2.0 / 2024-02-20
 
-* ADDED: Add support gruf 2.19
+- ADDED: Add support gruf 2.19
 
 ### v0.1.1 / 2023-10-16
 
-* FIXED: Remove activesupport dependency
+- FIXED: Remove activesupport dependency
 
 ### v0.1.0 / 2023-08-07
 
-* Initial release!
+- Initial release!

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -1,129 +1,129 @@
 # Release History: opentelemetry-instrumentation-http
 
-### v0.29.0 / 2026-03-17
+## v0.29.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.28.0 / 2026-01-13
+## v0.28.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.27.1 / 2025-11-25
+## v0.27.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.27.0 / 2025-10-22
+## v0.27.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.26.1 / 2025-09-30
+## v0.26.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.26.0 / 2025-09-30
+## v0.26.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.25.1 / 2025-07-01
+## v0.25.1 / 2025-07-01
 
 - FIXED: Update span name when semconv stability is enabled
 
-### v0.25.0 / 2025-06-17
+## v0.25.0 / 2025-06-17
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
 
-### v0.24.0 / 2025-01-16
+## v0.24.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.23.5 / 2024-11-26
+## v0.23.5 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.23.4 / 2024-07-23
+## v0.23.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.23.3 / 2024-04-30
+## v0.23.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.23.2 / 2023-11-23
+## v0.23.2 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.23.1 / 2023-06-05
+## v0.23.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.23.0 / 2023-05-15
+## v0.23.0 / 2023-05-15
 
 - ADDED: Add span_preprocessor hook
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.0 / 2023-01-14
+## v0.21.0 / 2023-01-14
 
 - ADDED: Add request/response hooks to more http clients
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.6 / 2022-05-05
+## v0.19.6 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.5 / 2022-05-02
+## v0.19.5 / 2022-05-02
 
 - FIXED: RubyGems Fallback
 
-### v0.19.4 / 2022-02-02
+## v0.19.4 / 2022-02-02
 
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-01
+## v0.19.3 / 2021-12-01
 
 - FIXED: Change net attribute names to match the semantic conventions spec for http
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - (No significant changes)
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.2 / 2021-03-29
+## v0.16.2 / 2021-03-29
 
 - FIXED: HTTP Instrumentation should check for gem presence
 
-### v0.16.1 / 2021-03-25
+## v0.16.1 / 2021-03-25
 
 - FIXED: HTTP instrumentation missing require
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - Initial release.

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -7,123 +7,123 @@
 
 ### v0.28.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.27.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.27.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.26.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.26.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.25.1 / 2025-07-01
 
-* FIXED: Update span name when semconv stability is enabled
+- FIXED: Update span name when semconv stability is enabled
 
 ### v0.25.0 / 2025-06-17
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)
 
 ### v0.24.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.23.5 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.23.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.23.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.23.2 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.23.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.23.0 / 2023-05-15
 
-* ADDED: Add span_preprocessor hook
+- ADDED: Add span_preprocessor hook
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
 
-* ADDED: Add request/response hooks to more http clients
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- ADDED: Add request/response hooks to more http clients
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.6 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.5 / 2022-05-02
 
-* FIXED: RubyGems Fallback
+- FIXED: RubyGems Fallback
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Excessive hash creation on context attr merging
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-01
 
-* FIXED: Change net attribute names to match the semantic conventions spec for http
+- FIXED: Change net attribute names to match the semantic conventions spec for http
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.2 / 2021-03-29
 
-* FIXED: HTTP Instrumentation should check for gem presence
+- FIXED: HTTP Instrumentation should check for gem presence
 
 ### v0.16.1 / 2021-03-25
 
-* FIXED: HTTP instrumentation missing require
+- FIXED: HTTP instrumentation missing require
 
 ### v0.16.0 / 2021-03-17
 
-* Initial release.
+- Initial release.

--- a/instrumentation/http_client/CHANGELOG.md
+++ b/instrumentation/http_client/CHANGELOG.md
@@ -7,121 +7,121 @@
 
 ### v0.27.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.26.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.26.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.25.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.24.0 / 2025-08-13
 
-* ADDED: Add HTTPClient `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1588](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1588)
+- ADDED: Add HTTPClient `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1588](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1588)
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.22.7 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.6 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.22.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.22.4 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.3 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
 
-* ADDED: Add request/response hooks to more http clients
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- ADDED: Add request/response hooks to more http clients
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Excessive hash creation on context attr merging
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-01
 
-* FIXED: Change net attribute names to match the semantic conventions spec for http
+- FIXED: Change net attribute names to match the semantic conventions spec for http
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Remove passwords from http.url
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* Initial release.
+- Initial release.

--- a/instrumentation/http_client/CHANGELOG.md
+++ b/instrumentation/http_client/CHANGELOG.md
@@ -1,127 +1,127 @@
 # Release History: opentelemetry-instrumentation-http_client
 
-### v0.28.0 / 2026-03-17
+## v0.28.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.27.0 / 2026-01-13
+## v0.27.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.26.1 / 2025-11-25
+## v0.26.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.26.0 / 2025-10-22
+## v0.26.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.25.1 / 2025-09-30
+## v0.25.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.25.0 / 2025-09-30
+## v0.25.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.24.0 / 2025-08-13
+## v0.24.0 / 2025-08-13
 
 - ADDED: Add HTTPClient `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1588](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1588)
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.8 / 2024-11-26
+## v0.22.8 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.22.7 / 2024-07-23
+## v0.22.7 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.6 / 2024-06-18
+## v0.22.6 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.22.5 / 2024-05-09
+## v0.22.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.22.4 / 2024-04-30
+## v0.22.4 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.3 / 2023-11-23
+## v0.22.3 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.2 / 2023-07-21
+## v0.22.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.22.1 / 2023-06-05
+## v0.22.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.0 / 2023-01-14
+## v0.21.0 / 2023-01-14
 
 - ADDED: Add request/response hooks to more http clients
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.5 / 2022-05-05
+## v0.19.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.4 / 2022-02-02
+## v0.19.4 / 2022-02-02
 
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-01
+## v0.19.3 / 2021-12-01
 
 - FIXED: Change net attribute names to match the semantic conventions spec for http
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Remove passwords from http.url
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - Initial release.

--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -7,54 +7,54 @@
 
 ### v0.6.1 / 2026-02-27
 
-* FIXED: Httpx support to ~> 1.6 adapt to request init_time (#2030)
+- FIXED: Httpx support to ~> 1.6 adapt to request init_time (#2030)
 
 ### v0.6.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.5.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.4.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.3.0 / 2025-08-13
 
-* ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
+- ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
 
 ### v0.2.1 / 2025-04-29
 
-* FIXED: Httpx instrumentation trace context propagation
+- FIXED: Httpx instrumentation trace context propagation
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.3 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.1.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.1.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.1.0 / 2023-11-06
 
-* Initial Release.
+- Initial Release.

--- a/instrumentation/httpx/CHANGELOG.md
+++ b/instrumentation/httpx/CHANGELOG.md
@@ -1,60 +1,60 @@
 # Release History: opentelemetry-instrumentation-httpx
 
-### v0.7.0 / 2026-03-17
+## v0.7.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.6.1 / 2026-02-27
+## v0.6.1 / 2026-02-27
 
 - FIXED: Httpx support to ~> 1.6 adapt to request init_time (#2030)
 
-### v0.6.0 / 2026-01-13
+## v0.6.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.5.1 / 2025-11-25
+## v0.5.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.4.1 / 2025-09-30
+## v0.4.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.4.0 / 2025-09-30
+## v0.4.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.3.0 / 2025-08-13
+## v0.3.0 / 2025-08-13
 
 - ADDED: HTTPX `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1589](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1589)
 
-### v0.2.1 / 2025-04-29
+## v0.2.1 / 2025-04-29
 
 - FIXED: Httpx instrumentation trace context propagation
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.3 / 2024-11-26
+## v0.1.3 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.1.2 / 2024-04-30
+## v0.1.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.1.1 / 2023-11-23
+## v0.1.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.1.0 / 2023-11-06
+## v0.1.0 / 2023-11-06
 
 - Initial Release.

--- a/instrumentation/koala/CHANGELOG.md
+++ b/instrumentation/koala/CHANGELOG.md
@@ -2,81 +2,81 @@
 
 ### v0.23.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.22.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.22.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.21.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.20.6 / 2025-01-07
 
-* FIXED: Loosen the koala pin to ~> 3.0
+- FIXED: Loosen the koala pin to ~> 3.0
 
 ### v0.20.5 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.20.4 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.20.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.20.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.18.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.4 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* Initial release.
+- Initial release.

--- a/instrumentation/koala/CHANGELOG.md
+++ b/instrumentation/koala/CHANGELOG.md
@@ -1,82 +1,82 @@
 # Release History: opentelemetry-instrumentation-koala
 
-### v0.23.0 / 2025-10-22
+## v0.23.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.22.1 / 2025-09-30
+## v0.22.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.22.0 / 2025-09-30
+## v0.22.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.21.0 / 2025-01-16
+## v0.21.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.20.6 / 2025-01-07
+## v0.20.6 / 2025-01-07
 
 - FIXED: Loosen the koala pin to ~> 3.0
 
-### v0.20.5 / 2024-06-18
+## v0.20.5 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.20.4 / 2024-05-09
+## v0.20.4 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.20.3 / 2024-04-30
+## v0.20.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.20.2 / 2023-07-21
+## v0.20.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.20.1 / 2023-06-05
+## v0.20.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.20.0 / 2023-04-17
+## v0.20.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.19.1 / 2023-01-14
+## v0.19.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.19.0 / 2022-06-09
+## v0.19.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.18.5 / 2022-05-05
+## v0.18.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.18.4 / 2021-12-02
+## v0.18.4 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - Initial release.

--- a/instrumentation/lmdb/CHANGELOG.md
+++ b/instrumentation/lmdb/CHANGELOG.md
@@ -2,78 +2,78 @@
 
 ### v0.25.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.24.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.24.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.3 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.20.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
+- ADDED: Validate Using Enums
 
 ### v0.19.2 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Configure db.statement toggle
-* DOCS: Update docs to rely more on environment variable configuration
+- ADDED: Configure db.statement toggle
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* Initial release.
+- Initial release.

--- a/instrumentation/lmdb/CHANGELOG.md
+++ b/instrumentation/lmdb/CHANGELOG.md
@@ -1,79 +1,79 @@
 # Release History: opentelemetry-instrumentation-lmdb
 
-### v0.25.0 / 2025-10-22
+## v0.25.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.24.1 / 2025-09-30
+## v0.24.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.24.0 / 2025-09-30
+## v0.24.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.3 / 2024-07-23
+## v0.22.3 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.2 / 2024-04-30
+## v0.22.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.1 / 2023-06-05
+## v0.22.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.20.0 / 2022-05-02
+## v0.20.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 
-### v0.19.2 / 2021-12-02
+## v0.19.2 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - ADDED: Configure db.statement toggle
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - Initial release.

--- a/instrumentation/logger/CHANGELOG.md
+++ b/instrumentation/logger/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Release History: opentelemetry-instrumentation-logger
 
-### v0.3.2 / 2026-03-17
+## v0.3.2 / 2026-03-17
 
-* FIXED: Return the original logger value instead of broadcasts array (#1988)
-* FIXED: Return the original value instead of broadcasts array
+- FIXED: Return the original logger value instead of broadcasts array (#1988)
+- FIXED: Return the original value instead of broadcasts array
 
-### v0.3.1 / 2026-02-11
+## v0.3.1 / 2026-02-11
 
 - FIXED: Prevent deadlock from recursive logging (#1944)
 
-### v0.3.0 / 2025-10-28
+## v0.3.0 / 2025-10-28
 
 - ADDED: Use formatted_message in Ruby logger instrumentation
 
-### v0.2.0 / 2025-10-22
+## v0.2.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.1.0 / 2025-10-09
+## v0.1.0 / 2025-10-09
 
 - Initial release.

--- a/instrumentation/logger/CHANGELOG.md
+++ b/instrumentation/logger/CHANGELOG.md
@@ -7,17 +7,17 @@
 
 ### v0.3.1 / 2026-02-11
 
-* FIXED: Prevent deadlock from recursive logging (#1944)
+- FIXED: Prevent deadlock from recursive logging (#1944)
 
 ### v0.3.0 / 2025-10-28
 
-* ADDED: Use formatted_message in Ruby logger instrumentation
+- ADDED: Use formatted_message in Ruby logger instrumentation
 
 ### v0.2.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.1.0 / 2025-10-09
 
-Initial release.
+- Initial release.

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -2,121 +2,121 @@
 
 ### v0.25.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.24.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.24.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.4 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.2 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-10-04
 
-* ADDED: Support mongodb db statement without obfuscation
+- ADDED: Support mongodb db statement without obfuscation
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* FIXED: RubyGems Fallback
+- ADDED: Validate Using Enums
+- FIXED: RubyGems Fallback
 
 ### v0.18.4 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.2 / 2021-08-12
 
-* FIXED: Flakey mongo test
+- FIXED: Flakey mongo test
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Replace `Time.now` with `Process.clock_gettime`
-* FIXED: Mongodb test asserting error message
+- BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Replace `Time.now` with `Process.clock_gettime`
+- FIXED: Mongodb test asserting error message
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Mongo instrumentation accepts peer service config attribute.
-* FIXED: Fix Mongo instrumentation example.
-* FIXED: Refactor propagators to add #fields
+- ADDED: Mongo instrumentation accepts peer service config attribute.
+- FIXED: Fix Mongo instrumentation example.
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Mongo Instrumentation: Do not send nil attributes
+- FIXED: Mongo Instrumentation: Do not send nil attributes
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-03
 
-* Initial release of Mongo Instrumentation (ported from Datadog)
+- Initial release of Mongo Instrumentation (ported from Datadog)

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -1,122 +1,122 @@
 # Release History: opentelemetry-instrumentation-mongo
 
-### v0.25.0 / 2025-10-22
+## v0.25.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.24.1 / 2025-09-30
+## v0.24.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.24.0 / 2025-09-30
+## v0.24.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.4 / 2024-07-23
+## v0.22.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.3 / 2024-04-30
+## v0.22.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.2 / 2023-11-23
+## v0.22.2 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.1 / 2023-06-05
+## v0.22.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-10-04
+## v0.21.0 / 2022-10-04
 
 - ADDED: Support mongodb db statement without obfuscation
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.0 / 2022-05-02
+## v0.19.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: RubyGems Fallback
 
-### v0.18.4 / 2021-12-02
+## v0.18.4 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - FIXED: Flakey mongo test
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - BREAKING CHANGE: Replace `Time.now` with `Process.clock_gettime`
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Replace `Time.now` with `Process.clock_gettime`
 - FIXED: Mongodb test asserting error message
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Mongo instrumentation accepts peer service config attribute.
 - FIXED: Fix Mongo instrumentation example.
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - FIXED: Mongo Instrumentation: Do not send nil attributes
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-03
+## v0.9.0 / 2020-11-03
 
 - Initial release of Mongo Instrumentation (ported from Datadog)

--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -1,93 +1,93 @@
 # Release History: opentelemetry-instrumentation-mysql2
 
-### v0.33.0 / 2026-01-13
+## v0.33.0 / 2026-01-13
 
 - ADDED: Add SQL Comment Propagator
 
-### v0.32.1 / 2025-12-03
+## v0.32.1 / 2025-12-03
 
 - FIXED: Update gemspec dependencies to sql-processor
 
-### v0.32.0 / 2025-12-02
+## v0.32.0 / 2025-12-02
 
 - ADDED: Replace references sql-obfuscation -> sql-processor
 
-### v0.31.0 / 2025-10-22
+## v0.31.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.30.1 / 2025-09-30
+## v0.30.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.30.0 / 2025-09-30
+## v0.30.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.29.1 / 2025-04-16
+## v0.29.1 / 2025-04-16
 
 - refactor: Use SQL helpers for context attributes #1271
 
-### v0.29.0 / 2025-01-16
+## v0.29.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.28.0 / 2024-09-12
+## v0.28.0 / 2024-09-12
 
 - BREAKING CHANGE: Return message when sql is over the obfuscation limit. Fixes a bug where sql statements with prepended comments that hit the obfuscation limit would be sent raw.
 
-### v0.27.2 / 2024-07-23
+## v0.27.2 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.27.1 / 2024-04-30
+## v0.27.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.27.0 / 2024-02-15
+## v0.27.0 / 2024-02-15
 
 - ADDED: Instrument mysql2 prepare statement
 
-### v0.26.1 / 2024-02-08
+## v0.26.1 / 2024-02-08
 
 - FIXED: Add missing requires for sql-helpers to mysql, pg, and trilogy instrumentation
 
-### v0.26.0 / 2024-02-08
+## v0.26.0 / 2024-02-08
 
 - BREAKING CHANGE: Move shared sql behavior to helper gems
 
-### v0.25.0 / 2023-10-16
+## v0.25.0 / 2023-10-16
 
 - BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
 - ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
-### v0.24.3 / 2023-08-03
+## v0.24.3 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.24.2 / 2023-06-05
+## v0.24.2 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.24.1 / 2023-06-01
+## v0.24.1 / 2023-06-01
 
 - FIXED: Regex non-match with obfuscation limit (issue #486)
 
-### v0.24.0 / 2023-05-25
+## v0.24.0 / 2023-05-25
 
 - ADDED: Add config[:obfuscation_limit] to pg and mysql2
 
-### v0.23.0 / 2023-04-17
+## v0.23.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
 - ADDED: Drop support for EoL Ruby 2.7
 - FIXED: Ensure encoding errors handled during SQL obfuscation for Trilogy
 
-### v0.22.0 / 2023-01-14
+## v0.22.0 / 2023-01-14
 
 - BREAKING CHANGE: Removed deprecated instrumentation options
 
@@ -96,28 +96,28 @@
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.1 / 2022-10-26
+## v0.21.1 / 2022-10-26
 
 - FIXED: Handle encoding errors in mysql obfuscation
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.20.1 / 2022-05-03
+## v0.20.1 / 2022-05-03
 
 - ADDED: `with_attributes` method for context propagation
 
-### v0.20.0 / 2021-12-01
+## v0.20.0 / 2021-12-01
 
 - ADDED: Add default options config helper + env var config option support
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - BREAKING CHANGE: Add option for db.statement
 
@@ -125,70 +125,70 @@
 - DOCS: Update docs to rely more on environment variable configuration
 - DOCS: Move to using new db_statement
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - Fix: Nil value for db.name attribute #744
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Update DB semantic conventions
 - FIXED: Example scripts now reference local common lib
 - ADDED: Configurable obfuscation of sql in mysql2 instrumentation to avoid logging sensitive data
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - ADDED: Add peer service config to mysql
 - FIXED: Copyright comments to not reference year
 
-### v0.10.1 / 2020-12-09
+## v0.10.1 / 2020-12-09
 
 - FIXED: Semantic conventions db.type -> db.system
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Remove 'canonical' from status codes
 
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -2,37 +2,37 @@
 
 ### v0.33.0 / 2026-01-13
 
-* ADDED: Add SQL Comment Propagator
+- ADDED: Add SQL Comment Propagator
 
 ### v0.32.1 / 2025-12-03
 
-* FIXED: Update gemspec dependencies to sql-processor
+- FIXED: Update gemspec dependencies to sql-processor
 
 ### v0.32.0 / 2025-12-02
 
-* ADDED: Replace references sql-obfuscation -> sql-processor
+- ADDED: Replace references sql-obfuscation -> sql-processor
 
 ### v0.31.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.30.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.30.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.29.1 / 2025-04-16
 
-* refactor: Use SQL helpers for context attributes #1271
+- refactor: Use SQL helpers for context attributes #1271
 
 ### v0.29.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.28.0 / 2024-09-12
 

--- a/instrumentation/net_http/CHANGELOG.md
+++ b/instrumentation/net_http/CHANGELOG.md
@@ -1,176 +1,176 @@
 # Release History: opentelemetry-instrumentation-net_http
 
-### v0.28.0 / 2026-03-17
+## v0.28.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.27.0 / 2026-01-13
+## v0.27.0 / 2026-01-13
 
 - ADDED: HTTP Client Semconv v1.17 Span Naming
 
-### v0.26.1 / 2025-11-25
+## v0.26.1 / 2025-11-25
 
 - FIXED: Update support for unknown HTTP methods to match semantic conventions
 
-### v0.26.0 / 2025-10-22
+## v0.26.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.25.1 / 2025-09-30
+## v0.25.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.25.0 / 2025-09-30
+## v0.25.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.24.0 / 2025-08-26
+## v0.24.0 / 2025-08-26
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
 
-### v0.23.1 / 2025-08-13
+## v0.23.1 / 2025-08-13
 
 - FIXED: net_http and aws_sdk ci fix
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.8 / 2024-11-26
+## v0.22.8 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.22.7 / 2024-07-23
+## v0.22.7 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.6 / 2024-06-18
+## v0.22.6 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.22.5 / 2024-05-09
+## v0.22.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.22.4 / 2023-11-23
+## v0.22.4 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.3 / 2023-11-22
+## v0.22.3 / 2023-11-22
 
 - FIXED: Update `Net::HTTP` instrumentation to no-op on untraced contexts
 
-### v0.22.2 / 2023-07-21
+## v0.22.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.22.1 / 2023-06-05
+## v0.22.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 - FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - FIXED: Add untraced check to the Net::HTTP connect instrumentation
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-10-04
+## v0.21.0 / 2022-10-04
 
 - ADDED: Add Net::HTTP :untraced_hosts option
 - FIXED: Rename HTTP CONNECT for low level connection spans
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.5 / 2022-05-05
+## v0.19.5 / 2022-05-05
 
 - (No significant changes)
 
-### v0.19.4 / 2022-02-02
+## v0.19.4 / 2022-02-02
 
 - FIXED: Client Context attrs overwrite in net::http
 - FIXED: Excessive hash creation on context attr merging
 
-### v0.19.3 / 2021-12-01
+## v0.19.3 / 2021-12-01
 
 - FIXED: Change net attribute names to match the semantic conventions spec for http
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add Net::HTTP#connect tracing
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - ADDED: Add common helpers
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Added documentation for net_http gem in instrumentation
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/net_http/CHANGELOG.md
+++ b/instrumentation/net_http/CHANGELOG.md
@@ -7,170 +7,170 @@
 
 ### v0.27.0 / 2026-01-13
 
-* ADDED: HTTP Client Semconv v1.17 Span Naming
+- ADDED: HTTP Client Semconv v1.17 Span Naming
 
 ### v0.26.1 / 2025-11-25
 
-* FIXED: Update support for unknown HTTP methods to match semantic conventions
+- FIXED: Update support for unknown HTTP methods to match semantic conventions
 
 ### v0.26.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.25.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.24.0 / 2025-08-26
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1572](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1572)
 
 ### v0.23.1 / 2025-08-13
 
-* FIXED: net_http and aws_sdk ci fix
+- FIXED: net_http and aws_sdk ci fix
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.22.7 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.6 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.22.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.22.4 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.3 / 2023-11-22
 
-* FIXED: Update `Net::HTTP` instrumentation to no-op on untraced contexts
+- FIXED: Update `Net::HTTP` instrumentation to no-op on untraced contexts
 
 ### v0.22.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
+- FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.21.1 / 2023-01-14
 
-* FIXED: Add untraced check to the Net::HTTP connect instrumentation
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- FIXED: Add untraced check to the Net::HTTP connect instrumentation
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-10-04
 
-* ADDED: Add Net::HTTP :untraced_hosts option
-* FIXED: Rename HTTP CONNECT for low level connection spans
+- ADDED: Add Net::HTTP :untraced_hosts option
+- FIXED: Rename HTTP CONNECT for low level connection spans
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.5 / 2022-05-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.4 / 2022-02-02
 
-* FIXED: Client Context attrs overwrite in net::http
-* FIXED: Excessive hash creation on context attr merging
+- FIXED: Client Context attrs overwrite in net::http
+- FIXED: Excessive hash creation on context attr merging
 
 ### v0.19.3 / 2021-12-01
 
-* FIXED: Change net attribute names to match the semantic conventions spec for http
+- FIXED: Change net attribute names to match the semantic conventions spec for http
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add Net::HTTP#connect tracing
+- ADDED: Add Net::HTTP#connect tracing
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* ADDED: Add common helpers
+- ADDED: Add common helpers
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Added documentation for net_http gem in instrumentation
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Added documentation for net_http gem in instrumentation
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/net_ldap/CHANGELOG.md
+++ b/instrumentation/net_ldap/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History: opentelemetry-instrumentation-net_ldap
 
-### v0.1.0 / 2026-02-22
+## v0.1.0 / 2026-02-22
 
 - ADDED: Add net_ldap instrumentation (#1587)

--- a/instrumentation/net_ldap/CHANGELOG.md
+++ b/instrumentation/net_ldap/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ### v0.1.0 / 2026-02-22
 
-* ADDED: Add net_ldap instrumentation (#1587)
+- ADDED: Add net_ldap instrumentation (#1587)

--- a/instrumentation/pg/CHANGELOG.md
+++ b/instrumentation/pg/CHANGELOG.md
@@ -2,51 +2,51 @@
 
 ### v0.35.0 / 2026-01-13
 
-* ADDED: Add SQL Comment Propagator
+- ADDED: Add SQL Comment Propagator
 
 ### v0.34.1 / 2025-12-03
 
-* FIXED: Update gemspec dependencies to sql-processor
+- FIXED: Update gemspec dependencies to sql-processor
 
 ### v0.34.0 / 2025-12-02
 
-* ADDED: Replace references sql-obfuscation -> sql-processor
+- ADDED: Replace references sql-obfuscation -> sql-processor
 
 ### v0.33.0 / 2025-11-03
 
-* ADDED: Instrument PG connect
+- ADDED: Instrument PG connect
 
 ### v0.32.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.31.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.31.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.30.1 / 2025-04-16
 
-* refactor: Use SQL helpers for context attributes #1271
+- refactor: Use SQL helpers for context attributes #1271
 
 ### v0.30.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.29.2 / 2025-01-07
 
-* FIXED: Update instrumentation pg to support merge statements
+- FIXED: Update instrumentation pg to support merge statements
 
 ### v0.29.1 / 2024-11-26
 
-* FIXED: Get correct table name if table name is quoted
+- FIXED: Get correct table name if table name is quoted
 
 ### v0.29.0 / 2024-09-12
 

--- a/instrumentation/pg/CHANGELOG.md
+++ b/instrumentation/pg/CHANGELOG.md
@@ -1,115 +1,115 @@
 # Release History: opentelemetry-instrumentation-pg
 
-### v0.35.0 / 2026-01-13
+## v0.35.0 / 2026-01-13
 
 - ADDED: Add SQL Comment Propagator
 
-### v0.34.1 / 2025-12-03
+## v0.34.1 / 2025-12-03
 
 - FIXED: Update gemspec dependencies to sql-processor
 
-### v0.34.0 / 2025-12-02
+## v0.34.0 / 2025-12-02
 
 - ADDED: Replace references sql-obfuscation -> sql-processor
 
-### v0.33.0 / 2025-11-03
+## v0.33.0 / 2025-11-03
 
 - ADDED: Instrument PG connect
 
-### v0.32.0 / 2025-10-22
+## v0.32.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.31.1 / 2025-09-30
+## v0.31.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.31.0 / 2025-09-30
+## v0.31.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.30.1 / 2025-04-16
+## v0.30.1 / 2025-04-16
 
 - refactor: Use SQL helpers for context attributes #1271
 
-### v0.30.0 / 2025-01-16
+## v0.30.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.29.2 / 2025-01-07
+## v0.29.2 / 2025-01-07
 
 - FIXED: Update instrumentation pg to support merge statements
 
-### v0.29.1 / 2024-11-26
+## v0.29.1 / 2024-11-26
 
 - FIXED: Get correct table name if table name is quoted
 
-### v0.29.0 / 2024-09-12
+## v0.29.0 / 2024-09-12
 
 - BREAKING CHANGE: Return message when sql is over the obfuscation limit. Fixes a bug where sql statements with prepended comments that hit the obfuscation limit would be sent raw.
 
-### v0.28.0 / 2024-08-15
+## v0.28.0 / 2024-08-15
 
 - ADDED: Collect pg db.collection_name attribute
 - FIXED: Update versions to be tested (includes drop support for pg 1.2)
 
-### v0.27.4 / 2024-07-23
+## v0.27.4 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.27.3 / 2024-05-11
+## v0.27.3 / 2024-05-11
 
 - ADDED: Support prepend SQL comment for PG instrumentation
 
-### v0.27.2 / 2024-04-30
+## v0.27.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.27.1 / 2024-02-08
+## v0.27.1 / 2024-02-08
 
 - FIXED: Add missing requires for sql-helpers to mysql, pg, and trilogy instrumentation
 
-### v0.27.0 / 2024-02-08
+## v0.27.0 / 2024-02-08
 
 - BREAKING CHANGE: Move shared sql behavior to helper gems
 
-### v0.26.1 / 2023-11-23
+## v0.26.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.26.0 / 2023-10-16
+## v0.26.0 / 2023-10-16
 
 - BREAKING CHANGE: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
 - ADDED: Obfuscation for mysql2, dalli and postgresql as default option for db_statement
 
-### v0.25.3 / 2023-07-29
+## v0.25.3 / 2023-07-29
 
 - FIXED: Pass block explicitly in `define_method` calls for PG instrumentation query methods
 
-### v0.25.2 / 2023-06-05
+## v0.25.2 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.25.1 / 2023-06-01
+## v0.25.1 / 2023-06-01
 
 - FIXED: Regex non-match with obfuscation limit (issue #486)
 
-### v0.25.0 / 2023-05-25
+## v0.25.0 / 2023-05-25
 
 - ADDED: Add config[:obfuscation_limit] to pg and mysql2
 
-### v0.24.0 / 2023-04-17
+## v0.24.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.23.0 / 2023-01-14
+## v0.23.0 / 2023-01-14
 
 - BREAKING CHANGE: Removed deprecated instrumentation options
 
@@ -118,56 +118,56 @@
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.22.3 / 2022-12-06
+## v0.22.3 / 2022-12-06
 
 - FIXED: Use attributes from the active PG connection
 
-### v0.22.2 / 2022-11-10
+## v0.22.2 / 2022-11-10
 
 - FIXED: Safeguard against host being nil
 
-### v0.22.1 / 2022-10-27
+## v0.22.1 / 2022-10-27
 
 - FIXED: Only take the first item in a comma-separated list for pg attrs
 
-### v0.22.0 / 2022-10-04
+## v0.22.0 / 2022-10-04
 
 - ADDED: Add `with_attributes` context propagation for PG instrumentation
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.20.0 / 2022-05-02
+## v0.20.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: Update pg instrumentation to handle non primitive argument
 - FIXED: RubyGems Fallback
 
-### v0.19.2 / 2021-12-02
+## v0.19.2 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.1 / 2021-09-29
+## v0.19.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - ADDED: Add db_statement toggle for postgres
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - ADDED: Add option to postgres instrumentation to disable db.statement
 
-### v0.17.1 / 2021-04-23
+## v0.17.1 / 2021-04-23
 
 - Initial release.
 - ADDED: Initial postgresql instrumentation

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -2,102 +2,102 @@
 
 ### v0.12.0 / 2025-12-02
 
-* ADDED: Replace references sql-obfuscation -> sql-processor
+- ADDED: Replace references sql-obfuscation -> sql-processor
 
 ### v0.11.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.11.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.10.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.10.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.9.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.8.4 / 2024-10-08
 
-* FIXED: Fix bulk_enqueue when enqueuing more than 5 jobs
+- FIXED: Fix bulk_enqueue when enqueuing more than 5 jobs
 
 ### v0.8.3 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.8.2 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.8.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.8.0 / 2024-02-08
 
-* BREAKING CHANGE: Move shared sql behavior to helper gems
+- BREAKING CHANGE: Move shared sql behavior to helper gems
 
 ### v0.7.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.7.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.6.2 / 2023-08-07
 
-* FIXED: Correctly set bulk_enqueue job options
+- FIXED: Correctly set bulk_enqueue job options
 
 ### v0.6.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.6.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
-* FIXED: Drop Rails dependency for ActiveSupport Instrumentation
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
+- FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
 ### v0.5.1 / 2023-01-14
 
-* FIXED: Remove `job_options` when using `bulk_enqueue`
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- FIXED: Remove `job_options` when using `bulk_enqueue`
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.5.0 / 2022-10-28
 
-* ADDED: Add support for `job_options` argument
+- ADDED: Add support for `job_options` argument
 
 ### v0.4.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.3.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* FIXED: RubyGems Fallback
+- ADDED: Validate Using Enums
+- FIXED: RubyGems Fallback
 
 ### v0.2.0 / 2021-12-01
 
-* ADDED: Instrument Que poller
+- ADDED: Instrument Que poller
 
 ### v0.1.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2021-09-15
 
-* Initial release.
+- Initial release.

--- a/instrumentation/que/CHANGELOG.md
+++ b/instrumentation/que/CHANGELOG.md
@@ -1,103 +1,103 @@
 # Release History: opentelemetry-instrumentation-que
 
-### v0.12.0 / 2025-12-02
+## v0.12.0 / 2025-12-02
 
 - ADDED: Replace references sql-obfuscation -> sql-processor
 
-### v0.11.1 / 2025-10-22
+## v0.11.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.11.0 / 2025-10-21
+## v0.11.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.10.1 / 2025-09-30
+## v0.10.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.10.0 / 2025-09-30
+## v0.10.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.9.0 / 2025-01-16
+## v0.9.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.8.4 / 2024-10-08
+## v0.8.4 / 2024-10-08
 
 - FIXED: Fix bulk_enqueue when enqueuing more than 5 jobs
 
-### v0.8.3 / 2024-07-23
+## v0.8.3 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.8.2 / 2024-07-02
+## v0.8.2 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.8.1 / 2024-04-30
+## v0.8.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.8.0 / 2024-02-08
+## v0.8.0 / 2024-02-08
 
 - BREAKING CHANGE: Move shared sql behavior to helper gems
 
-### v0.7.1 / 2023-11-23
+## v0.7.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.7.0 / 2023-09-07
+## v0.7.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.6.2 / 2023-08-07
+## v0.6.2 / 2023-08-07
 
 - FIXED: Correctly set bulk_enqueue job options
 
-### v0.6.1 / 2023-06-05
+## v0.6.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.6.0 / 2023-04-17
+## v0.6.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 - FIXED: Drop Rails dependency for ActiveSupport Instrumentation
 
-### v0.5.1 / 2023-01-14
+## v0.5.1 / 2023-01-14
 
 - FIXED: Remove `job_options` when using `bulk_enqueue`
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.5.0 / 2022-10-28
+## v0.5.0 / 2022-10-28
 
 - ADDED: Add support for `job_options` argument
 
-### v0.4.0 / 2022-06-09
+## v0.4.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.3.0 / 2022-05-02
+## v0.3.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: RubyGems Fallback
 
-### v0.2.0 / 2021-12-01
+## v0.2.0 / 2021-12-01
 
 - ADDED: Instrument Que poller
 
-### v0.1.1 / 2021-09-29
+## v0.1.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.1.0 / 2021-09-15
+## v0.1.0 / 2021-09-15
 
 - Initial release.

--- a/instrumentation/racecar/CHANGELOG.md
+++ b/instrumentation/racecar/CHANGELOG.md
@@ -1,64 +1,64 @@
 # Release History: opentelemetry-instrumentation-racecar
 
-### v0.6.1 / 2025-12-23
+## v0.6.1 / 2025-12-23
 
 - FIXED: Use a unique consumer group in tests to fix racecar tests
 
-### v0.6.0 / 2025-10-22
+## v0.6.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.5.1 / 2025-09-30
+## v0.5.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.5.0 / 2025-09-30
+## v0.5.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.4.0 / 2025-01-16
+## v0.4.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.3.4 / 2024-07-09
+## v0.3.4 / 2024-07-09
 
 - FIXED: Suppress header access with symbol key deprecation warning in Racecar Instrumentation
 
-### v0.3.3 / 2024-07-02
+## v0.3.3 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.3.2 / 2024-04-30
+## v0.3.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.3.1 / 2024-04-05
+## v0.3.1 / 2024-04-05
 
 - FIXED: Fix markdown header
 
-### v0.3.0 / 2023-09-07
+## v0.3.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.2.1 / 2023-06-05
+## v0.2.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.2.0 / 2023-04-17
+## v0.2.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.1.2 / 2023-03-24
+## v0.1.2 / 2023-03-24
 
 - FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
 
-### v0.1.1 / 2023-01-14
+## v0.1.1 / 2023-01-14
 
 - DOCS: More gem documentation fixes
 
-### v0.1.0 / 2022-11-08
+## v0.1.0 / 2022-11-08
 
 - Initial release.

--- a/instrumentation/racecar/CHANGELOG.md
+++ b/instrumentation/racecar/CHANGELOG.md
@@ -2,63 +2,63 @@
 
 ### v0.6.1 / 2025-12-23
 
-* FIXED: Use a unique consumer group in tests to fix racecar tests
+- FIXED: Use a unique consumer group in tests to fix racecar tests
 
 ### v0.6.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.5.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.4.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.3.4 / 2024-07-09
 
-* FIXED: Suppress header access with symbol key deprecation warning in Racecar Instrumentation
+- FIXED: Suppress header access with symbol key deprecation warning in Racecar Instrumentation
 
 ### v0.3.3 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.3.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.3.1 / 2024-04-05
 
-* FIXED: Fix markdown header
+- FIXED: Fix markdown header
 
 ### v0.3.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.2.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.2.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.2 / 2023-03-24
 
-* FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
+- FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
 
 ### v0.1.1 / 2023-01-14
 
-* DOCS: More gem documentation fixes
+- DOCS: More gem documentation fixes
 
 ### v0.1.0 / 2022-11-08
 
-* Initial release.
+- Initial release.

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -7,218 +7,218 @@
 
 ### v0.29.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.28.2 / 2025-10-07
 
-* FIXED: Unify rack middleware_args
+- FIXED: Unify rack middleware_args
 
 ### v0.28.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.28.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.27.1 / 2025-09-16
 
-* DOCS: Typo in Rack::Instrumentation usage example of middleware_args
+- DOCS: Typo in Rack::Instrumentation usage example of middleware_args
 
 ### v0.27.0 / 2025-08-19
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
 ### v0.26.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.0 / 2024-10-23
 
-* ADDED: Set span error only for 5xx response range
+- ADDED: Set span error only for 5xx response range
 
 ### v0.24.6 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.24.5 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.24.4 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.24.3 / 2024-05-08
 
-* FIXED: Rack event baggage handling
+- FIXED: Rack event baggage handling
 
 ### v0.24.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.24.1 / 2024-04-05
 
-* DOCS: Fix typo where Rake is mentioned instead of Rack
+- DOCS: Fix typo where Rake is mentioned instead of Rack
 
 ### v0.24.0 / 2024-01-06
 
-* BREAKING CHANGE: Use Rack Events By Default
-* ADDED: Use Rack Events By Default
-* FIXED: Backport Rack proxy event to middleware
+- BREAKING CHANGE: Use Rack Events By Default
+- ADDED: Use Rack Events By Default
+- FIXED: Backport Rack proxy event to middleware
 
 ### v0.23.5 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.23.4 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.23.3 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.23.2 / 2023-06-08
 
-* FIXED: Ensure Rack Events Handler Exists
+- FIXED: Ensure Rack Events Handler Exists
 
 ### v0.23.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.23.0 / 2023-04-17
 
-* BREAKING CHANGE: Remove retain_middleware_names Rack Option
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Remove retain_middleware_names Rack Option
-* ADDED: Drop support for EoL Ruby 2.7
-* ADDED: Use Rack::Events for instrumentation
+- BREAKING CHANGE: Remove retain_middleware_names Rack Option
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Remove retain_middleware_names Rack Option
+- ADDED: Drop support for EoL Ruby 2.7
+- ADDED: Use Rack::Events for instrumentation
 
 ### v0.22.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.22.0 / 2022-11-16
 
-* ADDED: Add experimental traceresponse propagator to Rack instrumentation
+- ADDED: Add experimental traceresponse propagator to Rack instrumentation
 
 ### v0.21.1 / 2022-10-04
 
-* FIXED: Bring http.request.header and http.response.header in line with semconv
+- FIXED: Bring http.request.header and http.response.header in line with semconv
 
 ### v0.21.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.20.2 / 2022-05-02
 
-* FIXED: Update server instrumentation to not reflect 400 status as error
+- FIXED: Update server instrumentation to not reflect 400 status as error
 
 ### v0.20.1 / 2021-12-01
 
-* FIXED: [Instrumentation Rack] Log content type http header
-* FIXED: Use monotonic clock where possible
-* FIXED: Rack to stop using api env getter
+- FIXED: [Instrumentation Rack] Log content type http header
+- FIXED: Use monotonic clock where possible
+- FIXED: Rack to stop using api env getter
 
 ### v0.20.0 / 2021-10-06
 
-* FIXED: Prevent high cardinality rack span name as a default [#973](https://github.com/open-telemetry/opentelemetry-ruby/pull/973)
+- FIXED: Prevent high cardinality rack span name as a default [#973](https://github.com/open-telemetry/opentelemetry-ruby/pull/973)
 
 The default was to set the span name as the path of the request, we have
 corrected this as it was not adhering to the spec requirement using low
-cardinality span names.  You can restore the previous behavior of high
+cardinality span names. You can restore the previous behavior of high
 cardinality span names by passing in a url quantization function that
-forwards the uri path.  More details on this is available in the readme.
+forwards the uri path. More details on this is available in the readme.
 
 ### v0.19.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-08-18
 
-* FIXED: Rack middleware assuming script_name presence
+- FIXED: Rack middleware assuming script_name presence
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* ADDED: Add Tracer.non_recording_span to API
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- ADDED: Add Tracer.non_recording_span to API
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Removed http.status_text attribute #750
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility
-* ADDED: Pass env to url quantization rack config to allow more flexibility
-* ADDED: Add rack instrumentation config option to accept callable to filter requests to trace
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility
+- ADDED: Pass env to url quantization rack config to allow more flexibility
+- ADDED: Add rack instrumentation config option to accept callable to filter requests to trace
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation
+- ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Add untraced endpoints config to rack middleware
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Add untraced endpoints config to rack middleware
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Only include user agent when present
+- FIXED: Only include user agent when present
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.1 / 2020-12-09
 
-* FIXED: Rack current_span
+- FIXED: Rack current_span
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Instrument rails
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Instrument rails
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Move context/span methods to Trace module
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Move context/span methods to Trace module
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Move context/span methods to Trace module
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* FIXED: Remove superfluous file from Rack gem
-* DOCS: Added README for Rack Instrumentation
-* DOCS: Standardize top-level docs structure and readme
+- FIXED: Remove superfluous file from Rack gem
+- DOCS: Added README for Rack Instrumentation
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -1,95 +1,95 @@
 # Release History: opentelemetry-instrumentation-rack
 
-### v0.30.0 / 2026-03-17
+## v0.30.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.29.0 / 2025-10-22
+## v0.29.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.28.2 / 2025-10-07
+## v0.28.2 / 2025-10-07
 
 - FIXED: Unify rack middleware_args
 
-### v0.28.1 / 2025-09-30
+## v0.28.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.28.0 / 2025-09-30
+## v0.28.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.27.1 / 2025-09-16
+## v0.27.1 / 2025-09-16
 
 - DOCS: Typo in Rack::Instrumentation usage example of middleware_args
 
-### v0.27.0 / 2025-08-19
+## v0.27.0 / 2025-08-19
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
-### v0.26.0 / 2025-01-16
+## v0.26.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.25.0 / 2024-10-23
+## v0.25.0 / 2024-10-23
 
 - ADDED: Set span error only for 5xx response range
 
-### v0.24.6 / 2024-07-23
+## v0.24.6 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.24.5 / 2024-06-18
+## v0.24.5 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.24.4 / 2024-05-09
+## v0.24.4 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.24.3 / 2024-05-08
+## v0.24.3 / 2024-05-08
 
 - FIXED: Rack event baggage handling
 
-### v0.24.2 / 2024-04-30
+## v0.24.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.24.1 / 2024-04-05
+## v0.24.1 / 2024-04-05
 
 - DOCS: Fix typo where Rake is mentioned instead of Rack
 
-### v0.24.0 / 2024-01-06
+## v0.24.0 / 2024-01-06
 
 - BREAKING CHANGE: Use Rack Events By Default
 - ADDED: Use Rack Events By Default
 - FIXED: Backport Rack proxy event to middleware
 
-### v0.23.5 / 2023-11-23
+## v0.23.5 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.23.4 / 2023-08-03
+## v0.23.4 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.23.3 / 2023-07-21
+## v0.23.3 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.23.2 / 2023-06-08
+## v0.23.2 / 2023-06-08
 
 - FIXED: Ensure Rack Events Handler Exists
 
-### v0.23.1 / 2023-06-05
+## v0.23.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.23.0 / 2023-04-17
+## v0.23.0 / 2023-04-17
 
 - BREAKING CHANGE: Remove retain_middleware_names Rack Option
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
@@ -97,35 +97,35 @@
 - ADDED: Drop support for EoL Ruby 2.7
 - ADDED: Use Rack::Events for instrumentation
 
-### v0.22.1 / 2023-01-14
+## v0.22.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.22.0 / 2022-11-16
+## v0.22.0 / 2022-11-16
 
 - ADDED: Add experimental traceresponse propagator to Rack instrumentation
 
-### v0.21.1 / 2022-10-04
+## v0.21.1 / 2022-10-04
 
 - FIXED: Bring http.request.header and http.response.header in line with semconv
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.20.2 / 2022-05-02
+## v0.20.2 / 2022-05-02
 
 - FIXED: Update server instrumentation to not reflect 400 status as error
 
-### v0.20.1 / 2021-12-01
+## v0.20.1 / 2021-12-01
 
 - FIXED: [Instrumentation Rack] Log content type http header
 - FIXED: Use monotonic clock where possible
 - FIXED: Rack to stop using api env getter
 
-### v0.20.0 / 2021-10-06
+## v0.20.0 / 2021-10-06
 
 - FIXED: Prevent high cardinality rack span name as a default [#973](https://github.com/open-telemetry/opentelemetry-ruby/pull/973)
 
@@ -135,34 +135,34 @@ cardinality span names. You can restore the previous behavior of high
 cardinality span names by passing in a url quantization function that
 forwards the uri path. More details on this is available in the readme.
 
-### v0.19.3 / 2021-09-29
+## v0.19.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.2 / 2021-08-18
+## v0.19.2 / 2021-08-18
 
 - FIXED: Rack middleware assuming script_name presence
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - ADDED: Add Tracer.non_recording_span to API
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Removed http.status_text attribute #750
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility
 - ADDED: Pass env to url quantization rack config to allow more flexibility
@@ -170,55 +170,55 @@ forwards the uri path. More details on this is available in the readme.
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Add untraced endpoints config to rack middleware
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - FIXED: Only include user agent when present
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.1 / 2020-12-09
+## v0.10.1 / 2020-12-09
 
 - FIXED: Rack current_span
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Instrument rails
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Move context/span methods to Trace module
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Move context/span methods to Trace module
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - FIXED: Remove superfluous file from Rack gem
 - DOCS: Added README for Rack Instrumentation
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/rails/CHANGELOG.md
+++ b/instrumentation/rails/CHANGELOG.md
@@ -7,16 +7,16 @@
 
 ### v0.39.1 / 2025-10-22
 
-* FIXED: Update opentelemetry-instrumentation-base dependency
+- FIXED: Update opentelemetry-instrumentation-base dependency
 
 ### v0.39.0 / 2025-10-21
 
-* BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
-* ADDED: Min Ruby Version 3.2 and Rails 7.1
+- BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
+- ADDED: Min Ruby Version 3.2 and Rails 7.1
 
 ### v0.38.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.37.0 / 2025-08-19
 
@@ -24,206 +24,206 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 
 ### v0.36.0 / 2025-02-04
 
-* ADDED: Add active_storage instrumentation to `rails`
-* ADDED: Strip Rails `(.:format)` suffix from `http.route` (action_pack)
+- ADDED: Add active_storage instrumentation to `rails`
+- ADDED: Strip Rails `(.:format)` suffix from `http.route` (action_pack)
 
 ### v0.35.1 / 2025-01-28
 
-* DOCS: Required version in Rails README from 0.24 to 0.34.
+- DOCS: Required version in Rails README from 0.24 to 0.34.
 
 ### v0.35.0 / 2025-01-16
 
-* BREAKING CHANGE: Drop Support for EoL Rails 6.1
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Drop Support for EoL Rails 6.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Drop Support for EoL Rails 6.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Drop Support for EoL Rails 6.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.34.1 / 2025-01-14
 
-* FIXED: Add Concurrent Ruby dependency to Rails
+- FIXED: Add Concurrent Ruby dependency to Rails
 
 ### v0.34.0 / 2024-12-19
 
-* ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
+- ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
 ### v0.33.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.33.0 / 2024-11-19
 
-* ADDED: Use Semconv Naming For ActionPack
+- ADDED: Use Semconv Naming For ActionPack
 
 ### v0.32.0 / 2024-10-22
 
-* BREAKING CHANGE: Rename Active Record find_by_sql spans to query
-* FIXED: Emit Active Record query spans for Rails 7.0+
-* ADDED: Subscribe to process.action_mailer notifications
+- BREAKING CHANGE: Rename Active Record find_by_sql spans to query
+- FIXED: Emit Active Record query spans for Rails 7.0+
+- ADDED: Subscribe to process.action_mailer notifications
 
 ### v0.31.2 / 2024-08-15
 
-* FIXED: Rails instrumentation should load ActiveJob instrumentation
+- FIXED: Rails instrumentation should load ActiveJob instrumentation
 
 ### v0.31.1 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.31.0 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
-* CHANGED: Update ActiveSupport Instrumentation
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
+- CHANGED: Update ActiveSupport Instrumentation
 
 ### v0.30.2 / 2024-06-04
 
-* FIXED: Add action_mailer to rails and all
+- FIXED: Add action_mailer to rails and all
 
 ### v0.30.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.30.0 / 2024-01-09
 
-* BREAKING CHANGE: Use ActiveSupport instead of patches #703
+- BREAKING CHANGE: Use ActiveSupport instead of patches #703
 
 ### v0.29.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.29.0 / 2023-11-22
 
-* BREAKING CHANGE: Drop Rails 6.0 EOL
-* ADDED: Drop Rails 6.0 EOL
+- BREAKING CHANGE: Drop Rails 6.0 EOL
+- ADDED: Drop Rails 6.0 EOL
 
 ### v0.28.1 / 2023-10-16
 
-* FIXED: Add Rails 7.1 compatibility
+- FIXED: Add Rails 7.1 compatibility
 
 ### v0.28.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.27.1 / 2023-06-05
 
-* FIXED: Use latest bug fix version for all dependencies
+- FIXED: Use latest bug fix version for all dependencies
 
 ### v0.27.0 / 2023-06-05
 
-* FIXED: Base config options
-* FIXED: Upgrade ActionPack and ActionView min versions
+- FIXED: Base config options
+- FIXED: Upgrade ActionPack and ActionView min versions
 
 ### v0.26.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.25.0 / 2023-02-08
 
-* BREAKING CHANGE: Update Instrumentations GraphQL, HttpClient, Rails [#303](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/303)
-* BREAKING CHANGE: Drop Rails 5 Support [#315](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/315)
-* DOCS: Rails Instrumentation Compatibility
+- BREAKING CHANGE: Update Instrumentations GraphQL, HttpClient, Rails [#303](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/303)
+- BREAKING CHANGE: Drop Rails 5 Support [#315](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/315)
+- DOCS: Rails Instrumentation Compatibility
 
 ### v0.24.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
+- DOCS: Fix gem homepage
 
 ### v0.24.0 / 2022-12-06
 
-* BREAKING CHANGE: Remove enable_recognize_route and span_naming options
-* FIXED: Remove enable_recognize_route and span_naming options
+- BREAKING CHANGE: Remove enable_recognize_route and span_naming options
+- FIXED: Remove enable_recognize_route and span_naming options
 
 ### v0.23.1 / 2022-11-08
 
-* FIXED: Bump rails instrumentation dependency on action_pack instrumentation
+- FIXED: Bump rails instrumentation dependency on action_pack instrumentation
 
 ### v0.23.0 / 2022-10-14
 
-* ADDED: Name ActionPack spans with the HTTP method and route
+- ADDED: Name ActionPack spans with the HTTP method and route
 
 ### v0.22.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.21.0 / 2022-05-02
 
-* ADDED: OTel Railtie
-* FIXED: RubyGems Fallback
+- ADDED: OTel Railtie
+- FIXED: RubyGems Fallback
 
 ### v0.20.0 / 2021-12-01
 
-* ADDED: Move activesupport notification subscriber out of action_view gem
-* FIXED: Instrumentation of Rails 7
+- ADDED: Move activesupport notification subscriber out of action_view gem
+- FIXED: Instrumentation of Rails 7
 
 ### v0.19.4 / 2021-10-06
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.3 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-09-09
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-08-12
 
-* ADDED: Instrument active record
-* ADDED: Add ActionView instrumentation via ActiveSupport::Notifications
-* FIXED: Rails instrumentation to not explicitly install sub gems
-* DOCS: Update docs to rely more on environment variable configuration
-* This release adds support for Active Record and Action View.
-* The `enable_recognize_route` configuration option has been moved to the ActionPack gem.
-* See readme for details on how to configure the sub instrumentation gems.
+- ADDED: Instrument active record
+- ADDED: Add ActionView instrumentation via ActiveSupport::Notifications
+- FIXED: Rails instrumentation to not explicitly install sub gems
+- DOCS: Update docs to rely more on environment variable configuration
+- This release adds support for Active Record and Action View.
+- The `enable_recognize_route` configuration option has been moved to the ActionPack gem.
+- See readme for details on how to configure the sub instrumentation gems.
 
 ### v0.18.1 / 2021-06-23
 
-* FIXED: Updated rack middleware position to zero
+- FIXED: Updated rack middleware position to zero
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Added http.route in rails instrumentation to match the spec
-* FIXED: Rails example by not using `rails` from git
-* FIXED: Updated rack middleware position to zero
+- ADDED: Added http.route in rails instrumentation to match the spec
+- FIXED: Rails example by not using `rails` from git
+- FIXED: Updated rack middleware position to zero
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Rails tests
-* FIXED: Copyright comments to not reference year
+- FIXED: Rails tests
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* FIXED: Otel-instrumentation-all not installing all
+- FIXED: Otel-instrumentation-all not installing all
 
 ### v0.9.0 / 2020-11-27
 
-* Initial release.
+- Initial release.

--- a/instrumentation/rails/CHANGELOG.md
+++ b/instrumentation/rails/CHANGELOG.md
@@ -1,176 +1,176 @@
 # Release History: opentelemetry-instrumentation-rails
 
-### v0.40.0 / 2026-03-17
+## v0.40.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.39.1 / 2025-10-22
+## v0.39.1 / 2025-10-22
 
 - FIXED: Update opentelemetry-instrumentation-base dependency
 
-### v0.39.0 / 2025-10-21
+## v0.39.0 / 2025-10-21
 
 - BREAKING CHANGE: Min Ruby Version 3.2 and Rails 7.1
 - ADDED: Min Ruby Version 3.2 and Rails 7.1
 
-### v0.38.0 / 2025-09-30
+## v0.38.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.37.0 / 2025-08-19
+## v0.37.0 / 2025-08-19
 
 ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
-### v0.36.0 / 2025-02-04
+## v0.36.0 / 2025-02-04
 
 - ADDED: Add active_storage instrumentation to `rails`
 - ADDED: Strip Rails `(.:format)` suffix from `http.route` (action_pack)
 
-### v0.35.1 / 2025-01-28
+## v0.35.1 / 2025-01-28
 
 - DOCS: Required version in Rails README from 0.24 to 0.34.
 
-### v0.35.0 / 2025-01-16
+## v0.35.0 / 2025-01-16
 
 - BREAKING CHANGE: Drop Support for EoL Rails 6.1
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Drop Support for EoL Rails 6.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.34.1 / 2025-01-14
+## v0.34.1 / 2025-01-14
 
 - FIXED: Add Concurrent Ruby dependency to Rails
 
-### v0.34.0 / 2024-12-19
+## v0.34.0 / 2024-12-19
 
 - ADDED: Upgrade ActiveSupport Instrumentation 0.7.0
 
-### v0.33.1 / 2024-11-26
+## v0.33.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.33.0 / 2024-11-19
+## v0.33.0 / 2024-11-19
 
 - ADDED: Use Semconv Naming For ActionPack
 
-### v0.32.0 / 2024-10-22
+## v0.32.0 / 2024-10-22
 
 - BREAKING CHANGE: Rename Active Record find_by_sql spans to query
 - FIXED: Emit Active Record query spans for Rails 7.0+
 - ADDED: Subscribe to process.action_mailer notifications
 
-### v0.31.2 / 2024-08-15
+## v0.31.2 / 2024-08-15
 
 - FIXED: Rails instrumentation should load ActiveJob instrumentation
 
-### v0.31.1 / 2024-07-23
+## v0.31.1 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.31.0 / 2024-07-02
+## v0.31.0 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 - CHANGED: Update ActiveSupport Instrumentation
 
-### v0.30.2 / 2024-06-04
+## v0.30.2 / 2024-06-04
 
 - FIXED: Add action_mailer to rails and all
 
-### v0.30.1 / 2024-04-30
+## v0.30.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.30.0 / 2024-01-09
+## v0.30.0 / 2024-01-09
 
 - BREAKING CHANGE: Use ActiveSupport instead of patches #703
 
-### v0.29.1 / 2023-11-23
+## v0.29.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.29.0 / 2023-11-22
+## v0.29.0 / 2023-11-22
 
 - BREAKING CHANGE: Drop Rails 6.0 EOL
 - ADDED: Drop Rails 6.0 EOL
 
-### v0.28.1 / 2023-10-16
+## v0.28.1 / 2023-10-16
 
 - FIXED: Add Rails 7.1 compatibility
 
-### v0.28.0 / 2023-09-07
+## v0.28.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.27.1 / 2023-06-05
+## v0.27.1 / 2023-06-05
 
 - FIXED: Use latest bug fix version for all dependencies
 
-### v0.27.0 / 2023-06-05
+## v0.27.0 / 2023-06-05
 
 - FIXED: Base config options
 - FIXED: Upgrade ActionPack and ActionView min versions
 
-### v0.26.0 / 2023-04-17
+## v0.26.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.25.0 / 2023-02-08
+## v0.25.0 / 2023-02-08
 
 - BREAKING CHANGE: Update Instrumentations GraphQL, HttpClient, Rails [#303](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/303)
 - BREAKING CHANGE: Drop Rails 5 Support [#315](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/315)
 - DOCS: Rails Instrumentation Compatibility
 
-### v0.24.1 / 2023-01-14
+## v0.24.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 
-### v0.24.0 / 2022-12-06
+## v0.24.0 / 2022-12-06
 
 - BREAKING CHANGE: Remove enable_recognize_route and span_naming options
 - FIXED: Remove enable_recognize_route and span_naming options
 
-### v0.23.1 / 2022-11-08
+## v0.23.1 / 2022-11-08
 
 - FIXED: Bump rails instrumentation dependency on action_pack instrumentation
 
-### v0.23.0 / 2022-10-14
+## v0.23.0 / 2022-10-14
 
 - ADDED: Name ActionPack spans with the HTTP method and route
 
-### v0.22.0 / 2022-06-09
+## v0.22.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.21.0 / 2022-05-02
+## v0.21.0 / 2022-05-02
 
 - ADDED: OTel Railtie
 - FIXED: RubyGems Fallback
 
-### v0.20.0 / 2021-12-01
+## v0.20.0 / 2021-12-01
 
 - ADDED: Move activesupport notification subscriber out of action_view gem
 - FIXED: Instrumentation of Rails 7
 
-### v0.19.4 / 2021-10-06
+## v0.19.4 / 2021-10-06
 
 - (No significant changes)
 
-### v0.19.3 / 2021-09-29
+## v0.19.3 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-09-09
+## v0.19.1 / 2021-09-09
 
 - (No significant changes)
 
-### v0.19.0 / 2021-08-12
+## v0.19.0 / 2021-08-12
 
 - ADDED: Instrument active record
 - ADDED: Add ActionView instrumentation via ActiveSupport::Notifications
@@ -180,50 +180,50 @@ ADDED: Add action_pack `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable comp
 - The `enable_recognize_route` configuration option has been moved to the ActionPack gem.
 - See readme for details on how to configure the sub instrumentation gems.
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - FIXED: Updated rack middleware position to zero
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Added http.route in rails instrumentation to match the spec
 - FIXED: Rails example by not using `rails` from git
 - FIXED: Updated rack middleware position to zero
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Rails tests
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - FIXED: Otel-instrumentation-all not installing all
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - Initial release.

--- a/instrumentation/rake/CHANGELOG.md
+++ b/instrumentation/rake/CHANGELOG.md
@@ -2,43 +2,43 @@
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.4.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.4.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.3.1 / 2025-06-03
 
-* FIXED: Handle force_flush for rake task with arguments
+- FIXED: Handle force_flush for rake task with arguments
 
 ### v0.3.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.2.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.2.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.1.1 / 2023-01-14
 
-* DOCS: More gem documentation fixes
+- DOCS: More gem documentation fixes
 
 ### v0.1.0 / 2022-10-14
 
-* Initial release.
+- Initial release.

--- a/instrumentation/rake/CHANGELOG.md
+++ b/instrumentation/rake/CHANGELOG.md
@@ -1,44 +1,44 @@
 # Release History: opentelemetry-instrumentation-rake
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.4.1 / 2025-09-30
+## v0.4.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.4.0 / 2025-09-30
+## v0.4.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.3.1 / 2025-06-03
+## v0.3.1 / 2025-06-03
 
 - FIXED: Handle force_flush for rake task with arguments
 
-### v0.3.0 / 2025-01-16
+## v0.3.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.2.2 / 2024-04-30
+## v0.2.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.2.1 / 2023-06-05
+## v0.2.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.2.0 / 2023-04-17
+## v0.2.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.1.1 / 2023-01-14
+## v0.1.1 / 2023-01-14
 
 - DOCS: More gem documentation fixes
 
-### v0.1.0 / 2022-10-14
+## v0.1.0 / 2022-10-14
 
 - Initial release.

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -2,102 +2,102 @@
 
 ### v0.9.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.8.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.8.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.7.0 / 2025-05-06
 
-* ADDED: Update minimum gem version requirement for rdkafka to 0.18.0
+- ADDED: Update minimum gem version requirement for rdkafka to 0.18.0
 
 ### v0.6.0 / 2025-02-11
 
-* ADDED: Rdkafka support to v0.19 including
+- ADDED: Rdkafka support to v0.19 including
 
 ### v0.5.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.4.9 / 2025-01-07
 
-* FIXED: Strict rdkafka support to v0.14
+- FIXED: Strict rdkafka support to v0.14
 
 ### v0.4.8 / 2024-07-23
 
-* DOCS: Link to rdkafka example
-* DOCS: Add cspell to CI
+- DOCS: Link to rdkafka example
+- DOCS: Add cspell to CI
 
 ### v0.4.7 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.4.6 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.4.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.4.4 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.4.3 / 2024-04-05
 
-* FIXED: Suppress deprecation warning in Rdkafka Instrumentation
+- FIXED: Suppress deprecation warning in Rdkafka Instrumentation
 
 ### v0.4.2 / 2023-11-23
 
-* FIXED: Retry Release of 0.4.1 [#730](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/730)
+- FIXED: Retry Release of 0.4.1 [#730](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/730)
 
 ### v0.4.1 / 2023-11-22
 
-* FIXED: Get Rdkafka version from VERSION constant
+- FIXED: Get Rdkafka version from VERSION constant
 
 ### v0.4.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.3.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.3.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.3.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.2.3 / 2023-03-24
 
-* FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
+- FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
 
 ### v0.2.2 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.2.1 / 2022-11-14
 
-* Loosen dependency on opentelemetry-api
+- Loosen dependency on opentelemetry-api
 
 ### v0.2.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.1.0 / 2022-05-02
 
-* Initial release.
+- Initial release.

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -1,103 +1,103 @@
 # Release History: opentelemetry-instrumentation-rdkafka
 
-### v0.9.0 / 2025-10-22
+## v0.9.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.8.1 / 2025-09-30
+## v0.8.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.8.0 / 2025-09-30
+## v0.8.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.7.0 / 2025-05-06
+## v0.7.0 / 2025-05-06
 
 - ADDED: Update minimum gem version requirement for rdkafka to 0.18.0
 
-### v0.6.0 / 2025-02-11
+## v0.6.0 / 2025-02-11
 
 - ADDED: Rdkafka support to v0.19 including
 
-### v0.5.0 / 2025-01-16
+## v0.5.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.4.9 / 2025-01-07
+## v0.4.9 / 2025-01-07
 
 - FIXED: Strict rdkafka support to v0.14
 
-### v0.4.8 / 2024-07-23
+## v0.4.8 / 2024-07-23
 
 - DOCS: Link to rdkafka example
 - DOCS: Add cspell to CI
 
-### v0.4.7 / 2024-07-02
+## v0.4.7 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.4.6 / 2024-06-18
+## v0.4.6 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.4.5 / 2024-05-09
+## v0.4.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.4.4 / 2024-04-30
+## v0.4.4 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.4.3 / 2024-04-05
+## v0.4.3 / 2024-04-05
 
 - FIXED: Suppress deprecation warning in Rdkafka Instrumentation
 
-### v0.4.2 / 2023-11-23
+## v0.4.2 / 2023-11-23
 
 - FIXED: Retry Release of 0.4.1 [#730](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/730)
 
-### v0.4.1 / 2023-11-22
+## v0.4.1 / 2023-11-22
 
 - FIXED: Get Rdkafka version from VERSION constant
 
-### v0.4.0 / 2023-09-07
+## v0.4.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.3.2 / 2023-07-21
+## v0.3.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.3.1 / 2023-06-05
+## v0.3.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.3.0 / 2023-04-17
+## v0.3.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.2.3 / 2023-03-24
+## v0.2.3 / 2023-03-24
 
 - FIXED: Skip recording non-utf8 kafka keys in racecar and rdkafka
 
-### v0.2.2 / 2023-01-14
+## v0.2.2 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.2.1 / 2022-11-14
+## v0.2.1 / 2022-11-14
 
 - Loosen dependency on opentelemetry-api
 
-### v0.2.0 / 2022-06-09
+## v0.2.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.1.0 / 2022-05-02
+## v0.1.0 / 2022-05-02
 
 - Initial release.

--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -1,110 +1,110 @@
 # Release History: opentelemetry-instrumentation-redis
 
-### v0.28.0 / 2025-10-22
+## v0.28.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.27.1 / 2025-09-30
+## v0.27.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.27.0 / 2025-09-30
+## v0.27.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.26.1 / 2025-02-04
+## v0.26.1 / 2025-02-04
 
 - FIXED: Do not expose auth params with Redis 5
 
-### v0.26.0 / 2025-01-16
+## v0.26.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.25.7 / 2024-07-23
+## v0.25.7 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.25.6 / 2024-06-18
+## v0.25.6 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.25.5 / 2024-05-09
+## v0.25.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.25.4 / 2024-04-30
+## v0.25.4 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.25.3 / 2023-08-03
+## v0.25.3 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.25.2 / 2023-07-21
+## v0.25.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.25.1 / 2023-06-05
+## v0.25.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.25.0 / 2023-04-17
+## v0.25.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.24.1 / 2023-01-14
+## v0.24.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.24.0 / 2022-09-14
+## v0.24.0 / 2022-09-14
 
 - ADDED: Redis-rb 5.0 and redis-client support
 
-### v0.23.0 / 2022-06-09
+## v0.23.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.22.1 / 2022-06-09
+## v0.22.1 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.22.0 / 2022-05-02
+## v0.22.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: Add appraisals for redis 4.2-4.6
 
-### v0.21.3 / 2022-02-02
+## v0.21.3 / 2022-02-02
 
 - FIXED: Prevent redis instrumentation from mutating the command
 
-### v0.21.2 / 2021-12-01
+## v0.21.2 / 2021-12-01
 
 - (No significant changes)
 
-### v0.21.1 / 2021-09-29
+## v0.21.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.21.0 / 2021-08-12
+## v0.21.0 / 2021-08-12
 
 - ADDED: Add toggle for redis db.statement attribute
 
-### v0.20.0 / 2021-06-23
+## v0.20.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.19.0 / 2021-05-28
+## v0.19.0 / 2021-05-28
 
 - ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
   refactor: redis attribute utils [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
@@ -113,62 +113,62 @@
 - ADDED: Option to obfuscate redis arguments
 - FIXED: Instrument Redis more thoroughly by patching Client#process.
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Update DB semantic conventions
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - (No significant changes)
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - ADDED: Accept config for redis peer service attribute
 - ADDED: Move utf8 encoding to common utils
 - FIXED: Copyright comments to not reference year
 
-### v0.10.1 / 2020-12-09
+## v0.10.1 / 2020-12-09
 
 - FIXED: Semantic conventions db.type -> db.system
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Redis attribute propagation
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Added redis documentation
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -2,173 +2,173 @@
 
 ### v0.28.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.27.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.26.1 / 2025-02-04
 
-* FIXED: Do not expose auth params with Redis 5
+- FIXED: Do not expose auth params with Redis 5
 
 ### v0.26.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.7 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.25.6 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.25.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.25.4 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.25.3 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.25.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.25.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.25.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.24.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.24.0 / 2022-09-14
 
-* ADDED: Redis-rb 5.0 and redis-client support
+- ADDED: Redis-rb 5.0 and redis-client support
 
 ### v0.23.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.22.1 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.22.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* FIXED: Add appraisals for redis 4.2-4.6
+- ADDED: Validate Using Enums
+- FIXED: Add appraisals for redis 4.2-4.6
 
 ### v0.21.3 / 2022-02-02
 
-* FIXED: Prevent redis instrumentation from mutating the command
+- FIXED: Prevent redis instrumentation from mutating the command
 
 ### v0.21.2 / 2021-12-01
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.21.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.21.0 / 2021-08-12
 
-* ADDED: Add toggle for redis db.statement attribute
+- ADDED: Add toggle for redis db.statement attribute
 
 ### v0.20.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.19.0 / 2021-05-28
 
-* ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
+- ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-refactor: redis attribute utils [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
-refactor: simplify redis attribute assignment [#758](https://github.com/open-telemetry/opentelemetry-ruby/pull/758)
-test: split redis instrumentation test [#754](https://github.com/open-telemetry/opentelemetry-ruby/pull/754)
-* ADDED: Option to obfuscate redis arguments
-* FIXED: Instrument Redis more thoroughly by patching Client#process.
+- ADDED: Updated API dependency for 1.0.0.rc1
+  refactor: redis attribute utils [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
+  refactor: simplify redis attribute assignment [#758](https://github.com/open-telemetry/opentelemetry-ruby/pull/758)
+  test: split redis instrumentation test [#754](https://github.com/open-telemetry/opentelemetry-ruby/pull/754)
+- ADDED: Option to obfuscate redis arguments
+- FIXED: Instrument Redis more thoroughly by patching Client#process.
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Update DB semantic conventions
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Update DB semantic conventions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation
+- ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* ADDED: Accept config for redis peer service attribute
-* ADDED: Move utf8 encoding to common utils
-* FIXED: Copyright comments to not reference year
+- ADDED: Accept config for redis peer service attribute
+- ADDED: Move utf8 encoding to common utils
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.1 / 2020-12-09
 
-* FIXED: Semantic conventions db.type -> db.system
+- FIXED: Semantic conventions db.type -> db.system
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Redis attribute propagation
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Redis attribute propagation
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Added redis documentation
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Added redis documentation
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/resque/CHANGELOG.md
+++ b/instrumentation/resque/CHANGELOG.md
@@ -2,75 +2,75 @@
 
 ### v0.8.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.7.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.7.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.6.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.5.2 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.5.1 / 2024-02-08
 
-* DOCS: Relocate Resque config option comments to render in Yard docs
+- DOCS: Relocate Resque config option comments to render in Yard docs
 
 ### v0.5.0 / 2023-09-07
 
-* FIXED: Align messaging instrumentation operation names
+- FIXED: Align messaging instrumentation operation names
 
 ### v0.4.2 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.4.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.4.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
-* ADDED: Add :force_flush option to Resque instrumentation
-* FIXED: Fix flaky tests for resque.
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
+- ADDED: Add :force_flush option to Resque instrumentation
+- FIXED: Fix flaky tests for resque.
 
 ### v0.3.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.3.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.2.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
+- ADDED: Validate Using Enums
 
 ### v0.1.3 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.1 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2021-06-23
 
-* Initial release.
+- Initial release.

--- a/instrumentation/resque/CHANGELOG.md
+++ b/instrumentation/resque/CHANGELOG.md
@@ -1,76 +1,76 @@
 # Release History: opentelemetry-instrumentation-resque
 
-### v0.8.0 / 2025-10-22
+## v0.8.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.7.1 / 2025-09-30
+## v0.7.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.7.0 / 2025-09-30
+## v0.7.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.6.0 / 2025-01-16
+## v0.6.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.5.2 / 2024-04-30
+## v0.5.2 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.5.1 / 2024-02-08
+## v0.5.1 / 2024-02-08
 
 - DOCS: Relocate Resque config option comments to render in Yard docs
 
-### v0.5.0 / 2023-09-07
+## v0.5.0 / 2023-09-07
 
 - FIXED: Align messaging instrumentation operation names
 
-### v0.4.2 / 2023-08-03
+## v0.4.2 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.4.1 / 2023-06-05
+## v0.4.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.4.0 / 2023-04-17
+## v0.4.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 - ADDED: Add :force_flush option to Resque instrumentation
 - FIXED: Fix flaky tests for resque.
 
-### v0.3.1 / 2023-01-14
+## v0.3.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.3.0 / 2022-06-09
+## v0.3.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.2.0 / 2022-05-02
+## v0.2.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 
-### v0.1.3 / 2021-12-02
+## v0.1.3 / 2021-12-02
 
 - (No significant changes)
 
-### v0.1.2 / 2021-09-29
+## v0.1.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.1.1 / 2021-08-12
+## v0.1.1 / 2021-08-12
 
 - (No significant changes)
 
-### v0.1.0 / 2021-06-23
+## v0.1.0 / 2021-06-23
 
 - Initial release.

--- a/instrumentation/restclient/CHANGELOG.md
+++ b/instrumentation/restclient/CHANGELOG.md
@@ -7,150 +7,150 @@
 
 ### v0.26.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.25.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.25.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.24.0 / 2025-08-13
 
-* ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
+- ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.8 / 2024-11-26
 
-* CHANGED: Performance Freeze all range objects #1222
+- CHANGED: Performance Freeze all range objects #1222
 
 ### v0.22.7 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.6 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.22.5 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.22.4 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.22.3 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.22.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.0 / 2023-01-14
 
-* ADDED: Add request/response hooks to more http clients
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- ADDED: Add request/response hooks to more http clients
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.4 / 2022-05-02
 
-* FIXED: Restclient invalid span attribute type Symbol
+- FIXED: Restclient invalid span attribute type Symbol
 
 ### v0.19.3 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: Removed http.status_text attribute #750
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: RestClient instrumentation accepts peer service config attribute.
-* FIXED: Refactor propagators to add #fields
+- ADDED: RestClient instrumentation accepts peer service config attribute.
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Remove passwords from http.url
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module
-* FIXED: Move context/span methods to Trace module
+- BREAKING CHANGE: Move context/span methods to Trace module
+- FIXED: Move context/span methods to Trace module
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/restclient/CHANGELOG.md
+++ b/instrumentation/restclient/CHANGELOG.md
@@ -1,156 +1,156 @@
 # Release History: opentelemetry-instrumentation-restclient
 
-### v0.27.0 / 2026-03-17
+## v0.27.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.26.0 / 2025-10-22
+## v0.26.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.25.1 / 2025-09-30
+## v0.25.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.25.0 / 2025-09-30
+## v0.25.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.24.0 / 2025-08-13
+## v0.24.0 / 2025-08-13
 
 - ADDED: Add REST Client `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1568](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1568)
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.8 / 2024-11-26
+## v0.22.8 / 2024-11-26
 
 - CHANGED: Performance Freeze all range objects #1222
 
-### v0.22.7 / 2024-07-23
+## v0.22.7 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.6 / 2024-06-18
+## v0.22.6 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.22.5 / 2024-05-09
+## v0.22.5 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.22.4 / 2024-04-30
+## v0.22.4 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.22.3 / 2023-11-23
+## v0.22.3 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.2 / 2023-07-21
+## v0.22.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.22.1 / 2023-06-05
+## v0.22.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.0 / 2023-01-14
+## v0.21.0 / 2023-01-14
 
 - ADDED: Add request/response hooks to more http clients
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.4 / 2022-05-02
+## v0.19.4 / 2022-05-02
 
 - FIXED: Restclient invalid span attribute type Symbol
 
-### v0.19.3 / 2021-12-02
+## v0.19.3 / 2021-12-02
 
 - (No significant changes)
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: Removed http.status_text attribute #750
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: RestClient instrumentation accepts peer service config attribute.
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Remove passwords from http.url
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Move context/span methods to Trace module
 - FIXED: Move context/span methods to Trace module
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/rspec/CHANGELOG.md
+++ b/instrumentation/rspec/CHANGELOG.md
@@ -2,56 +2,56 @@
 
 ### v0.7.0 / 2025-11-04
 
-* ADDED: Add example.id attribute to RSpec instrumentation
-* FIXED: Capture correct descriptions for RSpec one-liner examples
+- ADDED: Add example.id attribute to RSpec instrumentation
+- FIXED: Capture correct descriptions for RSpec one-liner examples
 
 ### v0.6.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.5.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.5.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.4.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.3.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.3.2 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.3.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.3.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
-* DOCS: Fix typo in rspec example
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
+- DOCS: Fix typo in rspec example
 
 ### v0.2.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.2.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Strip console codes from RSpec messages and better handle multiple failures
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Strip console codes from RSpec messages and better handle multiple failures
+- FIXED: Broken test file requirements
 
 ### v0.1.0 / 2021-12-01
 
-* Initial release.
+- Initial release.

--- a/instrumentation/rspec/CHANGELOG.md
+++ b/instrumentation/rspec/CHANGELOG.md
@@ -1,57 +1,57 @@
 # Release History: opentelemetry-instrumentation-rspec
 
-### v0.7.0 / 2025-11-04
+## v0.7.0 / 2025-11-04
 
 - ADDED: Add example.id attribute to RSpec instrumentation
 - FIXED: Capture correct descriptions for RSpec one-liner examples
 
-### v0.6.0 / 2025-10-22
+## v0.6.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.5.1 / 2025-09-30
+## v0.5.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.5.0 / 2025-09-30
+## v0.5.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.4.0 / 2025-01-16
+## v0.4.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.3.3 / 2024-04-30
+## v0.3.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.3.2 / 2023-11-23
+## v0.3.2 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.3.1 / 2023-06-05
+## v0.3.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.3.0 / 2023-04-17
+## v0.3.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 - DOCS: Fix typo in rspec example
 
-### v0.2.1 / 2023-01-14
+## v0.2.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.2.0 / 2022-06-09
+## v0.2.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Strip console codes from RSpec messages and better handle multiple failures
 - FIXED: Broken test file requirements
 
-### v0.1.0 / 2021-12-01
+## v0.1.0 / 2021-12-01
 
 - Initial release.

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -2,113 +2,113 @@
 
 ### v0.24.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.23.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.23.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.3 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.21.2 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.21.1 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.21.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.20.2 / 2023-08-09
 
-* FIXED: propagate context from async producer
+- FIXED: propagate context from async producer
 
 ### v0.20.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.20.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.19.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.19.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.18.6 / 2022-05-02
 
-* FIXED: RubyGems Fallback
+- FIXED: RubyGems Fallback
 
 ### v0.18.5 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.4 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.3 / 2021-09-29
 
-* FIXED: Use Kafka::VERSION fallback for compatibility
+- FIXED: Use Kafka::VERSION fallback for compatibility
 
 ### v0.18.2 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.18.1 / 2021-06-23
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Add minimum gem version for ruby-kafka
-* FIXED: Ruby_kafka baggage propagation
-* FIXED: Remove unused ruby-kafka events file
+- FIXED: Add minimum gem version for ruby-kafka
+- FIXED: Ruby_kafka baggage propagation
+- FIXED: Remove unused ruby-kafka events file
 
 ### v0.12.0 / 2020-12-24
 
-* Initial release.
+- Initial release.

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -1,114 +1,114 @@
 # Release History: opentelemetry-instrumentation-ruby_kafka
 
-### v0.24.0 / 2025-10-22
+## v0.24.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.23.1 / 2025-09-30
+## v0.23.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.23.0 / 2025-09-30
+## v0.23.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.3 / 2024-07-23
+## v0.21.3 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.21.2 / 2024-07-02
+## v0.21.2 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.21.1 / 2024-04-30
+## v0.21.1 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.21.0 / 2023-09-07
+## v0.21.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.20.2 / 2023-08-09
+## v0.20.2 / 2023-08-09
 
 - FIXED: propagate context from async producer
 
-### v0.20.1 / 2023-06-05
+## v0.20.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.20.0 / 2023-04-17
+## v0.20.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.19.1 / 2023-01-14
+## v0.19.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.19.0 / 2022-06-09
+## v0.19.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.18.6 / 2022-05-02
+## v0.18.6 / 2022-05-02
 
 - FIXED: RubyGems Fallback
 
-### v0.18.5 / 2021-12-02
+## v0.18.5 / 2021-12-02
 
 - (No significant changes)
 
-### v0.18.4 / 2021-09-29
+## v0.18.4 / 2021-09-29
 
 - (No significant changes)
 
-### v0.18.3 / 2021-09-29
+## v0.18.3 / 2021-09-29
 
 - FIXED: Use Kafka::VERSION fallback for compatibility
 
-### v0.18.2 / 2021-08-12
+## v0.18.2 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.18.1 / 2021-06-23
+## v0.18.1 / 2021-06-23
 
 - (No significant changes)
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - FIXED: Add minimum gem version for ruby-kafka
 - FIXED: Ruby_kafka baggage propagation
 - FIXED: Remove unused ruby-kafka events file
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - Initial release.

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -2,191 +2,191 @@
 
 ### v0.28.1 / 2025-12-02
 
-* FIXED: Sidekiq spans crashing when enqueued by Exq
+- FIXED: Sidekiq spans crashing when enqueued by Exq
 
 ### v0.28.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.27.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.26.1 / 2025-04-01
 
-* FIXED: Add support for Sidekiq 8
+- FIXED: Add support for Sidekiq 8
 
 ### v0.26.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.25.7 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.25.6 / 2024-07-02
 
-* DOCS: Fix CHANGELOGs to reflect a past breaking change
+- DOCS: Fix CHANGELOGs to reflect a past breaking change
 
 ### v0.25.5 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.25.4 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.25.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.25.2 / 2024-02-08
 
-* DOCS: Fix doc for sidekiq options.
+- DOCS: Fix doc for sidekiq options.
 
 ### v0.25.1 / 2024-02-08
 
-* DOCS: ✏️ Sidekiq instrumentation options
+- DOCS: ✏️ Sidekiq instrumentation options
 
 ### v0.25.0 / 2023-09-07
 
-* BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
+- BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
 ### v0.24.4 / 2023-08-07
 
-* FIXED: Allow traces inside jobs while avoiding Redis noise
+- FIXED: Allow traces inside jobs while avoiding Redis noise
 
 ### v0.24.3 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.24.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.24.1 / 2023-06-05
 
-* FIXED: Base config options
+- FIXED: Base config options
 
 ### v0.24.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.23.0 / 2023-02-01
 
-* BREAKING CHANGE: Drop Rails 5 Support
-* ADDED: Drop Rails 5 Support
+- BREAKING CHANGE: Drop Rails 5 Support
+- ADDED: Drop Rails 5 Support
 
 ### v0.22.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.22.0 / 2022-06-09
 
-* Upgrading Base dependency version
+- Upgrading Base dependency version
 
 ### v0.21.1 / 2022-06-09
 
-* FIXED: Broken test file requirements
-* FIXED: Make sidekiq instrumentation compatible with sidekiq 6.5.0
+- FIXED: Broken test file requirements
+- FIXED: Make sidekiq instrumentation compatible with sidekiq 6.5.0
 
 ### v0.21.0 / 2022-05-02
 
-* ADDED: Validate Using Enums
-* FIXED: RubyGems Fallback
+- ADDED: Validate Using Enums
+- FIXED: RubyGems Fallback
 
 ### v0.20.2 / 2021-12-02
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.20.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.20.0 / 2021-08-18
 
-* ADDED: Gracefully flush provider on sidekiq shutdown event
+- ADDED: Gracefully flush provider on sidekiq shutdown event
 
 ### v0.19.1 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Sidekiq propagation config
+- BREAKING CHANGE: Sidekiq propagation config
   - Config option enable_job_class_span_names renamed to span_naming and now expects a symbol of value :job_class, or :queue
-  - The default behavior is no longer to have one continuous trace for the enqueue and process spans, using links is the new default.  To maintain the previous behavior the config option propagation_style must be set to :child.
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Sidekiq propagation config
-* FIXED: Total order constraint on span.status=
+  - The default behavior is no longer to have one continuous trace for the enqueue and process spans, using links is the new default. To maintain the previous behavior the config option propagation_style must be set to :child.
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Sidekiq propagation config
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* TEST: update test for redis instrumentation refactor [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
-* BREAKING CHANGE: Remove optional parent_context from in_span
-* FIXED: Remove optional parent_context from in_span
-* FIXED: Instrument Redis more thoroughly by patching Client#process.
+- ADDED: Updated API dependency for 1.0.0.rc1
+- TEST: update test for redis instrumentation refactor [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
+- BREAKING CHANGE: Remove optional parent_context from in_span
+- FIXED: Remove optional parent_context from in_span
+- FIXED: Instrument Redis more thoroughly by patching Client#process.
 
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Accept config for sidekiq peer service attribute
+- ADDED: Accept config for sidekiq peer service attribute
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation
+- ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* ADDED: Instrument sidekiq background work
-* FIXED: Adjust Sidekiq middlewares to match semantic conventions
-* FIXED: Set minimum compatible version and use untraced helper
+- ADDED: Instrument sidekiq background work
+- FIXED: Adjust Sidekiq middlewares to match semantic conventions
+- FIXED: Set minimum compatible version and use untraced helper
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Adding README for Sidekiq instrumentation
-* DOCS: Remove duplicate reference in Sidekiq README
-* DOCS: Standardize top-level docs structure and readme
+- DOCS: Adding README for Sidekiq instrumentation
+- DOCS: Remove duplicate reference in Sidekiq README
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -1,125 +1,125 @@
 # Release History: opentelemetry-instrumentation-sidekiq
 
-### v0.28.1 / 2025-12-02
+## v0.28.1 / 2025-12-02
 
 - FIXED: Sidekiq spans crashing when enqueued by Exq
 
-### v0.28.0 / 2025-10-22
+## v0.28.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.27.1 / 2025-09-30
+## v0.27.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.27.0 / 2025-09-30
+## v0.27.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.26.1 / 2025-04-01
+## v0.26.1 / 2025-04-01
 
 - FIXED: Add support for Sidekiq 8
 
-### v0.26.0 / 2025-01-16
+## v0.26.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.25.7 / 2024-07-23
+## v0.25.7 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.25.6 / 2024-07-02
+## v0.25.6 / 2024-07-02
 
 - DOCS: Fix CHANGELOGs to reflect a past breaking change
 
-### v0.25.5 / 2024-06-18
+## v0.25.5 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.25.4 / 2024-05-09
+## v0.25.4 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.25.3 / 2024-04-30
+## v0.25.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.25.2 / 2024-02-08
+## v0.25.2 / 2024-02-08
 
 - DOCS: Fix doc for sidekiq options.
 
-### v0.25.1 / 2024-02-08
+## v0.25.1 / 2024-02-08
 
 - DOCS: ✏️ Sidekiq instrumentation options
 
-### v0.25.0 / 2023-09-07
+## v0.25.0 / 2023-09-07
 
 - BREAKING CHANGE: Align messaging instrumentation operation names [#648](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/648)
 
-### v0.24.4 / 2023-08-07
+## v0.24.4 / 2023-08-07
 
 - FIXED: Allow traces inside jobs while avoiding Redis noise
 
-### v0.24.3 / 2023-08-03
+## v0.24.3 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.24.2 / 2023-07-21
+## v0.24.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.24.1 / 2023-06-05
+## v0.24.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.24.0 / 2023-04-17
+## v0.24.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.23.0 / 2023-02-01
+## v0.23.0 / 2023-02-01
 
 - BREAKING CHANGE: Drop Rails 5 Support
 - ADDED: Drop Rails 5 Support
 
-### v0.22.1 / 2023-01-14
+## v0.22.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.22.0 / 2022-06-09
+## v0.22.0 / 2022-06-09
 
 - Upgrading Base dependency version
 
-### v0.21.1 / 2022-06-09
+## v0.21.1 / 2022-06-09
 
 - FIXED: Broken test file requirements
 - FIXED: Make sidekiq instrumentation compatible with sidekiq 6.5.0
 
-### v0.21.0 / 2022-05-02
+## v0.21.0 / 2022-05-02
 
 - ADDED: Validate Using Enums
 - FIXED: RubyGems Fallback
 
-### v0.20.2 / 2021-12-02
+## v0.20.2 / 2021-12-02
 
 - (No significant changes)
 
-### v0.20.1 / 2021-09-29
+## v0.20.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.20.0 / 2021-08-18
+## v0.20.0 / 2021-08-18
 
 - ADDED: Gracefully flush provider on sidekiq shutdown event
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - (No significant changes)
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Sidekiq propagation config
   - Config option enable_job_class_span_names renamed to span_naming and now expects a symbol of value :job_class, or :queue
@@ -128,7 +128,7 @@
 - FIXED: Sidekiq propagation config
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - TEST: update test for redis instrumentation refactor [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
@@ -136,57 +136,57 @@
 - FIXED: Remove optional parent_context from in_span
 - FIXED: Instrument Redis more thoroughly by patching Client#process.
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - ADDED: Accept config for sidekiq peer service attribute
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - ADDED: Add instrumentation config validation
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - ADDED: Instrument sidekiq background work
 - FIXED: Adjust Sidekiq middlewares to match semantic conventions
 - FIXED: Set minimum compatible version and use untraced helper
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - (No significant changes)
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - DOCS: Adding README for Sidekiq instrumentation
 - DOCS: Remove duplicate reference in Sidekiq README
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/sinatra/CHANGELOG.md
+++ b/instrumentation/sinatra/CHANGELOG.md
@@ -1,182 +1,182 @@
 # Release History: opentelemetry-instrumentation-sinatra
 
-### v0.29.0 / 2026-03-17
+## v0.29.0 / 2026-03-17
 
-* BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
-* ADDED: Default to stable HTTP semantic conventions (#2051)
+- BREAKING CHANGE: Default to stable HTTP semantic conventions (#2051)
+- ADDED: Default to stable HTTP semantic conventions (#2051)
 
-### v0.28.0 / 2025-10-22
+## v0.28.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.27.1 / 2025-10-07
+## v0.27.1 / 2025-10-07
 
 - FIXED: Unify rack middleware_args
 
-### v0.27.0 / 2025-09-30
+## v0.27.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.26.0 / 2025-08-19
+## v0.26.0 / 2025-08-19
 
 - ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
-### v0.25.0 / 2025-01-16
+## v0.25.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.24.1 / 2024-07-23
+## v0.24.1 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.24.0 / 2024-07-02
+## v0.24.0 / 2024-07-02
 
 - ADDED: Make Rack install optional for sinatra
 
-### v0.23.5 / 2024-06-18
+## v0.23.5 / 2024-06-18
 
 - FIXED: Relax otel common gem constraints
 
-### v0.23.4 / 2024-05-09
+## v0.23.4 / 2024-05-09
 
 - FIXED: Untrace entire request
 
-### v0.23.3 / 2024-04-30
+## v0.23.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.23.2 / 2023-07-21
+## v0.23.2 / 2023-07-21
 
 - ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
-### v0.23.1 / 2023-06-05
+## v0.23.1 / 2023-06-05
 
 - (No significant changes)
 
-### v0.23.0 / 2023-06-05
+## v0.23.0 / 2023-06-05
 
 - ADDED: Use Rack Middleware Helper
 - FIXED: Base config options
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.5 / 2023-02-13
+## v0.21.5 / 2023-02-13
 
 - FIXED: Add exceptions to sinatra spans, ruboproof test.
 
-### v0.21.4 / 2023-02-08
+## v0.21.4 / 2023-02-08
 
 - CHANGED: incorrect error type being recorded when Sinatra route raises exception [#317](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/317)
 
-### v0.21.3 / 2023-01-27
+## v0.21.3 / 2023-01-27
 
 - fix: Check if env['sinatra.error'] exists before recording it
 
-### v0.21.2 / 2023-01-14
+## v0.21.2 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.1 / 2022-11-16
+## v0.21.1 / 2022-11-16
 
 - FIXED: Loosen dependency on Rack
 
-### v0.21.0 / 2022-10-12
+## v0.21.0 / 2022-10-12
 
 - ADDED: Use rack middleware in sinatra middleware
 - FIXED: Add exceptions to sinatra spans.
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.19.4 / 2022-05-02
+## v0.19.4 / 2022-05-02
 
 - FIXED: Update server instrumentation to not reflect 400 status as error
 
-### v0.19.3 / 2021-12-01
+## v0.19.3 / 2021-12-01
 
 - FIXED: Sinatra to stop using api env getter
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - DOCS: Update docs to rely more on environment variable configuration
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Total order constraint on span.status=
 - FIXED: Total order constraint on span.status=
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - BREAKING CHANGE: Remove optional parent_context from in_span
 - FIXED: Remove optional parent_context from in_span
 - FIXED: Removed http.status_text attribute #750
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - (No significant changes)
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - FIXED: Example scripts now reference local common lib
 - DOCS: Replace Gitter with GitHub Discussions
 
-### v0.15.0 / 2021-02-18
+## v0.15.0 / 2021-02-18
 
 - (No significant changes)
 
-### v0.14.0 / 2021-02-03
+## v0.14.0 / 2021-02-03
 
 - BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 - ADDED: Replace getter and setter callables and remove rack specific propagators
 
-### v0.13.0 / 2021-01-29
+## v0.13.0 / 2021-01-29
 
 - (No significant changes)
 
-### v0.12.0 / 2020-12-24
+## v0.12.0 / 2020-12-24
 
 - (No significant changes)
 
-### v0.11.0 / 2020-12-11
+## v0.11.0 / 2020-12-11
 
 - FIXED: Copyright comments to not reference year
 
-### v0.10.0 / 2020-12-03
+## v0.10.0 / 2020-12-03
 
 - (No significant changes)
 
-### v0.9.0 / 2020-11-27
+## v0.9.0 / 2020-11-27
 
 - BREAKING CHANGE: Add timeout for force_flush and shutdown
 - ADDED: Add timeout for force_flush and shutdown
 
-### v0.8.0 / 2020-10-27
+## v0.8.0 / 2020-10-27
 
 - BREAKING CHANGE: Remove 'canonical' from status codes
 - FIXED: Remove 'canonical' from status codes
 
-### v0.7.1 / 2020-10-08
+## v0.7.1 / 2020-10-08
 
 - FIXED: Set span name to sinatra.route
 
-### v0.7.0 / 2020-10-07
+## v0.7.0 / 2020-10-07
 
 - FIXED: Default to sinatra.route for span name
 - DOCS: Standardize top-level docs structure and readme
 
-### v0.6.0 / 2020-09-10
+## v0.6.0 / 2020-09-10
 
 - (No significant changes)

--- a/instrumentation/sinatra/CHANGELOG.md
+++ b/instrumentation/sinatra/CHANGELOG.md
@@ -7,176 +7,176 @@
 
 ### v0.28.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.27.1 / 2025-10-07
 
-* FIXED: Unify rack middleware_args
+- FIXED: Unify rack middleware_args
 
 ### v0.27.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.26.0 / 2025-08-19
 
-* ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
+- ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable compatibility for Rack integration [#1594](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1594)
 
 ### v0.25.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.24.1 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.24.0 / 2024-07-02
 
-* ADDED: Make Rack install optional for sinatra
+- ADDED: Make Rack install optional for sinatra
 
 ### v0.23.5 / 2024-06-18
 
-* FIXED: Relax otel common gem constraints
+- FIXED: Relax otel common gem constraints
 
 ### v0.23.4 / 2024-05-09
 
-* FIXED: Untrace entire request
+- FIXED: Untrace entire request
 
 ### v0.23.3 / 2024-04-30
 
-* FIXED: Bundler conflict warnings
+- FIXED: Bundler conflict warnings
 
 ### v0.23.2 / 2023-07-21
 
-* ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
+- ADDED: Update `opentelemetry-common` from [0.19.3 to 0.20.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/537)
 
 ### v0.23.1 / 2023-06-05
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.23.0 / 2023-06-05
 
-* ADDED: Use Rack Middleware Helper
-* FIXED: Base config options
+- ADDED: Use Rack Middleware Helper
+- FIXED: Base config options
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.5 / 2023-02-13
 
-* FIXED: Add exceptions to sinatra spans, ruboproof test.
+- FIXED: Add exceptions to sinatra spans, ruboproof test.
 
 ### v0.21.4 / 2023-02-08
 
-* CHANGED: incorrect error type being recorded when Sinatra route raises exception [#317](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/317)
+- CHANGED: incorrect error type being recorded when Sinatra route raises exception [#317](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/317)
 
 ### v0.21.3 / 2023-01-27
 
-* fix: Check if env['sinatra.error'] exists before recording it
+- fix: Check if env['sinatra.error'] exists before recording it
 
 ### v0.21.2 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.1 / 2022-11-16
 
-* FIXED: Loosen dependency on Rack
+- FIXED: Loosen dependency on Rack
 
 ### v0.21.0 / 2022-10-12
 
-* ADDED: Use rack middleware in sinatra middleware
-* FIXED: Add exceptions to sinatra spans.
+- ADDED: Use rack middleware in sinatra middleware
+- FIXED: Add exceptions to sinatra spans.
 
 ### v0.20.0 / 2022-06-09
 
-* Upgrading Base dependency version
-* FIXED: Broken test file requirements
+- Upgrading Base dependency version
+- FIXED: Broken test file requirements
 
 ### v0.19.4 / 2022-05-02
 
-* FIXED: Update server instrumentation to not reflect 400 status as error
+- FIXED: Update server instrumentation to not reflect 400 status as error
 
 ### v0.19.3 / 2021-12-01
 
-* FIXED: Sinatra to stop using api env getter
+- FIXED: Sinatra to stop using api env getter
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* DOCS: Update docs to rely more on environment variable configuration
+- DOCS: Update docs to rely more on environment variable configuration
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Total order constraint on span.status=
-* FIXED: Total order constraint on span.status=
+- BREAKING CHANGE: Total order constraint on span.status=
+- FIXED: Total order constraint on span.status=
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* BREAKING CHANGE: Remove optional parent_context from in_span
-* FIXED: Remove optional parent_context from in_span
-* FIXED: Removed http.status_text attribute #750
+- ADDED: Updated API dependency for 1.0.0.rc1
+- BREAKING CHANGE: Remove optional parent_context from in_span
+- FIXED: Remove optional parent_context from in_span
+- FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib
-* DOCS: Replace Gitter with GitHub Discussions
+- FIXED: Example scripts now reference local common lib
+- DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
-* ADDED: Replace getter and setter callables and remove rack specific propagators
+- BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
+- ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.12.0 / 2020-12-24
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year
+- FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown
-* ADDED: Add timeout for force_flush and shutdown
+- BREAKING CHANGE: Add timeout for force_flush and shutdown
+- ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Remove 'canonical' from status codes
-* FIXED: Remove 'canonical' from status codes
+- BREAKING CHANGE: Remove 'canonical' from status codes
+- FIXED: Remove 'canonical' from status codes
 
 ### v0.7.1 / 2020-10-08
 
-* FIXED: Set span name to sinatra.route
+- FIXED: Set span name to sinatra.route
 
 ### v0.7.0 / 2020-10-07
 
-* FIXED: Default to sinatra.route for span name
-* DOCS: Standardize top-level docs structure and readme
+- FIXED: Default to sinatra.route for span name
+- DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 
-* (No significant changes)
+- (No significant changes)

--- a/instrumentation/trilogy/CHANGELOG.md
+++ b/instrumentation/trilogy/CHANGELOG.md
@@ -6,41 +6,41 @@
 
 ### v0.66.0 / 2026-01-13
 
-* ADDED: Add SQL Comment Propagator
+- ADDED: Add SQL Comment Propagator
 
 ### v0.65.1 / 2025-12-03
 
-* FIXED: Update gemspec dependencies to sql-processor
+- FIXED: Update gemspec dependencies to sql-processor
 
 ### v0.65.0 / 2025-12-02
 
-* ADDED: Replace references sql-obfuscation -> sql-processor
+- ADDED: Replace references sql-obfuscation -> sql-processor
 
 ### v0.64.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.63.1 / 2025-09-30
 
-* FIXED: Min OTel Ruby API 1.7
+- FIXED: Min OTel Ruby API 1.7
 
 ### v0.63.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.62.0 / 2025-09-25
 
-* ADDED: Trilogy: introduce record_exception setting
+- ADDED: Trilogy: introduce record_exception setting
 
 ### v0.61.1 / 2025-04-16
 
-* refactor: Use SQL helpers for context attributes #1271
+- refactor: Use SQL helpers for context attributes #1271
 
 ### v0.61.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.60.0 / 2024-09-12
 

--- a/instrumentation/trilogy/CHANGELOG.md
+++ b/instrumentation/trilogy/CHANGELOG.md
@@ -1,142 +1,142 @@
 # Release History: opentelemetry-instrumentation-trilogy
 
-### v0.67.0 / 2026-03-17
+## v0.67.0 / 2026-03-17
 
-* ADDED: Cache static span attributes in Trilogy instrumentation (#2089)
+- ADDED: Cache static span attributes in Trilogy instrumentation (#2089)
 
-### v0.66.0 / 2026-01-13
+## v0.66.0 / 2026-01-13
 
 - ADDED: Add SQL Comment Propagator
 
-### v0.65.1 / 2025-12-03
+## v0.65.1 / 2025-12-03
 
 - FIXED: Update gemspec dependencies to sql-processor
 
-### v0.65.0 / 2025-12-02
+## v0.65.0 / 2025-12-02
 
 - ADDED: Replace references sql-obfuscation -> sql-processor
 
-### v0.64.0 / 2025-10-22
+## v0.64.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.63.1 / 2025-09-30
+## v0.63.1 / 2025-09-30
 
 - FIXED: Min OTel Ruby API 1.7
 
-### v0.63.0 / 2025-09-30
+## v0.63.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.62.0 / 2025-09-25
+## v0.62.0 / 2025-09-25
 
 - ADDED: Trilogy: introduce record_exception setting
 
-### v0.61.1 / 2025-04-16
+## v0.61.1 / 2025-04-16
 
 - refactor: Use SQL helpers for context attributes #1271
 
-### v0.61.0 / 2025-01-16
+## v0.61.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.60.0 / 2024-09-12
+## v0.60.0 / 2024-09-12
 
 - BREAKING CHANGE: Return message when sql is over the obfuscation limit. Fixes a bug where sql statements with prepended comments that hit the obfuscation limit would be sent raw.
 
-### v0.59.3 / 2024-04-30
+## v0.59.3 / 2024-04-30
 
 - FIXED: Bundler conflict warnings
 
-### v0.59.2 / 2024-02-20
+## v0.59.2 / 2024-02-20
 
 - FIXED: Dup string if frozen in trilogy query
 
-### v0.59.1 / 2024-02-08
+## v0.59.1 / 2024-02-08
 
 - FIXED: Add missing requires for sql-helpers to mysql, pg, and trilogy instrumentation
 
-### v0.59.0 / 2024-02-08
+## v0.59.0 / 2024-02-08
 
 - BREAKING CHANGE: Move shared sql behavior to helper gems
 
 - ADDED: Propagate context to Vitess
 
-### v0.58.0 / 2024-01-06
+## v0.58.0 / 2024-01-06
 
 - BREAKING CHANGE: Change db.mysql.instance.address to db.instance.id
 
 - ADDED: Change db.mysql.instance.address to db.instance.id
 - FIXED: Trilogy only set db.instance.id attribute if there is a value
 
-### v0.57.0 / 2023-10-27
+## v0.57.0 / 2023-10-27
 
 - ADDED: Instrument connect and ping
 
-### v0.56.3 / 2023-08-03
+## v0.56.3 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.56.2 / 2023-07-14
+## v0.56.2 / 2023-07-14
 
 - ADDED: `db.user` attribute (recommended connection-level attribute)
 
-### v0.56.1 / 2023-06-05
+## v0.56.1 / 2023-06-05
 
 - FIXED: Base config options
 
-### v0.56.0 / 2023-06-02
+## v0.56.0 / 2023-06-02
 
 - BREAKING CHANGE: Separate logical MySQL host from connected host
 
 - ADDED: Separate logical MySQL host from connected host
 
-### v0.55.1 / 2023-06-01
+## v0.55.1 / 2023-06-01
 
 - FIXED: Regex non-match with obfuscation limit (issue #486)
 
-### v0.55.0 / 2023-05-31
+## v0.55.0 / 2023-05-31
 
 - BREAKING CHANGE: Add database name for trilogy traces
 
 - ADDED: Add database name for trilogy traces
 
-### v0.54.0 / 2023-05-25
+## v0.54.0 / 2023-05-25
 
 - ADDED: Add Obfuscation Limit Option to Trilogy
 
-### v0.53.0 / 2023-04-17
+## v0.53.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.52.0 / 2023-03-06
+## v0.52.0 / 2023-03-06
 
 - ADDED: Add with_attributes context propagation to Trilogy instrumentation
 - ADDED: Add option to configure span name for trilogy
 - FIXED: Ensure encoding errors handled during SQL obfuscation for Trilogy
 
-### v0.51.1 / 2023-01-14
+## v0.51.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.51.0 / 2022-06-09
+## v0.51.0 / 2022-06-09
 
 - Upgrading Base dependency version
 - FIXED: Broken test file requirements
 
-### v0.50.2 / 2022-05-05
+## v0.50.2 / 2022-05-05
 
 - (No significant changes)
 
-### v0.50.1 / 2022-01-07
+## v0.50.1 / 2022-01-07
 
 - FIXED: Trilogy Driver Options
 
-### v0.50.0 / 2021-12-31
+## v0.50.0 / 2021-12-31
 
 - Initial release.

--- a/processor/baggage/CHANGELOG.md
+++ b/processor/baggage/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Release History: opentelemetry-processor-baggage
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.4.0 / 2025-09-30
+## v0.4.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.3.0 / 2025-01-16
+## v0.3.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.2.1 / 2024-11-26
+## v0.2.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.2.0 / 2024-06-18
+## v0.2.0 / 2024-06-18
 
 - BREAKING CHANGE: Add baggage key predicate func to baggage span processor
 - ADDED: Add baggage key predicate func to baggage span processor
 
-### v0.1.0 / 2024-04-18
+## v0.1.0 / 2024-04-18
 
 - Initial release.

--- a/processor/baggage/CHANGELOG.md
+++ b/processor/baggage/CHANGELOG.md
@@ -2,28 +2,28 @@
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.4.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.3.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.2.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.2.0 / 2024-06-18
 
-* BREAKING CHANGE: Add baggage key predicate func to baggage span processor
-* ADDED: Add baggage key predicate func to baggage span processor
+- BREAKING CHANGE: Add baggage key predicate func to baggage span processor
+- ADDED: Add baggage key predicate func to baggage span processor
 
 ### v0.1.0 / 2024-04-18
 
-* Initial release.
+- Initial release.

--- a/propagator/google_cloud_trace_context/CHANGELOG.md
+++ b/propagator/google_cloud_trace_context/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.2.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.1.0 / 2025-05-01
 
-Initial release.
+- Initial release.

--- a/propagator/google_cloud_trace_context/CHANGELOG.md
+++ b/propagator/google_cloud_trace_context/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History: opentelemetry-propagator-google_cloud_trace_context
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.2.0 / 2025-09-30
+## v0.2.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.1.0 / 2025-05-01
+## v0.1.0 / 2025-05-01
 
 - Initial release.

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -2,80 +2,80 @@
 
 ### v0.24.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.23.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.22.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.21.4 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.21.3 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.21.2 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.21.1 / 2023-07-19
 
-* DOCS: Add some clarity to ottrace docs [#522](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/522)
+- DOCS: Add some clarity to ottrace docs [#522](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/522)
 
 ### v0.21.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
-* DOCS: Update URLs to rubydocs
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
+- DOCS: Update URLs to rubydocs
 
 ### v0.20.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.20.0 / 2022-06-09
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.3 / 2021-10-29
 
-* FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags
+- FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags
 
 ### v0.19.2 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.1 / 2021-08-12
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.19.0 / 2021-06-23
 
-* BREAKING CHANGE: Refactor Baggage to remove Noop*
-* ADDED: Add Tracer.non_recording_span to API
-* FIXED: Support Case Insensitive Trace and Span IDs
-* FIXED: Refactor Baggage to remove Noop*
+- BREAKING CHANGE: Refactor Baggage to remove Noop\*
+- ADDED: Add Tracer.non_recording_span to API
+- FIXED: Support Case Insensitive Trace and Span IDs
+- FIXED: Refactor Baggage to remove Noop\*
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
+- ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
-* BREAKING CHANGE: Replace TextMapInjector/TextMapExtractor pairs with a TextMapPropagator.
+- BREAKING CHANGE: Replace TextMapInjector/TextMapExtractor pairs with a TextMapPropagator.
 
   [Check the propagator documentation](https://www.rubydoc.info/gems/opentelemetry-propagator-ottrace) for the new usage.
 
-* FIXED: Refactor propagators to add #fields
+- FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* Initial release.
+- Initial release.

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -1,74 +1,74 @@
 # Release History: opentelemetry-propagator-ottrace
 
-### v0.24.0 / 2025-10-22
+## v0.24.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.23.0 / 2025-09-30
+## v0.23.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.22.0 / 2025-01-16
+## v0.22.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.21.4 / 2024-11-26
+## v0.21.4 / 2024-11-26
 
 - (No significant changes)
 
-### v0.21.3 / 2024-07-23
+## v0.21.3 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.21.2 / 2023-11-23
+## v0.21.2 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.21.1 / 2023-07-19
+## v0.21.1 / 2023-07-19
 
 - DOCS: Add some clarity to ottrace docs [#522](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/522)
 
-### v0.21.0 / 2023-04-17
+## v0.21.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 - DOCS: Update URLs to rubydocs
 
-### v0.20.1 / 2023-01-14
+## v0.20.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.20.0 / 2022-06-09
+## v0.20.0 / 2022-06-09
 
 - (No significant changes)
 
-### v0.19.3 / 2021-10-29
+## v0.19.3 / 2021-10-29
 
 - FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags
 
-### v0.19.2 / 2021-09-29
+## v0.19.2 / 2021-09-29
 
 - (No significant changes)
 
-### v0.19.1 / 2021-08-12
+## v0.19.1 / 2021-08-12
 
 - (No significant changes)
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - BREAKING CHANGE: Refactor Baggage to remove Noop\*
 - ADDED: Add Tracer.non_recording_span to API
 - FIXED: Support Case Insensitive Trace and Span IDs
 - FIXED: Refactor Baggage to remove Noop\*
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - BREAKING CHANGE: Replace TextMapInjector/TextMapExtractor pairs with a TextMapPropagator.
 
@@ -76,6 +76,6 @@
 
 - FIXED: Refactor propagators to add #fields
 
-### v0.16.0 / 2021-03-17
+## v0.16.0 / 2021-03-17
 
 - Initial release.

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ## v0.19.3 / 2021-10-29
 
-- FIXED: Add Support fo OTTrace Bit Encoded Sampled Flags
+- FIXED: Add Support for OTTrace Bit Encoded Sampled Flags
 
 ## v0.19.2 / 2021-09-29
 

--- a/propagator/vitess/CHANGELOG.md
+++ b/propagator/vitess/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 ### v0.4.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.3.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2024-02-08
 
-Initial release.
+- Initial release.

--- a/propagator/vitess/CHANGELOG.md
+++ b/propagator/vitess/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Release History: opentelemetry-propagator-vitess
 
-### v0.4.0 / 2025-10-22
+## v0.4.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.3.0 / 2025-09-30
+## v0.3.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.1 / 2024-11-26
+## v0.1.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.1.0 / 2024-02-08
+## v0.1.0 / 2024-02-08
 
 - Initial release.

--- a/propagator/xray/CHANGELOG.md
+++ b/propagator/xray/CHANGELOG.md
@@ -2,75 +2,75 @@
 
 ### v0.26.1 / 2026-02-24
 
-* FIXED: Handle `Self` field in X-Amzn-Trace-Id header (#1958)
-* FIXED: Parse X-Amzn-Trace-Id header fields individually by name
+- FIXED: Handle `Self` field in X-Amzn-Trace-Id header (#1958)
+- FIXED: Parse X-Amzn-Trace-Id header fields individually by name
 
 ### v0.26.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
 
 ### v0.25.0 / 2025-09-30
 
-* ADDED: Bump minimum API Version to 1.7
+- ADDED: Bump minimum API Version to 1.7
 
 ### v0.24.0 / 2025-05-06
 
-* ADDED: Contribute xray lambda propagator
+- ADDED: Contribute xray lambda propagator
 
 ### v0.23.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.22.3 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.22.2 / 2024-07-23
 
-* DOCS: Add cspell to CI
+- DOCS: Add cspell to CI
 
 ### v0.22.1 / 2023-11-23
 
-* CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
+- CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
 ### v0.22.0 / 2023-04-17
 
-* BREAKING CHANGE: Drop support for EoL Ruby 2.7
-* ADDED: Drop support for EoL Ruby 2.7
+- BREAKING CHANGE: Drop support for EoL Ruby 2.7
+- ADDED: Drop support for EoL Ruby 2.7
 
 ### v0.21.1 / 2023-01-14
 
-* DOCS: Fix gem homepage
-* DOCS: More gem documentation fixes
+- DOCS: Fix gem homepage
+- DOCS: More gem documentation fixes
 
 ### v0.21.0 / 2022-06-09
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.20.1 / 2021-09-29
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.20.0 / 2021-08-12
 
-* ADDED: Xray compliant ids
+- ADDED: Xray compliant ids
 
 ### v0.19.0 / 2021-06-23
 
-* FIXED: XRay propagator null exception (#833)
-* ADDED: Add Tracer.non_recording_span to API
+- FIXED: XRay propagator null exception (#833)
+- ADDED: Add Tracer.non_recording_span to API
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API dependency for 1.0.0.rc1
-* FIXED: XRay trace_id parsing length
+- ADDED: Updated API dependency for 1.0.0.rc1
+- FIXED: XRay trace_id parsing length
 
 ### v0.17.0 / 2021-04-22
 
-* Initial release.
+- Initial release.
 
 ### v0.1.0 / 2021-02-26
 
-* Initial release.
+- Initial release.

--- a/propagator/xray/CHANGELOG.md
+++ b/propagator/xray/CHANGELOG.md
@@ -1,76 +1,76 @@
 # Release History: opentelemetry-propagator-xray
 
-### v0.26.1 / 2026-02-24
+## v0.26.1 / 2026-02-24
 
 - FIXED: Handle `Self` field in X-Amzn-Trace-Id header (#1958)
 - FIXED: Parse X-Amzn-Trace-Id header fields individually by name
 
-### v0.26.0 / 2025-10-22
+## v0.26.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 
-### v0.25.0 / 2025-09-30
+## v0.25.0 / 2025-09-30
 
 - ADDED: Bump minimum API Version to 1.7
 
-### v0.24.0 / 2025-05-06
+## v0.24.0 / 2025-05-06
 
 - ADDED: Contribute xray lambda propagator
 
-### v0.23.0 / 2025-01-16
+## v0.23.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.22.3 / 2024-11-26
+## v0.22.3 / 2024-11-26
 
 - (No significant changes)
 
-### v0.22.2 / 2024-07-23
+## v0.22.2 / 2024-07-23
 
 - DOCS: Add cspell to CI
 
-### v0.22.1 / 2023-11-23
+## v0.22.1 / 2023-11-23
 
 - CHANGED: Applied Rubocop Performance Recommendations [#727](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/727)
 
-### v0.22.0 / 2023-04-17
+## v0.22.0 / 2023-04-17
 
 - BREAKING CHANGE: Drop support for EoL Ruby 2.7
 - ADDED: Drop support for EoL Ruby 2.7
 
-### v0.21.1 / 2023-01-14
+## v0.21.1 / 2023-01-14
 
 - DOCS: Fix gem homepage
 - DOCS: More gem documentation fixes
 
-### v0.21.0 / 2022-06-09
+## v0.21.0 / 2022-06-09
 
 - (No significant changes)
 
-### v0.20.1 / 2021-09-29
+## v0.20.1 / 2021-09-29
 
 - (No significant changes)
 
-### v0.20.0 / 2021-08-12
+## v0.20.0 / 2021-08-12
 
 - ADDED: Xray compliant ids
 
-### v0.19.0 / 2021-06-23
+## v0.19.0 / 2021-06-23
 
 - FIXED: XRay propagator null exception (#833)
 - ADDED: Add Tracer.non_recording_span to API
 
-### v0.18.0 / 2021-05-21
+## v0.18.0 / 2021-05-21
 
 - ADDED: Updated API dependency for 1.0.0.rc1
 - FIXED: XRay trace_id parsing length
 
-### v0.17.0 / 2021-04-22
+## v0.17.0 / 2021-04-22
 
 - Initial release.
 
-### v0.1.0 / 2021-02-26
+## v0.1.0 / 2021-02-26
 
 - Initial release.

--- a/resources/aws/CHANGELOG.md
+++ b/resources/aws/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ### v0.5.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.4.0 / 2025-06-03
 
-* ADDED: Contribute aws eks resource detector
+- ADDED: Contribute aws eks resource detector
 
 ### v0.3.0 / 2025-05-07
 
-* ADDED: Contribute aws lambda resource detector
-* FIXED: Add missing semantic conventions require in AWS resource detectors
+- ADDED: Contribute aws lambda resource detector
+- FIXED: Add missing semantic conventions require in AWS resource detectors
 
 ### v0.2.0 / 2025-04-29
 
-* ADDED: Contribute aws ecs resource detector
+- ADDED: Contribute aws ecs resource detector
 
 ### v0.1.0 / 2025-04-09
 
-Initial release.
+- Initial release.

--- a/resources/aws/CHANGELOG.md
+++ b/resources/aws/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Release History: opentelemetry-resource-detector-aws
 
-### v0.5.0 / 2025-10-22
+## v0.5.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.4.0 / 2025-06-03
+## v0.4.0 / 2025-06-03
 
 - ADDED: Contribute aws eks resource detector
 
-### v0.3.0 / 2025-05-07
+## v0.3.0 / 2025-05-07
 
 - ADDED: Contribute aws lambda resource detector
 - FIXED: Add missing semantic conventions require in AWS resource detectors
 
-### v0.2.0 / 2025-04-29
+## v0.2.0 / 2025-04-29
 
 - ADDED: Contribute aws ecs resource detector
 
-### v0.1.0 / 2025-04-09
+## v0.1.0 / 2025-04-09
 
 - Initial release.

--- a/resources/azure/CHANGELOG.md
+++ b/resources/azure/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Release History: opentelemetry-resource-detector-azure
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.1 / 2024-11-26
+## v0.1.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.1.0 / 2023-09-07
+## v0.1.0 / 2023-09-07
 
 - Initial release.

--- a/resources/azure/CHANGELOG.md
+++ b/resources/azure/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2023-09-07
 
-* Initial release.
+- Initial release.

--- a/resources/container/CHANGELOG.md
+++ b/resources/container/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.2 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.1 / 2023-08-03
 
-* FIXED: Remove inline linter rules
+- FIXED: Remove inline linter rules
 
 ### v0.1.0 / 2023-08-02
 
-* Initial release
+- Initial release

--- a/resources/container/CHANGELOG.md
+++ b/resources/container/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Release History: opentelemetry-resource-detector-container
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.2 / 2024-11-26
+## v0.1.2 / 2024-11-26
 
 - (No significant changes)
 
-### v0.1.1 / 2023-08-03
+## v0.1.1 / 2023-08-03
 
 - FIXED: Remove inline linter rules
 
-### v0.1.0 / 2023-08-02
+## v0.1.0 / 2023-08-02
 
 - Initial release

--- a/resources/google_cloud_platform/CHANGELOG.md
+++ b/resources/google_cloud_platform/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Release History: opentelemetry-resource-detector-google_cloud_platform
 
-### v0.3.0 / 2025-10-22
+## v0.3.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.2.0 / 2025-01-16
+## v0.2.0 / 2025-01-16
 
 - BREAKING CHANGE: Set minimum supported version to Ruby 3.1
 - ADDED: Set minimum supported version to Ruby 3.1
 
-### v0.1.1 / 2024-11-26
+## v0.1.1 / 2024-11-26
 
 - (No significant changes)
 
-### v0.1.0 / 2023-09-07
+## v0.1.0 / 2023-09-07
 
 - Initial release.

--- a/resources/google_cloud_platform/CHANGELOG.md
+++ b/resources/google_cloud_platform/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ### v0.3.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.2.0 / 2025-01-16
 
-* BREAKING CHANGE: Set minimum supported version to Ruby 3.1
-* ADDED: Set minimum supported version to Ruby 3.1
+- BREAKING CHANGE: Set minimum supported version to Ruby 3.1
+- ADDED: Set minimum supported version to Ruby 3.1
 
 ### v0.1.1 / 2024-11-26
 
-* (No significant changes)
+- (No significant changes)
 
 ### v0.1.0 / 2023-09-07
 
-* Initial release.
+- Initial release.

--- a/sampler/xray/CHANGELOG.md
+++ b/sampler/xray/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Release History: opentelemetry-sampler-xray
 
-### v0.2.0 / 2025-10-22
+## v0.2.0 / 2025-10-22
 
 - BREAKING CHANGE: Min Ruby Version 3.2
 - ADDED: Min Ruby Version 3.2
 - ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
-### v0.1.0 / 2025-10-11
+## v0.1.0 / 2025-10-11
 
 - Initial release.

--- a/sampler/xray/CHANGELOG.md
+++ b/sampler/xray/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### v0.2.0 / 2025-10-22
 
-* BREAKING CHANGE: Min Ruby Version 3.2
-* ADDED: Min Ruby Version 3.2
-* ADDED: Update opentelemetry-sdk dependency to ~> 1.10
+- BREAKING CHANGE: Min Ruby Version 3.2
+- ADDED: Min Ruby Version 3.2
+- ADDED: Update opentelemetry-sdk dependency to ~> 1.10
 
 ### v0.1.0 / 2025-10-11
 
-Initial release.
+- Initial release.


### PR DESCRIPTION
This adds in linting of the changelog now that release-toys offers the configuration options required to produce new entries which will pass linting rules.

Note list symbol has been switched to - as historically that was what was originally used and is the required symbol for prettier.

All changes to md have occurred by running the linting tools with fix options and only where necessary targeted find & replace used ie headers.