### PR TITLE
chore: switch linkspector reporter

### DIFF
--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -36,7 +36,7 @@ jobs:
         uses: umbrelladocs/action-linkspector@652f85bc57bb1e7d4327260decc10aa68f7694c3 # v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
+          reporter: github-annotations
           fail_on_error: true
 
   json-lint-check:


### PR DESCRIPTION
Change linkspector reporter from github-pr-review to github-annotations which works better with merge queues and increases consistency with other checks.