### PR TITLE
test(rails): bump minitest to v6, remove test_unit/railtie from dummy test app

### DIFF
--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'appraisal', '~> 2.5'
-  gem 'minitest', '~> 5.0'
+  gem 'minitest', '~> 6.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.2.0'

--- a/instrumentation/rails/test/railtie/dummy/config/application.rb
+++ b/instrumentation/rails/test/railtie/dummy/config/application.rb
@@ -15,7 +15,6 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 # require "action_cable/engine"
 # require "sprockets/railtie"
-require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
`rails/test_unit/railtie` is [causing test grief](https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/22807829210/job/66159742566#step:3:1). (See also: https://github.com/rails/rails/pull/56202)

It provides rake test task integration, test generators, and app.config options for generators. We don't need any of these convenience features in our dummy app.

* remove the railtie require from the dummy test app
* bumps MiniTest to v6 as per [Renovate's blocked attempt at the same update](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/renovate/minitest-6.x/instrumentation/rails/Gemfile) to confirm fix