### PR TITLE
fix: skip commit-me pr lint step in merge_group

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -23,6 +23,7 @@ jobs:
     name: Conventional Commits Validation
     runs-on: ubuntu-24.04
     steps:
+      # restrict checks to pull requests to avoid issues blocking the merge queue
       - if: ${{ github.event_name == 'pull_request' }}
         uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -8,7 +8,6 @@ on:
       - synchronize
       - reopened
       - edited
-  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
       - reopened
       - edited
+  merge_group:
 
 permissions:
   contents: read
@@ -22,7 +23,8 @@ jobs:
     name: Conventional Commits Validation
     runs-on: ubuntu-24.04
     steps:
-      - uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
         env:
           FORCE_COLOR: 3
         with:


### PR DESCRIPTION
Adds a condition to the running of the commit-me step so it only runs on pr's and not the merge queue.