### PR TITLE
ci: Remove hourly pr limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     ":separateMultipleMajorReleases",
   ],
   prConcurrentLimit: 12,
+  prHourlyLimit: 0,
   packageRules: [
     {
       groupName: "all patch versions",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
     ":separateMultipleMajorReleases",
   ],
   prConcurrentLimit: 12,
-  prHourlyLimit: 0,
+  prHourlyLimit: 12,
   packageRules: [
     {
       groupName: "all patch versions",


### PR DESCRIPTION
Remove limit on the number of pr's created per hour. This is based on the fact that still pr's are not raised in a timely manner due to rate limiting hence this does away with the hourly limit.

This setting is described in https://docs.renovatebot.com/configuration-options/#prhourlylimit