### PR TITLE
test: Add webmock patch for HTTP 6.0+

### DIFF
--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -12,6 +12,34 @@ require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
 
+# Monkey-patch webmock to support HTTP.rb's 6.0+ keyword arguments
+if defined?(HTTP::Response) && defined?(WebMock::HttpLibAdapters::HttpRbAdapter)
+  module HTTP
+    class Response
+      class << self
+        alias original_from_webmock from_webmock if method_defined?(:from_webmock)
+
+        def from_webmock(request, webmock_response, request_signature = nil)
+          # Mostly a copy, but remove a few conditions/variables related to versions we don't test
+          status  = Status.new(webmock_response.status.first)
+          headers = webmock_response.headers || {}
+          body = build_http_rb_response_body_from_webmock_response(webmock_response)
+
+          # This is the main change: remove the hash around the args on the
+          # final "new" call
+          new(
+            status: status,
+            version: '1.1',
+            headers: headers,
+            body: body,
+            request: request
+          )
+        end
+      end
+    end
+  end
+end
+
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)


### PR DESCRIPTION
HTTP 6.0 removed the options hash for arguments in favor of keyword arguments. Webmock hasn't released an update to accommodate the change.

Patching the from_webmock method to remove the hash around the args gets the tests to pass again.

The patch isn't a direct copy, it removes some code from the original method related to versions
we don't test.