### PR TITLE
chore: Fix typo in label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -116,7 +116,7 @@ instrumentation-gruf:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/gruf/**"
-instrumentation-httpc:
+instrumentation-http:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/http/**"


### PR DESCRIPTION
Fix typo. Could a maintainer rename the label prior to merge this PR.