### PR TITLE
ci: Add rake to ci testing

### DIFF
--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -39,6 +39,7 @@ on:
       - "instrumentation/net_ldap/**"
       - "instrumentation/rack/**"
       - "instrumentation/rails/**"
+      - "instrumentation/rake/**"
       - "instrumentation/restclient/**"
       - "instrumentation/rspec/**"
       - "instrumentation/sinatra/**"
@@ -107,6 +108,7 @@ jobs:
           - net_ldap
           - rack
           - rails
+          - rake
           - restclient
           - rspec
           - sinatra


### PR DESCRIPTION
It was discovered in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2059#issuecomment-4092737008 that rake was missing from the matrix.

This adds it seperately to avoid this fix being held up by the rspec-mocks vs minitest discussion.