### PR TITLE
fix: renovate not detecting/bumping ruby version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,9 +68,7 @@
       dependencyDashboardApproval: false,
     },
     {
-      matchFileNames: [
-        ".github/actions/test_gem/action.yml",
-      ],
+      matchFileNames: [".github/actions/test_gem/action.yml"],
       ignoreDeps: ["ruby"],
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,12 +25,22 @@
       schedule: ["before 6am every weekday"],
     },
     {
-      groupName: "Min-Ruby-sdk",
+      description: "Separate ruby updates so that patches can be installed after new minor has been released.",
       matchDepNames: ["ruby"],
-      matchFileNames: [".github/workflows/ci-markdown-checks.yml"],
-      dependencyDashboardApproval: true,
       separateMultipleMinor: true,
       separateMinorPatch: true,
+    },
+    {
+      description: "Group min ruby updates into a single update which needs to be approved via the dashboard.",
+      groupName: "Min-Ruby-sdk",
+      dependencyDashboardCategory: "Min Ruby Runtime",
+      matchDepNames: ["ruby"],
+      matchFileNames: [
+        ".github/workflows/ci-markdown-checks.yml",
+        "**/*.gemspec",
+      ],
+      matchUpdateTypes: ["minor", "major"],
+      dependencyDashboardApproval: true,
     },
     {
       matchUpdateTypes: ["minor"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,10 +76,6 @@
       schedule: ["before 8am on Monday"],
       dependencyDashboardApproval: false,
     },
-    {
-      matchFileNames: [".github/actions/test_gem/action.yml"],
-      ignoreDeps: ["ruby"],
-    },
   ],
   customManagers: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,7 +70,6 @@
     {
       matchFileNames: [
         ".github/actions/test_gem/action.yml",
-        ".github/workflows/installation-tests.yml",
       ],
       ignoreDeps: ["ruby"],
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,6 @@
     {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
-      matchFileNames: ["!.github/workflows/ci-markdown-checks.yml"],
       schedule: ["before 6am every weekday"],
     },
     {

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ruby/setup-ruby@dffb23f65a78bba8db45d387d5ea1bbd6be3ef18 # v1.293.0
         with:
-          ruby-version: 4.0.1
+          ruby-version: "4.0.1"
       - name: "Install Latest Gem Versions on Latest Ruby"
         working-directory: releases
         run: ./run.sh


### PR DESCRIPTION
Renovate is not detecting ruby versions.

This has resulted in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2097 appearing to be an ok update but in fact should fail due to lacking the setup-ruby update.

Matching can be checked by looking at https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1803

The renovate rule had been added to remove warnings from renovate logs but was having no impact on updates proposed and was causing updates to be hidden.

Note the previous min ruby rule has been split in 2 to ensure patches can still be processed without dashboard approval.