### PR TITLE
fix: force Mongo to use no auth

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -92,7 +92,7 @@ jobs:
         ports:
           - 11211:11211
       mongodb:
-        image: mongo:6.0.27@sha256:03cda579c8caad6573cb98c2b3d5ff5ead452a6450561129b89595b4b9c18de2
+        image: mongo:7.0.31@sha256:f2b40853c0f796b105e672e04045d2b3e127bd54782dfe7e9b08aebbd9f602ce
         ports:
           - 27017:27017
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       bash -c "bundle install && rake"
 
   mongo:
-    image: mongo:6.0.27@sha256:03cda579c8caad6573cb98c2b3d5ff5ead452a6450561129b89595b4b9c18de2
+    image: mongo:7.0.31@sha256:f2b40853c0f796b105e672e04045d2b3e127bd54782dfe7e9b08aebbd9f602ce
     expose:
       - "27017"
     ports:

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -41,7 +41,7 @@ module TestHelper
   end
 
   def client
-    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database)
+    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, auth: nil)
   end
 
   def database

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -41,7 +41,7 @@ module TestHelper
   end
 
   def client
-    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, auth: nil)
+    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, server_api: { version: "1" })
   end
 
   def database


### PR DESCRIPTION
This explicitly sets the tests to use no auth as in v7 the authentication handshake has become stricter.