### PR TITLE
ci: use root user for mongo connection

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -147,6 +147,8 @@ runs:
         TEST_MEMCACHED_PORT: 11211
         TEST_MONGODB_HOST: localhost
         TEST_MONGODB_PORT: 27017
+        TEST_MONGODB_USERNAME: root
+        TEST_MONGODB_PASSWORD: password
         TEST_RABBITMQ_HOST: localhost
         TEST_RABBITMQ_PORT: 5672
         TEST_RABBITMQ_URL: amqp://guest:guest@localhost:5672

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -95,6 +95,9 @@ jobs:
         image: mongo:6.0.27@sha256:03cda579c8caad6573cb98c2b3d5ff5ead452a6450561129b89595b4b9c18de2
         ports:
           - 27017:27017
+        env:
+          MONGO_INITDB_ROOT_USERNAME: root
+          MONGO_INITDB_ROOT_PASSWORD: password
 
   instrumentation_mysql:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,9 @@ services:
       - "27017"
     ports:
       - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=password
 
   mysql:
     image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -41,7 +41,7 @@ module TestHelper
   end
 
   def client
-    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, user: username, password: password, auth_source: "admin", auth_mech: :scram256)
+    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, user: username, password: password, auth_source: 'admin', auth_mech: :scram256)
   end
 
   def database

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -59,7 +59,7 @@ module TestHelper
   def username
     ENV.fetch('TEST_MONGODB_USERNAME ', 'root')
   end
-  
+
   def password
     ENV.fetch('TEST_MONGODB_PASSWORD', 'password')
   end

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -41,7 +41,7 @@ module TestHelper
   end
 
   def client
-    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database)
+    @client ||= Mongo::Client.new(["#{host}:#{port}"], database: database, user: username, password: password, auth_source: "admin", auth_mech: :scram256)
   end
 
   def database
@@ -54,5 +54,13 @@ module TestHelper
 
   def port
     ENV.fetch('TEST_MONGODB_PORT', 27_017).to_i
+  end
+
+  def username
+    ENV.fetch('TEST_MONGODB_USERNAME ', 'root')
+  end
+  
+  def password
+    ENV.fetch('TEST_MONGODB_PASSWORD', 'password')
   end
 end


### PR DESCRIPTION
Connect to Mongo using root user to remove warning in tests

>   WARN -- : MONGODB | Failed to authenticate to localhost:27017: Mongo::Auth::Unauthorized: User plain_user (mechanism: plain) is not authorized to access otel_test (auth source: $external, used mechanism: PLAIN, used server: localhost:27017 (STANDALONE)): [334:MechanismUnavailable]: Received authentication for mechanism PLAIN which is not enabled