### PR TITLE
fix: constrain mongo to versions lacking native otel

### DIFF
--- a/instrumentation/mongo/Appraisals
+++ b/instrumentation/mongo/Appraisals
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'mongo-latest' do
-  gem 'mongo'
+appraise 'mongo-2.22' do
+  gem 'mongo', '~> 2.22.0'
 
   # TODO: bson 5.1.0 isn't compatible with JRuby as of 2025/06/17
   gem 'bson', '< 5.1.0' if defined?(JRUBY_VERSION)

--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -6,11 +6,11 @@ The OpenTelemetry Mongo Ruby gem is a community maintained instrumentation for [
 >
 > **Development Frozen:**
 > Mongo Ruby Driver 2.23.0+ includes native OpenTelemetry instrumentation. For the best experience and continued support, we recommend:
-
-- **Mongo Ruby Driver < 2.23.0**: Use `opentelemetry-instrumentation-mongo` gem
-- **Mongo Ruby Driver ≥ 2.23.0**: Use Mongo Ruby Driver's built-in OpenTelemetry support (remove `opentelemetry-instrumentation-mongo` gem)
-
-Community instrumentation is compatible with Mongo Ruby Driver versions up to 2.23.x. Development of this gem is frozen for newer Mongo Ruby Driver versions in favor of the native integration.
+>
+> - **Mongo Ruby Driver < 2.23.0**: Use `opentelemetry-instrumentation-mongo` gem
+> - **Mongo Ruby Driver ≥ 2.23.0**: Use Mongo Ruby Driver's built-in OpenTelemetry support (remove `opentelemetry-instrumentation-mongo` gem)
+>
+> Community instrumentation is compatible with Mongo Ruby Driver versions up to 2.23.x. Development of this gem is frozen for newer Mongo Ruby Driver versions in favor of the native integration.
 
 ## How do I get started?
 

--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -2,6 +2,16 @@
 
 The OpenTelemetry Mongo Ruby gem is a community maintained instrumentation for [Mongo][mongo-home].
 
+> [!NOTE]
+>
+> **Development Frozen:**
+> Mongo Ruby Driver 2.23.0+ includes native OpenTelemetry instrumentation. For the best experience and continued support, we recommend:
+
+- **Mongo Ruby Driver < 2.23.0**: Use `opentelemetry-instrumentation-mongo` gem
+- **Mongo Ruby Driver ≥ 2.23.0**: Use Mongo Ruby Driver's built-in OpenTelemetry support (remove `opentelemetry-instrumentation-mongo` gem)
+
+Community instrumentation is compatible with Mongo Ruby Driver versions up to 2.23.x. Development of this gem is frozen for newer Mongo Ruby Driver versions in favor of the native integration.
+
 ## How do I get started?
 
 Install the gem using:

--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -5,6 +5,7 @@ The OpenTelemetry Mongo Ruby gem is a community maintained instrumentation for [
 > [!NOTE]
 >
 > **Development Frozen:**
+>
 > Mongo Ruby Driver 2.23.0+ includes native OpenTelemetry instrumentation. For the best experience and continued support, we recommend:
 >
 > - **Mongo Ruby Driver < 2.23.0**: Use `opentelemetry-instrumentation-mongo` gem

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
@@ -10,6 +10,7 @@ module OpenTelemetry
       # Instrumentation class that detects and installs the Mongo instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('2.5.0')
+        MAX_VERSION = Gem::Version.new('2.22.0') # Mongo 2.32.0+ has native OpenTelemetry instrumentation
 
         install do |_config|
           require_dependencies
@@ -21,7 +22,14 @@ module OpenTelemetry
         end
 
         compatible do
-          gem_version >= MINIMUM_VERSION
+          if gem_version < MINIMUM_VERSION
+            false
+          elsif gem_version > MAX_VERSION
+            OpenTelemetry.logger.info("Mongo #{gem_version} has native OpenTelemetry support. Skipping community instrumentation.")
+            false
+          else
+            true
+          end
         end
 
         option :peer_service, default: nil, validate: :string

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       # Instrumentation class that detects and installs the Mongo instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('2.5.0')
-        MAX_VERSION = Gem::Version.new('2.22.0') # Mongo 2.32.0+ has native OpenTelemetry instrumentation
+        MAX_VERSION = Gem::Version.new('2.22.0') # Mongo 2.23.0+ has native OpenTelemetry instrumentation
 
         install do |_config|
           require_dependencies


### PR DESCRIPTION
This constrains the mongo instrumentation to only versions lacking native integration ie v2.23+.

See https://github.com/mongodb/mongo-ruby-driver/pull/2957 for implementation pr