### PR TITLE
chore: [PG] Update README with obfuscation_limit details

### DIFF
--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -54,6 +54,11 @@ OpenTelemetry::SDK.configure do |c|
     # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
     # setting this option to :omit or disable sanitization of the attribute by setting it to :include
     db_statement: :include,
+
+    # When `db_statement` is enabled, this instrumentation obfuscates SQL queries. By default, it
+    # obfuscates queries up to 2000 characters. You can override the default with a different
+    # `obfuscation_limit`, but higher values may impact performance.
+    obfuscation_limit: 2000
   }
 end
 ```


### PR DESCRIPTION
Document the `obfuscation_limit` config in the README.

The config was released in [v0.25.0](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/pg/CHANGELOG.md#v0250--2023-05-25) (on 2023-05-25), but it was never documented, so this PR fixes it.