### PR TITLE
chore: run cspell on PR titles

### DIFF
--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -2,6 +2,12 @@ name: File Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
   merge_group:
 
 permissions:

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -137,6 +137,7 @@ jobs:
           config: .cspell.yml
           suggestions: true
           treat_flagged_words_as_errors: true
+          incremental_files_only: false
 
   format-check:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -127,6 +127,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Extract PR title
+        id: pr
+        run: |
+          echo "${{ github.event.pull_request.title }}" > pr_title.md
       - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 # v8.3.0
         with:
           use_cspell_files: true

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -133,7 +133,6 @@ jobs:
           echo "${{ github.event.pull_request.title }}" > pr_title.md
       - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 # v8.3.0
         with:
-          use_cspell_files: true
           config: .cspell.yml
           suggestions: true
           treat_flagged_words_as_errors: true


### PR DESCRIPTION
This ensures that the content which will be added to changelogs will pass cspell checks and avoid blocking releases.

See results of testing below which resulted in a failure 
![image](https://github.com/user-attachments/assets/298d1f30-e49e-48c0-914c-f13aa05335d4)
