### PR TITLE
test: Test Anthropic against ruby 4

### DIFF
--- a/instrumentation/anthropic/Appraisals
+++ b/instrumentation/anthropic/Appraisals
@@ -4,13 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Anthropic gem requires Ruby 3.2 but is not compatible with Ruby 4+
-# https://github.com/anthropics/anthropic-sdk-ruby/issues/147
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
-  appraise 'anthropic-latest' do
-    gem 'anthropic'
+%w[1.17.0].each do |version|
+  appraise "anthropic-#{version}" do
+    gem 'anthropic', "~> #{version}"
   end
+end
 
+appraise 'anthropic-latest' do
+  gem 'anthropic'
+end
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
   appraise 'anthropic-1.9.0' do
     gem 'anthropic', '~> 1.9.0'
   end


### PR DESCRIPTION
anthropic now supports ruby 4 so we should extend our appraisals to support testing against Ruby 4.