### PR TITLE
test: Switch to Minitest Test Doubles

### DIFF
--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'

--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'

--- a/helpers/mysql/test/helpers/mysql_test.rb
+++ b/helpers/mysql/test/helpers/mysql_test.rb
@@ -262,11 +262,12 @@ describe OpenTelemetry::Helpers::MySQL do
         sql = (+'SELECT 1').force_encoding('ASCII-8BIT')
         result = nil
         OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-          allow(OpenTelemetry::Common::Utilities).to receive(:utf8_encode) { |_| raise 'boom!' }
-          result = OpenTelemetry::Helpers::MySQL.extract_statement_type(sql)
+          OpenTelemetry::Common::Utilities.stub(:utf8_encode, ->(_) { raise 'boom!' }) do
+            result = OpenTelemetry::Helpers::MySQL.extract_statement_type(sql)
 
-          assert_nil(result)
-          assert_match(/Error extracting/, log_stream.string)
+            assert_nil(result)
+            assert_match(/Error extracting/, log_stream.string)
+          end
         end
       end
     end

--- a/helpers/mysql/test/test_helper.rb
+++ b/helpers/mysql/test/test_helper.rb
@@ -11,6 +11,6 @@ Bundler.require(:default, :development, :test)
 require 'opentelemetry'
 require 'opentelemetry-helpers-mysql'
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/instrumentation_test.rb
+++ b/instrumentation/active_job/test/opentelemetry/instrumentation/active_job/instrumentation_test.rb
@@ -23,8 +23,9 @@ describe OpenTelemetry::Instrumentation::ActiveJob do
 
   describe '#compatible' do
     it 'returns false for unsupported gem versions' do
-      allow(ActiveJob).to receive(:version).and_return(Gem::Version.new('4.2.0'))
-      _(instrumentation.compatible?).must_equal false
+      ActiveJob.stub(:version, Gem::Version.new('4.2.0')) do
+        _(instrumentation.compatible?).must_equal false
+      end
     end
 
     it 'returns true for supported gem versions' do

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -12,7 +12,7 @@ Bundler.require(:default, :development, :test)
 require 'active_job'
 require 'opentelemetry-instrumentation-active_job'
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 class TestJob < ActiveJob::Base
   def perform; end

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/active_model_serializers/test/test_helper.rb
+++ b/instrumentation/active_model_serializers/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'active_support/all'
 require 'opentelemetry-instrumentation-active_model_serializers'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # disable logging

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
@@ -23,8 +23,9 @@ describe OpenTelemetry::Instrumentation::ActiveRecord do
 
   describe 'compatible' do
     it 'when a version below the minimum supported gem version is installed' do
-      allow(ActiveRecord).to receive(:version).and_return(Gem::Version.new('4.2.0'))
-      _(instrumentation.compatible?).must_equal false
+      ActiveRecord.stub(:version, Gem::Version.new('4.2.0')) do
+        _(instrumentation.compatible?).must_equal false
+      end
     end
 
     it 'when supported gem version installed' do

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'active_record'
 require 'opentelemetry-instrumentation-active_record'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # Global opentelemetry-sdk setup:

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'

--- a/instrumentation/active_storage/test/opentelemetry/instrumentation/active_storage/subscription_test.rb
+++ b/instrumentation/active_storage/test/opentelemetry/instrumentation/active_storage/subscription_test.rb
@@ -341,10 +341,9 @@ describe OpenTelemetry::Instrumentation::ActiveStorage do
   end
 
   def create_blob(key:, filename:, content_type:)
-    allow(ActiveStorage::Blob).to receive(:generate_unique_secure_token).and_return(key)
     io = StringIO.new(File.read("#{Dir.pwd}/test/fixtures/#{filename}"))
-    blob = ActiveStorage::Blob.create_and_upload!(io: io, filename: filename, content_type: content_type)
-    allow(ActiveStorage::Blob).to receive(:generate_unique_secure_token).and_call_original
-    blob
+    ActiveStorage::Blob.stub(:generate_unique_secure_token, key) do
+      ActiveStorage::Blob.create_and_upload!(io: io, filename: filename, content_type: content_type)
+    end
   end
 end

--- a/instrumentation/active_storage/test/test_helper.rb
+++ b/instrumentation/active_storage/test/test_helper.rb
@@ -12,7 +12,7 @@ Bundler.require(:default, :development, :test)
 
 require 'active_storage'
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'test_helpers/app_config'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-sdk', '~> 1.1'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-sdk', '~> 1.1'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
+++ b/instrumentation/active_support/test/opentelemetry/instrumentation/active_support/span_subscriber_test.rb
@@ -264,14 +264,14 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
 
         describe 'when using a unstable formatter' do
           it 'defaults to the notification name' do
-            allow(OpenTelemetry).to receive(:handle_error).with(exception: RuntimeError, message: String)
+            OpenTelemetry.stub(:handle_error, ->(**_kwargs) { nil }) do
+              OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
+              ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
 
-            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_name, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
-            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-            _(last_span).wont_be_nil
-            _(last_span.name).must_equal(notification_name)
-            _(last_span.attributes['extra']).must_equal('context')
+              _(last_span).wont_be_nil
+              _(last_span.name).must_equal(notification_name)
+              _(last_span.attributes['extra']).must_equal('context')
+            end
           end
         end
       end
@@ -383,14 +383,14 @@ describe 'OpenTelemetry::Instrumentation::ActiveSupport::SpanSubscriber' do
 
         describe 'when using a unstable formatter' do
           it 'defaults to the notification name' do
-            allow(OpenTelemetry).to receive(:handle_error).with(exception: RuntimeError, message: String)
+            OpenTelemetry.stub(:handle_error, ->(**_kwargs) { nil }) do
+              OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
+              ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
 
-            OpenTelemetry::Instrumentation::ActiveSupport.subscribe(tracer, notification_pattern, nil, nil, span_name_formatter: ->(_) { raise 'boom' })
-            ActiveSupport::Notifications.instrument(notification_name, extra: 'context')
-
-            _(last_span).wont_be_nil
-            _(last_span.name).must_equal(notification_name)
-            _(last_span.attributes['extra']).must_equal('context')
+              _(last_span).wont_be_nil
+              _(last_span.name).must_equal(notification_name)
+              _(last_span.attributes['extra']).must_equal('context')
+            end
           end
         end
       end

--- a/instrumentation/active_support/test/test_helper.rb
+++ b/instrumentation/active_support/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'active_support/core_ext'
 require 'opentelemetry-instrumentation-active_support'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/anthropic/Gemfile
+++ b/instrumentation/anthropic/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
 
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/anthropic/Gemfile
+++ b/instrumentation/anthropic/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
 
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.7'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.7'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
@@ -41,152 +41,37 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
   describe 'validate_wrapper' do
     it 'result should be span' do
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: event_v1, context: context)
-      _(last_span).must_be_kind_of(OpenTelemetry::SDK::Trace::SpanData)
+      otel_wrapper.stub(:call_original_handler, {}) do
+        otel_wrapper.call_wrapped(event: event_v1, context: context)
+        _(last_span).must_be_kind_of(OpenTelemetry::SDK::Trace::SpanData)
+      end
     end
 
     it 'validate_spans' do
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: event_v1, context: context)
-
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :server
-      _(last_span.status.code).must_equal 1
-      _(last_span.hex_parent_span_id).must_equal '0000000000000000'
-
-      _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
-      _(last_span.attributes['faas.trigger']).must_equal 'http'
-      _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['cloud.account.id']).must_equal 'id'
-      _(last_span.attributes['http.method']).must_equal 'GET'
-      _(last_span.attributes['http.route']).must_equal '/'
-      _(last_span.attributes['http.target']).must_equal '/'
-      _(last_span.attributes['http.user_agent']).must_equal 'curl/8.1.2'
-      _(last_span.attributes['http.scheme']).must_equal 'http'
-      _(last_span.attributes['net.host.name']).must_equal '127.0.0.1:3000'
-
-      _(last_span.instrumentation_scope).must_be_kind_of OpenTelemetry::SDK::InstrumentationScope
-      _(last_span.instrumentation_scope.name).must_equal 'OpenTelemetry::Instrumentation::AwsLambda'
-      _(last_span.instrumentation_scope.version).must_equal OpenTelemetry::Instrumentation::AwsLambda::VERSION
-
-      _(last_span.hex_span_id.size).must_equal 16
-      _(last_span.hex_trace_id.size).must_equal 32
-      _(last_span.trace_flags.sampled?).must_equal true
-
-      assert_equal last_span.tracestate, {}
-    end
-
-    it 'validate_spans_with_parent_context' do
-      event_v1['headers']['Traceparent'] = '00-48b05d64abe4690867685635f72bdbac-ff40ea9699e62af2-01'
-      event_v1['headers']['Tracestate']  = 'otel=ff40ea9699e62af2-01'
-
-      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: event_v1, context: context)
-
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :server
-
-      _(last_span.hex_parent_span_id).must_equal 'ff40ea9699e62af2'
-      _(last_span.hex_span_id.size).must_equal 16
-      _(last_span.hex_trace_id.size).must_equal 32
-      _(last_span.trace_flags.sampled?).must_equal true
-      _(last_span.tracestate.to_h).must_equal({ 'otel' => 'ff40ea9699e62af2-01' })
-      event_v1['headers'].delete('traceparent')
-      event_v1['headers'].delete('tracestate')
-    end
-
-    it 'validate_spans_with_v2_events' do
-      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: event_v2, context: context)
-
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :server
-      _(last_span.status.code).must_equal 1
-      _(last_span.hex_parent_span_id).must_equal '0000000000000000'
-
-      _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
-      _(last_span.attributes['faas.trigger']).must_equal 'http'
-      _(last_span.attributes['cloud.account.id']).must_equal 'id'
-      _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['net.host.name']).must_equal 'id.execute-api.us-east-1.amazonaws.com'
-      _(last_span.attributes['http.method']).must_equal 'POST'
-      _(last_span.attributes['http.user_agent']).must_equal 'agent'
-      _(last_span.attributes['http.route']).must_equal '/path/to/resource'
-      _(last_span.attributes['http.target']).must_equal '/path/to/resource?parameter1=value1&parameter1=value2&parameter2=value'
-    end
-
-    it 'validate_spans_with_records_from_non_gateway_request' do
-      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: event_record, context: context)
-
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :consumer
-      _(last_span.status.code).must_equal 1
-      _(last_span.hex_parent_span_id).must_equal '0000000000000000'
-
-      _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
-      _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['cloud.account.id']).must_equal 'id'
-
-      assert_nil(last_span.attributes['faas.trigger'])
-      assert_nil(last_span.attributes['http.method'])
-      assert_nil(last_span.attributes['http.user_agent'])
-      assert_nil(last_span.attributes['http.route'])
-      assert_nil(last_span.attributes['http.target'])
-      assert_nil(last_span.attributes['net.host.name'])
-    end
-
-    it 'validate_spans_with_records_from_sqs' do
-      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      otel_wrapper.call_wrapped(event: sqs_record, context: context)
-
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :consumer
-      _(last_span.status.code).must_equal 1
-      _(last_span.hex_parent_span_id).must_equal '0000000000000000'
-
-      _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
-      _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
-      _(last_span.attributes['cloud.account.id']).must_equal 'id'
-      _(last_span.attributes['faas.trigger']).must_equal 'pubsub'
-      _(last_span.attributes['messaging.operation']).must_equal 'process'
-      _(last_span.attributes['messaging.system']).must_equal 'AmazonSQS'
-
-      assert_nil(last_span.attributes['http.method'])
-      assert_nil(last_span.attributes['http.user_agent'])
-      assert_nil(last_span.attributes['http.route'])
-      assert_nil(last_span.attributes['http.target'])
-      assert_nil(last_span.attributes['net.host.name'])
-    end
-  end
-
-  describe 'validate_error_handling' do
-    it 'handle error if original handler cause issue' do
-      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler) { |**_args| raise StandardError, 'Simulated Error' }
-      begin
+      otel_wrapper.stub(:call_original_handler, {}) do
         otel_wrapper.call_wrapped(event: event_v1, context: context)
-      rescue StandardError
+
         _(last_span.name).must_equal 'sample.test'
         _(last_span.kind).must_equal :server
-
-        _(last_span.status.code).must_equal 2
-        _(last_span.status.description).must_equal 'Simulated Error'
+        _(last_span.status.code).must_equal 1
         _(last_span.hex_parent_span_id).must_equal '0000000000000000'
 
-        _(last_span.events[0].name).must_equal 'exception'
-        _(last_span.events[0].attributes['exception.type']).must_equal 'StandardError'
-        _(last_span.events[0].attributes['exception.message']).must_equal 'Simulated Error'
+        _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
+        _(last_span.attributes['faas.trigger']).must_equal 'http'
+        _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['cloud.account.id']).must_equal 'id'
+        _(last_span.attributes['http.method']).must_equal 'GET'
+        _(last_span.attributes['http.route']).must_equal '/'
+        _(last_span.attributes['http.target']).must_equal '/'
+        _(last_span.attributes['http.user_agent']).must_equal 'curl/8.1.2'
+        _(last_span.attributes['http.scheme']).must_equal 'http'
+        _(last_span.attributes['net.host.name']).must_equal '127.0.0.1:3000'
+
+        _(last_span.instrumentation_scope).must_be_kind_of OpenTelemetry::SDK::InstrumentationScope
+        _(last_span.instrumentation_scope.name).must_equal 'OpenTelemetry::Instrumentation::AwsLambda'
+        _(last_span.instrumentation_scope.version).must_equal OpenTelemetry::Instrumentation::AwsLambda::VERSION
 
         _(last_span.hex_span_id.size).must_equal 16
         _(last_span.hex_trace_id.size).must_equal 32
@@ -196,16 +81,141 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
       end
     end
 
+    it 'validate_spans_with_parent_context' do
+      event_v1['headers']['Traceparent'] = '00-48b05d64abe4690867685635f72bdbac-ff40ea9699e62af2-01'
+      event_v1['headers']['Tracestate']  = 'otel=ff40ea9699e62af2-01'
+
+      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
+      otel_wrapper.stub(:call_original_handler, {}) do
+        otel_wrapper.call_wrapped(event: event_v1, context: context)
+
+        _(last_span.name).must_equal 'sample.test'
+        _(last_span.kind).must_equal :server
+
+        _(last_span.hex_parent_span_id).must_equal 'ff40ea9699e62af2'
+        _(last_span.hex_span_id.size).must_equal 16
+        _(last_span.hex_trace_id.size).must_equal 32
+        _(last_span.trace_flags.sampled?).must_equal true
+        _(last_span.tracestate.to_h).must_equal({ 'otel' => 'ff40ea9699e62af2-01' })
+        event_v1['headers'].delete('traceparent')
+        event_v1['headers'].delete('tracestate')
+      end
+    end
+
+    it 'validate_spans_with_v2_events' do
+      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
+      otel_wrapper.stub(:call_original_handler, {}) do
+        otel_wrapper.call_wrapped(event: event_v2, context: context)
+
+        _(last_span.name).must_equal 'sample.test'
+        _(last_span.kind).must_equal :server
+        _(last_span.status.code).must_equal 1
+        _(last_span.hex_parent_span_id).must_equal '0000000000000000'
+
+        _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
+        _(last_span.attributes['faas.trigger']).must_equal 'http'
+        _(last_span.attributes['cloud.account.id']).must_equal 'id'
+        _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['net.host.name']).must_equal 'id.execute-api.us-east-1.amazonaws.com'
+        _(last_span.attributes['http.method']).must_equal 'POST'
+        _(last_span.attributes['http.user_agent']).must_equal 'agent'
+        _(last_span.attributes['http.route']).must_equal '/path/to/resource'
+        _(last_span.attributes['http.target']).must_equal '/path/to/resource?parameter1=value1&parameter1=value2&parameter2=value'
+      end
+    end
+
+    it 'validate_spans_with_records_from_non_gateway_request' do
+      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
+      otel_wrapper.stub(:call_original_handler, {}) do
+        otel_wrapper.call_wrapped(event: event_record, context: context)
+
+        _(last_span.name).must_equal 'sample.test'
+        _(last_span.kind).must_equal :consumer
+        _(last_span.status.code).must_equal 1
+        _(last_span.hex_parent_span_id).must_equal '0000000000000000'
+
+        _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
+        _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['cloud.account.id']).must_equal 'id'
+
+        assert_nil(last_span.attributes['faas.trigger'])
+        assert_nil(last_span.attributes['http.method'])
+        assert_nil(last_span.attributes['http.user_agent'])
+        assert_nil(last_span.attributes['http.route'])
+        assert_nil(last_span.attributes['http.target'])
+        assert_nil(last_span.attributes['net.host.name'])
+      end
+    end
+
+    it 'validate_spans_with_records_from_sqs' do
+      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
+      otel_wrapper.stub(:call_original_handler, {}) do
+        otel_wrapper.call_wrapped(event: sqs_record, context: context)
+
+        _(last_span.name).must_equal 'sample.test'
+        _(last_span.kind).must_equal :consumer
+        _(last_span.status.code).must_equal 1
+        _(last_span.hex_parent_span_id).must_equal '0000000000000000'
+
+        _(last_span.attributes['aws.lambda.invoked_arn']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['faas.invocation_id']).must_equal '41784178-4178-4178-4178-4178417855e'
+        _(last_span.attributes['cloud.resource_id']).must_equal 'arn:aws:lambda:location:id:function_name:function_name'
+        _(last_span.attributes['cloud.account.id']).must_equal 'id'
+        _(last_span.attributes['faas.trigger']).must_equal 'pubsub'
+        _(last_span.attributes['messaging.operation']).must_equal 'process'
+        _(last_span.attributes['messaging.system']).must_equal 'AmazonSQS'
+
+        assert_nil(last_span.attributes['http.method'])
+        assert_nil(last_span.attributes['http.user_agent'])
+        assert_nil(last_span.attributes['http.route'])
+        assert_nil(last_span.attributes['http.target'])
+        assert_nil(last_span.attributes['net.host.name'])
+      end
+    end
+  end
+
+  describe 'validate_error_handling' do
+    it 'handle error if original handler cause issue' do
+      otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
+      otel_wrapper.stub(:call_original_handler, ->(**_args) { raise StandardError, 'Simulated Error' }) do
+        begin
+          otel_wrapper.call_wrapped(event: event_v1, context: context)
+        rescue StandardError
+          _(last_span.name).must_equal 'sample.test'
+          _(last_span.kind).must_equal :server
+
+          _(last_span.status.code).must_equal 2
+          _(last_span.status.description).must_equal 'Simulated Error'
+          _(last_span.hex_parent_span_id).must_equal '0000000000000000'
+
+          _(last_span.events[0].name).must_equal 'exception'
+          _(last_span.events[0].attributes['exception.type']).must_equal 'StandardError'
+          _(last_span.events[0].attributes['exception.message']).must_equal 'Simulated Error'
+
+          _(last_span.hex_span_id.size).must_equal 16
+          _(last_span.hex_trace_id.size).must_equal 32
+          _(last_span.trace_flags.sampled?).must_equal true
+
+          assert_equal last_span.tracestate, {}
+        end
+      end
+    end
+
     it 'if wrapped handler cause otel-related issue, wont break the entire lambda call' do
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_wrapped).and_return({ 'test' => 'ok' })
-      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-      allow(OpenTelemetry::Context).to receive(:with_current) { |_context|
-        tracer.start_span('test_span', attributes: {}, kind: :server)
-        raise StandardError, 'OTEL Error'
-      }
-      response = otel_wrapper.call_wrapped(event: event_v1, context: context)
-      _(response['test']).must_equal 'ok'
+      otel_wrapper.stub(:call_wrapped, { 'test' => 'ok' }) do
+        otel_wrapper.stub(:call_original_handler, {}) do
+          OpenTelemetry::Context.stub(:with_current, ->(_context) {
+            tracer.start_span('test_span', attributes: {}, kind: :server)
+            raise StandardError, 'OTEL Error'
+          }) do
+            response = otel_wrapper.call_wrapped(event: event_v1, context: context)
+            _(response['test']).must_equal 'ok'
+          end
+        end
+      end
     end
 
     describe 'no raise error when the span is not recording' do
@@ -213,14 +223,17 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
         otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
         tracer = OpenTelemetry.tracer_provider.tracer
 
-        allow(OpenTelemetry::Trace).to receive(:with_span) { |_span, &block|
+        OpenTelemetry::Trace.stub(:with_span, ->(_span, &block) {
           block.call(OpenTelemetry::Trace::Span::INVALID, OpenTelemetry::Context.current)
-        }
-        allow(tracer).to receive(:in_span) { |_name, **_kwargs, &block|
-          block.call(OpenTelemetry::Trace::Span::INVALID, OpenTelemetry::Context.current)
-        }
-        allow(otel_wrapper).to receive(:call_original_handler).and_return({})
-        assert otel_wrapper.call_wrapped(event: sqs_record, context: context)
+        }) do
+          tracer.stub(:in_span, ->(_name, **_kwargs, &block) {
+            block.call(OpenTelemetry::Trace::Span::INVALID, OpenTelemetry::Context.current)
+          }) do
+            otel_wrapper.stub(:call_original_handler, {}) do
+              assert otel_wrapper.call_wrapped(event: sqs_record, context: context)
+            end
+          end
+        end
       end
     end
   end
@@ -233,15 +246,16 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
       end
 
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-      allow(otel_wrapper).to receive(:call_original_handler, &stub)
-      otel_wrapper.call_wrapped(event: sqs_record, context: context)
+      otel_wrapper.stub(:call_original_handler, stub) do
+        otel_wrapper.call_wrapped(event: sqs_record, context: context)
 
-      _(last_span.name).must_equal 'sample.test'
-      _(last_span.kind).must_equal :consumer
-      _(last_span.status.code).must_equal 1
-      _(last_span.hex_parent_span_id).must_equal '0000000000000000'
+        _(last_span.name).must_equal 'sample.test'
+        _(last_span.kind).must_equal :consumer
+        _(last_span.status.code).must_equal 1
+        _(last_span.hex_parent_span_id).must_equal '0000000000000000'
 
-      _(last_span.attributes['test.attribute']).must_equal 320
+        _(last_span.attributes['test.attribute']).must_equal 320
+      end
     end
   end
 
@@ -278,8 +292,9 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
             _(flush_timeout).must_equal expected_flush_timeout
           end
 
-          allow(Handler).to receive(:wrap_lambda, &args_checker)
-          Handler.process(event: event_v1, context: context)
+          Handler.stub(:wrap_lambda, args_checker) do
+            Handler.process(event: event_v1, context: context)
+          end
         end
 
         it 'calls the original method with correct arguments' do
@@ -288,8 +303,9 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
             _(context).must_equal context
           end
 
-          allow(Handler).to receive(:process_without_instrumentation, &args_checker)
-          Handler.process(event: event_v1, context: context)
+          Handler.stub(:process_without_instrumentation, args_checker) do
+            Handler.process(event: event_v1, context: context)
+          end
         end
       end
 
@@ -308,8 +324,9 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
             _(flush_timeout).must_equal expected_flush_timeout
           end
 
-          allow(Handler).to receive(:wrap_lambda, &args_checker)
-          Handler.process(event: event_v1, context: context)
+          Handler.stub(:wrap_lambda, args_checker) do
+            Handler.process(event: event_v1, context: context)
+          end
         end
 
         it 'calls the original method with correct arguments' do
@@ -318,8 +335,9 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
             _(context).must_equal context
           end
 
-          allow(Handler).to receive(:process_without_instrumentation, &args_checker)
-          Handler.process(event: event_v1, context: context)
+          Handler.stub(:process_without_instrumentation, args_checker) do
+            Handler.process(event: event_v1, context: context)
+          end
         end
       end
     end

--- a/instrumentation/aws_lambda/test/test_helper.rb
+++ b/instrumentation/aws_lambda/test/test_helper.rb
@@ -11,7 +11,7 @@ Bundler.require(:default, :development, :test)
 require 'opentelemetry-instrumentation-aws_lambda'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 class MockLambdaContext
   attr_reader :aws_request_id, :invoked_function_arn, :function_name

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.7'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.7'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -21,31 +21,31 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
   describe '#compatible' do
     it 'returns false for unsupported gem versions' do
-      allow(Gem).to receive(:loaded_specs).and_return({ 'aws-sdk-core' => nil, 'aws-sdk' => nil })
-      hide_const('::Aws::CORE_GEM_VERSION')
-      _(instrumentation.compatible?).must_equal false
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => nil, 'aws-sdk' => nil }) do
+        hide_const('::Aws::CORE_GEM_VERSION')
+        _(instrumentation.compatible?).must_equal false
+      end
 
-      allow(Gem).to receive(:loaded_specs).and_return(
-        {
-          'aws-sdk-core' => nil,
-          'aws-sdk' => Gem::Specification.new { |s| s.version = '1.0.0' }
-        }
-      )
-      hide_const('::Aws::CORE_GEM_VERSION')
-      _(instrumentation.compatible?).must_equal false
+      Gem.stub(:loaded_specs, {
+                 'aws-sdk-core' => nil,
+                 'aws-sdk' => Gem::Specification.new { |s| s.version = '1.0.0' }
+               }) do
+        hide_const('::Aws::CORE_GEM_VERSION')
+        _(instrumentation.compatible?).must_equal false
+      end
 
-      allow(Gem).to receive(:loaded_specs).and_return(
-        {
-          'aws-sdk-core' => Gem::Specification.new { |s| s.version = '1.0.0' },
-          'aws-sdk' => nil
-        }
-      )
-      hide_const('::Aws::CORE_GEM_VERSION')
-      _(instrumentation.compatible?).must_equal false
+      Gem.stub(:loaded_specs, {
+                 'aws-sdk-core' => Gem::Specification.new { |s| s.version = '1.0.0' },
+                 'aws-sdk' => nil
+               }) do
+        hide_const('::Aws::CORE_GEM_VERSION')
+        _(instrumentation.compatible?).must_equal false
+      end
 
-      allow(Gem).to receive(:loaded_specs).and_return({ 'aws-sdk-core' => nil, 'aws-sdk' => nil })
-      stub_const('::Aws::CORE_GEM_VERSION', '1.9.9')
-      _(instrumentation.compatible?).must_equal false
+      Gem.stub(:loaded_specs, { 'aws-sdk-core' => nil, 'aws-sdk' => nil }) do
+        stub_const('::Aws::CORE_GEM_VERSION', '1.9.9')
+        _(instrumentation.compatible?).must_equal false
+      end
     end
 
     it 'returns true for supported gem versions' do

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'opentelemetry-instrumentation-aws_sdk'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -88,26 +88,28 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
         dalli.set('foo', 'bar')
         exporter.reset
 
-        allow(dalli.instance_variable_get(:@ring).servers.first).to receive(:write) { |_bytes| raise Dalli::NetworkError }
-        dalli.get_multi('foo', 'bar')
+        server_obj = dalli.instance_variable_get(:@ring).servers.first
+        server_obj.stub(:write, ->(_bytes) { raise Dalli::NetworkError }) do
+          dalli.get_multi('foo', 'bar')
 
-        if supports_retry_on_network_errors?
-          _(exporter.finished_spans.size).must_equal 2
-        else
-          _(exporter.finished_spans.size).must_equal 1
+          if supports_retry_on_network_errors?
+            _(exporter.finished_spans.size).must_equal 2
+          else
+            _(exporter.finished_spans.size).must_equal 1
+          end
+
+          _(span.name).must_equal 'getkq'
+          _(span.attributes['db.system']).must_equal 'memcached'
+          _(span.attributes['db.statement']).must_equal 'getkq foo bar'
+          _(span.attributes['db.operation']).must_equal 'getkq'
+          _(span.attributes['net.peer.name']).must_equal host
+          _(span.attributes['net.peer.port']).must_equal port
+
+          span_event = span.events.first
+          _(span_event.name).must_equal 'exception'
+          _(span_event.attributes['exception.type']).must_equal 'Dalli::NetworkError'
+          _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
         end
-
-        _(span.name).must_equal 'getkq'
-        _(span.attributes['db.system']).must_equal 'memcached'
-        _(span.attributes['db.statement']).must_equal 'getkq foo bar'
-        _(span.attributes['db.operation']).must_equal 'getkq'
-        _(span.attributes['net.peer.name']).must_equal host
-        _(span.attributes['net.peer.port']).must_equal port
-
-        span_event = span.events.first
-        _(span_event.name).must_equal 'exception'
-        _(span_event.attributes['exception.type']).must_equal 'Dalli::NetworkError'
-        _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
       end
 
       it 'omits db.statement' do
@@ -147,15 +149,17 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
         exporter.reset
 
         server = dalli.instance_variable_get(:@ring).servers.first
-        allow(server).to receive(:hostname).and_return('/tmp/memcached.sock')
-        allow(server).to receive(:port).and_return(nil)
-        dalli.set('foo', 'bar')
+        server.stub(:hostname, '/tmp/memcached.sock') do
+          server.stub(:port, nil) do
+            dalli.set('foo', 'bar')
 
-        puts exporter.finished_spans
-        _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'set'
-        _(span.attributes).wont_include 'net.peer.port'
-        _(span.attributes['net.peer.name']).must_equal '/tmp/memcached.sock'
+            puts exporter.finished_spans
+            _(exporter.finished_spans.size).must_equal 1
+            _(span.name).must_equal 'set'
+            _(span.attributes).wont_include 'net.peer.port'
+            _(span.attributes['net.peer.name']).must_equal '/tmp/memcached.sock'
+          end
+        end
       end
     end
   end

--- a/instrumentation/dalli/test/test_helper.rb
+++ b/instrumentation/dalli/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'sqlite3', '~> 2.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'sqlite3', '~> 2.9'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -29,13 +29,15 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
 
   describe 'compatible' do
     it 'when older gem version installed' do
-      allow(Gem).to receive(:loaded_specs).and_return({ 'delayed_job' => Gem::Specification.new { |s| s.version = '4.0.3' } })
-      _(instrumentation.compatible?).must_equal false
+      Gem.stub(:loaded_specs, { 'delayed_job' => Gem::Specification.new { |s| s.version = '4.0.3' } }) do
+        _(instrumentation.compatible?).must_equal false
+      end
     end
 
     it 'when future gem version installed' do
-      allow(Gem).to receive(:loaded_specs).and_return({ 'delayed_job' => Gem::Specification.new { |s| s.version = '5.3.0' } })
-      _(instrumentation.compatible?).must_equal true
+      Gem.stub(:loaded_specs, { 'delayed_job' => Gem::Specification.new { |s| s.version = '5.3.0' } }) do
+        _(instrumentation.compatible?).must_equal true
+      end
     end
   end
 

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -18,7 +18,7 @@ require 'active_support/core_ext/array/extract_options'
 require 'opentelemetry-instrumentation-delayed_job'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/dup/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/dup/instrumentation_test.rb
@@ -65,56 +65,57 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
         let(:span) { easy.instance_eval { @otel_span } }
 
         it 'creates a span' do
-          allow(Ethon::Curl).to receive(:easy_perform).and_return(0)
-          # NOTE: suppress call to #complete to isolate #perform functionality
-          allow(easy).to receive(:complete).and_return(nil)
+          Ethon::Curl.stub(:easy_perform, 0) do
+            # NOTE: suppress call to #complete to isolate #perform functionality
+            easy.stub(:complete, nil) do
+              easy.perform
 
-          easy.perform
-
-          _(span.name).must_equal 'HTTP'
-          _(span.attributes['http.method']).must_equal '_OTHER'
-          _(span.attributes['http.status_code']).must_be_nil
-          _(span.attributes['http.url']).must_equal 'http://example.com/test'
-          _(span.attributes['net.peer.name']).must_equal 'example.com'
-          _(span.attributes['http.request.method']).must_equal '_OTHER'
-          _(span.attributes['http.response.status_code']).must_be_nil
-          _(span.attributes['url.full']).must_equal 'http://example.com/test'
-          _(span.attributes['server.address']).must_equal 'example.com'
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.method']).must_equal '_OTHER'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['net.peer.name']).must_equal 'example.com'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.attributes['server.address']).must_equal 'example.com'
+            end
+          end
         end
 
         describe 'when the perform fails before complete with an exception' do
           it 'raises the original error and closes the span with error status' do
-            allow(Ethon::Curl).to receive(:easy_perform) { |_handle| raise StandardError, 'Connection failed' }
-
-            assert_raises StandardError, 'Connection failed' do
-              easy.perform
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.method']).must_equal '_OTHER'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
             end
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP'
-            _(span.attributes['http.method']).must_equal '_OTHER'
-            _(span.attributes['http.status_code']).must_be_nil
-            _(span.attributes['http.url']).must_equal 'http://example.com/test'
-            _(span.attributes['http.request.method']).must_equal '_OTHER'
-            _(span.attributes['http.response.status_code']).must_be_nil
-            _(span.attributes['url.full']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
           end
         end
       end
 
       describe '#complete' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'when response is successful' do
@@ -258,13 +259,13 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
       describe 'with unknown HTTP method' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'normalizes unknown HTTP methods' do

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/old/instrumentation_test.rb
@@ -66,50 +66,51 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
         let(:span) { easy.instance_eval { @otel_span } }
 
         it 'creates a span' do
-          allow(Ethon::Curl).to receive(:easy_perform).and_return(0)
-          # NOTE: suppress call to #complete to isolate #perform functionality
-          allow(easy).to receive(:complete).and_return(nil)
+          Ethon::Curl.stub(:easy_perform, 0) do
+            # NOTE: suppress call to #complete to isolate #perform functionality
+            easy.stub(:complete, nil) do
+              easy.perform
 
-          easy.perform
-
-          _(span.name).must_equal 'HTTP'
-          _(span.attributes['http.method']).must_equal '_OTHER'
-          _(span.attributes['http.status_code']).must_be_nil
-          _(span.attributes['http.url']).must_equal 'http://example.com/test'
-          _(span.attributes['net.peer.name']).must_equal 'example.com'
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.method']).must_equal '_OTHER'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.attributes['net.peer.name']).must_equal 'example.com'
+            end
+          end
         end
 
         describe 'when the perform fails before complete with an exception' do
           it 'raises the original error and closes the span with error status' do
-            allow(Ethon::Curl).to receive(:easy_perform) { |_handle| raise StandardError, 'Connection failed' }
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
 
-            assert_raises StandardError, 'Connection failed' do
-              easy.perform
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.method']).must_equal '_OTHER'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
             end
-
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP'
-            _(span.attributes['http.method']).must_equal '_OTHER'
-            _(span.attributes['http.status_code']).must_be_nil
-            _(span.attributes['http.url']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
           end
         end
       end
 
       describe '#complete' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'when response is successful' do
@@ -242,13 +243,13 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
       describe 'with unknown HTTP method' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'normalizes unknown HTTP methods' do

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/stable/instrumentation_test.rb
@@ -64,50 +64,51 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
         let(:span) { easy.instance_eval { @otel_span } }
 
         it 'creates a span' do
-          allow(Ethon::Curl).to receive(:easy_perform).and_return(0)
-          # NOTE: suppress call to #complete to isolate #perform functionality
-          allow(easy).to receive(:complete).and_return(nil)
+          Ethon::Curl.stub(:easy_perform, 0) do
+            # NOTE: suppress call to #complete to isolate #perform functionality
+            easy.stub(:complete, nil) do
+              easy.perform
 
-          easy.perform
-
-          _(span.name).must_equal 'HTTP'
-          _(span.attributes['http.request.method']).must_equal '_OTHER'
-          _(span.attributes['http.response.status_code']).must_be_nil
-          _(span.attributes['url.full']).must_equal 'http://example.com/test'
-          _(span.attributes['server.address']).must_equal 'example.com'
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.attributes['server.address']).must_equal 'example.com'
+            end
+          end
         end
 
         describe 'when the perform fails before complete with an exception' do
           it 'raises the original error and closes the span with error status' do
-            allow(Ethon::Curl).to receive(:easy_perform) { |_handle| raise StandardError, 'Connection failed' }
+            Ethon::Curl.stub(:easy_perform, ->(_handle) { raise StandardError, 'Connection failed' }) do
+              assert_raises StandardError, 'Connection failed' do
+                easy.perform
+              end
 
-            assert_raises StandardError, 'Connection failed' do
-              easy.perform
+              # NOTE: check the finished spans since we expect to have closed it
+              span = exporter.finished_spans.first
+              _(span.name).must_equal 'HTTP'
+              _(span.attributes['http.request.method']).must_equal '_OTHER'
+              _(span.attributes['http.response.status_code']).must_be_nil
+              _(span.attributes['url.full']).must_equal 'http://example.com/test'
+              _(span.status.code).must_equal(
+                OpenTelemetry::Trace::Status::ERROR
+              )
+              _(easy.instance_eval { @otel_span }).must_be_nil
             end
-
-            # NOTE: check the finished spans since we expect to have closed it
-            span = exporter.finished_spans.first
-            _(span.name).must_equal 'HTTP'
-            _(span.attributes['http.request.method']).must_equal '_OTHER'
-            _(span.attributes['http.response.status_code']).must_be_nil
-            _(span.attributes['url.full']).must_equal 'http://example.com/test'
-            _(span.status.code).must_equal(
-              OpenTelemetry::Trace::Status::ERROR
-            )
-            _(easy.instance_eval { @otel_span }).must_be_nil
           end
         end
       end
 
       describe '#complete' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'when response is successful' do
@@ -240,13 +241,13 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
       describe 'with unknown HTTP method' do
         def stub_response(options)
-          allow(easy).to receive(:mirror).and_return(Ethon::Easy::Mirror.new(options))
+          easy.stub(:mirror, Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # NOTE: perform calls complete
+            easy.complete
 
-          easy.otel_before_request
-          # NOTE: perform calls complete
-          easy.complete
-
-          yield
+            yield
+          end
         end
 
         it 'normalizes unknown HTTP methods' do

--- a/instrumentation/ethon/test/test_helper.rb
+++ b/instrumentation/ethon/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 require 'opentelemetry-instrumentation-faraday'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.2'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-rack', path: '../rack'
   gem 'builder', '~> 3.3'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'yard', '~> 0.9'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.2'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-rack', path: '../rack'
   gem 'builder', '~> 3.3'

--- a/instrumentation/grape/test/test_helper.rb
+++ b/instrumentation/grape/test/test_helper.rb
@@ -10,7 +10,7 @@ Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # Monkey-patch webmock to support HTTP.rb's 6.0+ keyword arguments

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/httpx/test/test_helper.rb
+++ b/instrumentation/httpx/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'httpx/adapters/webmock'
 require 'webmock/minitest'
 

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/koala/test/test_helper.rb
+++ b/instrumentation/koala/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 require 'opentelemetry-instrumentation-koala'

--- a/instrumentation/logger/Gemfile
+++ b/instrumentation/logger/Gemfile
@@ -15,7 +15,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-logs-sdk', '~> 0.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/logger/Gemfile
+++ b/instrumentation/logger/Gemfile
@@ -15,7 +15,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-logs-sdk', '~> 0.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
@@ -43,13 +43,14 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::Logger do
       timestamp = Time.now
       nano_timestamp = OpenTelemetry::SDK::Logs::LogRecord.new.send(:to_integer_nanoseconds, timestamp)
 
-      allow(Time).to receive(:now).and_return(timestamp)
-      ruby_logger.debug(msg)
-      assert_includes(log_record.body, msg)
-      assert_includes(log_record.body, 'DEBUG')
-      assert_equal('DEBUG', log_record.severity_text)
-      assert_equal(5, log_record.severity_number)
-      assert_equal(nano_timestamp, log_record.timestamp)
+      Time.stub(:now, timestamp) do
+        ruby_logger.debug(msg)
+        assert_includes(log_record.body, msg)
+        assert_includes(log_record.body, 'DEBUG')
+        assert_equal('DEBUG', log_record.severity_text)
+        assert_equal(5, log_record.severity_number)
+        assert_equal(nano_timestamp, log_record.timestamp)
+      end
     end
 
     it 'does not emit when @skip_otel_emit is true' do

--- a/instrumentation/logger/test/test_helper.rb
+++ b/instrumentation/logger/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'test_helpers/app_config'
 
 EXPORTER = OpenTelemetry::SDK::Logs::Export::InMemoryLogRecordExporter.new

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 require 'opentelemetry-instrumentation-mongo'

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
@@ -258,18 +258,19 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         def fake_socket.close; end
 
         # Replace the TCP socket creation with our fake socket
-        allow(TCPSocket).to receive(:open).and_return(fake_socket)
-        http.send(:connect)
+        TCPSocket.stub(:open, fake_socket) do
+          http.send(:connect)
 
-        http.send(:do_finish)
-        _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal('connect')
-        _(span.kind).must_equal(:internal)
-        _(span.attributes['net.peer.name']).must_equal('example.com')
-        _(span.attributes['net.peer.port']).must_equal(80)
-        # stable semantic conventions
-        _(span.attributes['server.address']).must_equal('example.com')
-        _(span.attributes['server.port']).must_equal(80)
+          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 1
+          _(span.name).must_equal('connect')
+          _(span.kind).must_equal(:internal)
+          _(span.attributes['net.peer.name']).must_equal('example.com')
+          _(span.attributes['net.peer.port']).must_equal(80)
+          # stable semantic conventions
+          _(span.attributes['server.address']).must_equal('example.com')
+          _(span.attributes['server.port']).must_equal(80)
+        end
       end
     end
 
@@ -278,30 +279,30 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         # Calling `tracer.in_span` within an untraced context causes the logging of "called
         # finish on an ended Span" messages. To avoid log noise, the instrumentation must
         # no-op (i.e., not call `tracer.in_span`) when the context is untraced.
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            Net::HTTP.get('example.com', '/body')
+          end
 
-        OpenTelemetry::Common::Utilities.untraced do
-          Net::HTTP.get('example.com', '/body')
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
 
       it 'no-ops on #connect' do
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            uri = URI.parse('http://example.com/body')
+            http = Net::HTTP.new(uri.host, uri.port)
 
-        OpenTelemetry::Common::Utilities.untraced do
-          uri = URI.parse('http://example.com/body')
-          http = Net::HTTP.new(uri.host, uri.port)
+            # Mock the connect
+            http.define_singleton_method(:connect) { true }
 
-          # Mock the connect
-          http.define_singleton_method(:connect) { true }
+            http.send(:connect)
+            http.send(:do_finish)
+          end
 
-          http.send(:connect)
-          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
     end
   end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
@@ -203,15 +203,16 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         def fake_socket.close; end
 
         # Replace the TCP socket creation with our fake socket
-        allow(TCPSocket).to receive(:open).and_return(fake_socket)
-        http.send(:connect)
+        TCPSocket.stub(:open, fake_socket) do
+          http.send(:connect)
 
-        http.send(:do_finish)
-        _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal('connect')
-        _(span.kind).must_equal(:internal)
-        _(span.attributes['net.peer.name']).must_equal('example.com')
-        _(span.attributes['net.peer.port']).must_equal(80)
+          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 1
+          _(span.name).must_equal('connect')
+          _(span.kind).must_equal(:internal)
+          _(span.attributes['net.peer.name']).must_equal('example.com')
+          _(span.attributes['net.peer.port']).must_equal(80)
+        end
       end
     end
 
@@ -220,30 +221,30 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         # Calling `tracer.in_span` within an untraced context causes the logging of "called
         # finish on an ended Span" messages. To avoid log noise, the instrumentation must
         # no-op (i.e., not call `tracer.in_span`) when the context is untraced.
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            Net::HTTP.get('example.com', '/body')
+          end
 
-        OpenTelemetry::Common::Utilities.untraced do
-          Net::HTTP.get('example.com', '/body')
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
 
       it 'no-ops on #connect' do
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            uri = URI.parse('http://example.com/body')
+            http = Net::HTTP.new(uri.host, uri.port)
 
-        OpenTelemetry::Common::Utilities.untraced do
-          uri = URI.parse('http://example.com/body')
-          http = Net::HTTP.new(uri.host, uri.port)
+            # Mock the connect
+            http.define_singleton_method(:connect) { true }
 
-          # Mock the connect
-          http.define_singleton_method(:connect) { true }
+            http.send(:connect)
+            http.send(:do_finish)
+          end
 
-          http.send(:connect)
-          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
     end
   end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
@@ -220,15 +220,16 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         def fake_socket.close; end
 
         # Replace the TCP socket creation with our fake socket
-        allow(TCPSocket).to receive(:open).and_return(fake_socket)
-        http.send(:connect)
+        TCPSocket.stub(:open, fake_socket) do
+          http.send(:connect)
 
-        http.send(:do_finish)
-        _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal('connect')
-        _(span.kind).must_equal(:internal)
-        _(span.attributes['server.address']).must_equal('example.com')
-        _(span.attributes['server.port']).must_equal(80)
+          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 1
+          _(span.name).must_equal('connect')
+          _(span.kind).must_equal(:internal)
+          _(span.attributes['server.address']).must_equal('example.com')
+          _(span.attributes['server.port']).must_equal(80)
+        end
       end
     end
 
@@ -237,30 +238,30 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         # Calling `tracer.in_span` within an untraced context causes the logging of "called
         # finish on an ended Span" messages. To avoid log noise, the instrumentation must
         # no-op (i.e., not call `tracer.in_span`) when the context is untraced.
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            Net::HTTP.get('example.com', '/body')
+          end
 
-        OpenTelemetry::Common::Utilities.untraced do
-          Net::HTTP.get('example.com', '/body')
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
 
       it 'no-ops on #connect' do
-        expect(instrumentation.tracer).not_to receive(:in_span)
+        instrumentation.tracer.stub(:in_span, ->(*) { flunk 'in_span should not be called' }) do
+          OpenTelemetry::Common::Utilities.untraced do
+            uri = URI.parse('http://example.com/body')
+            http = Net::HTTP.new(uri.host, uri.port)
 
-        OpenTelemetry::Common::Utilities.untraced do
-          uri = URI.parse('http://example.com/body')
-          http = Net::HTTP.new(uri.host, uri.port)
+            # Mock the connect
+            http.define_singleton_method(:connect) { true }
 
-          # Mock the connect
-          http.define_singleton_method(:connect) { true }
+            http.send(:connect)
+            http.send(:do_finish)
+          end
 
-          http.send(:connect)
-          http.send(:do_finish)
+          _(exporter.finished_spans.size).must_equal 0
         end
-
-        _(exporter.finished_spans.size).must_equal 0
       end
     end
   end

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -21,7 +21,7 @@ module Net
 end
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'

--- a/instrumentation/racecar/test/test_helper.rb
+++ b/instrumentation/racecar/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'active_support'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'rack-test', '~> 2.2.0'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'rack-test', '~> 2.2.0'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
@@ -446,10 +446,16 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::EventHandler' 
       let(:response_propagators) { [EventMockPropagator.new, OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator.new] }
 
       it 'is fault tolerant' do
-        expect(OpenTelemetry).to receive(:handle_error).with(exception: instance_of(EventMockPropagator::CustomError), message: /Unable/)
-
-        get '/ping'
-        _(last_response.headers).must_include('traceresponse')
+        error_handled = false
+        OpenTelemetry.stub(:handle_error, ->(**kwargs) {
+          assert_instance_of EventMockPropagator::CustomError, kwargs[:exception]
+          assert_match(/Unable/, kwargs[:message])
+          error_handled = true
+        }) do
+          get '/ping'
+          _(last_response.headers).must_include('traceresponse')
+        end
+        assert error_handled, 'expected handle_error to be called'
       end
     end
   end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/event_handler_resiliency_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/event_handler_resiliency_test.rb
@@ -17,13 +17,16 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::EventHandler::Resil
   before { skip unless ENV['BUNDLE_GEMFILE'].include?('old') }
 
   it 'reports unexpected errors without causing request errors' do
-    allow(OpenTelemetry::Instrumentation::Rack).to receive(:current_span).and_raise('Bad news!')
-    expect(OpenTelemetry).to receive(:handle_error).exactly(5).times
-
-    handler.on_start(nil, nil)
-    handler.on_commit(nil, nil)
-    handler.on_send(nil, nil)
-    handler.on_error(nil, nil, nil)
-    handler.on_finish(nil, nil)
+    call_count = 0
+    OpenTelemetry::Instrumentation::Rack.stub(:current_span, -> { raise 'Bad news!' }) do
+      OpenTelemetry.stub(:handle_error, ->(*_args, **_kwargs) { call_count += 1 }) do
+        handler.on_start(nil, nil)
+        handler.on_commit(nil, nil)
+        handler.on_send(nil, nil)
+        handler.on_error(nil, nil, nil)
+        handler.on_finish(nil, nil)
+      end
+    end
+    assert_equal 5, call_count
   end
 end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
@@ -425,10 +425,16 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler' 
       let(:response_propagators) { [EventMockPropagator.new, OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator.new] }
 
       it 'is fault tolerant' do
-        expect(OpenTelemetry).to receive(:handle_error).with(exception: instance_of(EventMockPropagator::CustomError), message: /Unable/)
-
-        get '/ping'
-        _(last_response.headers).must_include('traceresponse')
+        error_handled = false
+        OpenTelemetry.stub(:handle_error, ->(**kwargs) {
+          assert_instance_of EventMockPropagator::CustomError, kwargs[:exception]
+          assert_match(/Unable/, kwargs[:message])
+          error_handled = true
+        }) do
+          get '/ping'
+          _(last_response.headers).must_include('traceresponse')
+        end
+        assert error_handled, 'expected handle_error to be called'
       end
     end
   end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
@@ -421,10 +421,16 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandle
       let(:response_propagators) { [EventMockPropagator.new, OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator.new] }
 
       it 'is fault tolerant' do
-        expect(OpenTelemetry).to receive(:handle_error).with(exception: instance_of(EventMockPropagator::CustomError), message: /Unable/)
-
-        get '/ping'
-        _(last_response.headers).must_include('traceresponse')
+        error_handled = false
+        OpenTelemetry.stub(:handle_error, ->(**kwargs) {
+          assert_instance_of EventMockPropagator::CustomError, kwargs[:exception]
+          assert_match(/Unable/, kwargs[:message])
+          error_handled = true
+        }) do
+          get '/ping'
+          _(last_response.headers).must_include('traceresponse')
+        end
+        assert error_handled, 'expected handle_error to be called'
       end
     end
   end

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'rack/events'
 require 'opentelemetry-instrumentation-rack'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/rake/test/opentelemetry/instrumentation/rake/patches/task_test.rb
+++ b/instrumentation/rake/test/opentelemetry/instrumentation/rake/patches/task_test.rb
@@ -67,10 +67,11 @@ describe OpenTelemetry::Instrumentation::Rake::Patches::Task do
 
         Rake.application.instance_eval { @top_level_tasks = [task_string] }
 
-        allow(OpenTelemetry).to receive(:tracer_provider).and_return(mock)
-        Rake.application.invoke_task(task_string)
+        OpenTelemetry.stub(:tracer_provider, mock) do
+          Rake.application.invoke_task(task_string)
 
-        mock.verify
+          mock.verify
+        end
       end
     end
 

--- a/instrumentation/rake/test/test_helper.rb
+++ b/instrumentation/rake/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test do
   gem 'appraisal', '~> 2.5'
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -51,17 +51,18 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
 
   it 'will not be affected by tests that mock time' do
     current_time = Time.now
-    allow(Time).to receive(:now).and_return(Time.at(0))
-    spans = run_rspec_with_tracing do
-      RSpec.describe('group one') do
-        example('example one') { expect(Time.now).to eq Time.at(0) }
+    Time.stub(:now, Time.at(0)) do
+      spans = run_rspec_with_tracing do
+        RSpec.describe('group one') do
+          example('example one') { expect(Time.now).to eq Time.at(0) }
+        end
       end
+      _(spans.first.name).must_equal 'example one'
+      _(spans.first.attributes['rspec.example.result']).must_equal 'passed'
+      _(spans.first.start_timestamp).wont_equal 0
+      _(spans.first.start_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i, 10)
+      _(spans.first.end_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i, 10)
     end
-    _(spans.first.name).must_equal 'example one'
-    _(spans.first.attributes['rspec.example.result']).must_equal 'passed'
-    _(spans.first.start_timestamp).wont_equal 0
-    _(spans.first.start_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i, 10)
-    _(spans.first.end_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i, 10)
   end
 
   describe 'exports spans for example groups' do

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -13,7 +13,7 @@ require_relative 'rspec_patches'
 require 'rspec/core'
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -44,13 +44,15 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
     describe 'when the installing application bypasses RubyGems' do
       it 'falls back to the VERSION constant' do
         stub_const('Kafka::VERSION', '0.6.9')
-        allow(Gem).to receive(:loaded_specs).and_return({ 'ruby-kafka' => nil })
-        _(instrumentation.compatible?).must_equal false
+        Gem.stub(:loaded_specs, { 'ruby-kafka' => nil }) do
+          _(instrumentation.compatible?).must_equal false
 
-        version = OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
-        stub_const('Kafka::VERSION', version)
-        allow(Gem).to receive(:loaded_specs).and_return({ 'ruby-kafka' => nil })
-        _(instrumentation.compatible?).must_equal true
+          version = OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
+          stub_const('Kafka::VERSION', version)
+          Gem.stub(:loaded_specs, { 'ruby-kafka' => nil }) do
+            _(instrumentation.compatible?).must_equal true
+          end
+        end
       end
     end
   end

--- a/instrumentation/ruby_kafka/test/test_helper.rb
+++ b/instrumentation/ruby_kafka/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'rails', '>= 7.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-redis', path: '../redis'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
   gem 'rails', '>= 7.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-redis', path: '../redis'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/instrumentation_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/instrumentation_test.rb
@@ -55,61 +55,66 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Instrumentation do
 
     describe 'configuring the Sidekiq Client' do
       before do
-        allow(Sidekiq).to receive(:server?).and_return(false)
-        Sidekiq.configure_client do |config|
-          config.client_middleware do |chain|
-            chain.add(Frontkiq::SweetClientMiddleware)
+        Sidekiq.stub(:server?, false) do
+          Sidekiq.configure_client do |config|
+            config.client_middleware do |chain|
+              chain.add(Frontkiq::SweetClientMiddleware)
+            end
           end
         end
       end
 
       it 'prepends the Client::TracerMiddleware to the Sidekiq Client middleware chain' do
-        allow(Sidekiq).to receive(:server?).and_return(false)
-        instrumentation.install
+        Sidekiq.stub(:server?, false) do
+          instrumentation.install
 
-        middlewares = @sidekiq_config.client_middleware.entries
-        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
-        _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+          middlewares = @sidekiq_config.client_middleware.entries
+          _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
+          _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+        end
       end
     end
 
     describe 'configuring the Sidekiq Server' do
       before do
-        allow(Sidekiq).to receive(:server?).and_return(true)
-        Sidekiq.configure_server do |config|
-          config.client_middleware do |chain|
-            chain.add(Frontkiq::SweetClientMiddleware)
+        Sidekiq.stub(:server?, true) do
+          Sidekiq.configure_server do |config|
+            config.client_middleware do |chain|
+              chain.add(Frontkiq::SweetClientMiddleware)
+            end
+            config.server_middleware do |chain|
+              chain.add(Frontkiq::SweetServerMiddleware)
+            end
           end
-          config.server_middleware do |chain|
+
+          Sidekiq::Testing.server_middleware do |chain|
             chain.add(Frontkiq::SweetServerMiddleware)
           end
-        end
-
-        Sidekiq::Testing.server_middleware do |chain|
-          chain.add(Frontkiq::SweetServerMiddleware)
         end
       end
 
       it 'prepends the Client::TracerMiddleware to the Sidekiq Client middleware chain' do
-        allow(Sidekiq).to receive(:server?).and_return(true)
-        instrumentation.install
+        Sidekiq.stub(:server?, true) do
+          instrumentation.install
 
-        middlewares = @sidekiq_config.client_middleware.entries
-        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
-        _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+          middlewares = @sidekiq_config.client_middleware.entries
+          _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Client::TracerMiddleware)
+          _(middlewares.last.klass).must_equal(Frontkiq::SweetClientMiddleware)
+        end
       end
 
       it 'prepends the Server::TracerMiddleware to the Sidekiq Server middleware chain' do
-        allow(Sidekiq).to receive(:server?).and_return(true)
-        instrumentation.install
+        Sidekiq.stub(:server?, true) do
+          instrumentation.install
 
-        middlewares = @sidekiq_config.server_middleware.entries
-        _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
-        _(middlewares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
+          middlewares = @sidekiq_config.server_middleware.entries
+          _(middlewares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
+          _(middlewares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
 
-        testing_wares = Sidekiq::Testing.server_middleware.entries
-        _(testing_wares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
-        _(testing_wares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
+          testing_wares = Sidekiq::Testing.server_middleware.entries
+          _(testing_wares.first.klass).must_equal(OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
+          _(testing_wares.last.klass).must_equal(Frontkiq::SweetServerMiddleware)
+        end
       end
     end
   end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
@@ -63,21 +63,23 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Poller do
 
   describe '#wait' do
     it 'does not trace' do
-      allow(poller).to receive(:random_poll_interval).and_return(0.0)
-      poller.send(:wait)
+      poller.stub(:random_poll_interval, 0.0) do
+        poller.send(:wait)
 
-      _(spans.size).must_equal(0)
+        _(spans.size).must_equal(0)
+      end
     end
 
     describe 'when wait tracing is enabled' do
       let(:config) { { trace_poller_wait: true } }
 
       it 'traces' do
-        allow(poller).to receive(:random_poll_interval).and_return(0.0)
-        poller.send(:wait)
+        poller.stub(:random_poll_interval, 0.0) do
+          poller.send(:wait)
 
-        span_names = spans.map(&:name)
-        _(span_names).must_include('Sidekiq::Scheduled::Poller#wait')
+          span_names = spans.map(&:name)
+          _(span_names).must_include('Sidekiq::Scheduled::Poller#wait')
+        end
       end
     end
   end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/processor_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/processor_test.rb
@@ -42,9 +42,13 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Processor do
     end
 
     it 'does not run inside an untraced block' do
-      expect(processor).to receive(:fetch) # accounts for #fetch calling untraced
-      expect(OpenTelemetry::Common::Utilities).not_to receive(:untraced)
-      processor.send(:process_one)
+      fetch_called = false
+      processor.stub(:fetch, ->(*) { fetch_called = true }) do
+        OpenTelemetry::Common::Utilities.stub(:untraced, ->(*) { flunk 'untraced should not be called' }) do
+          processor.send(:process_one)
+        end
+      end
+      assert fetch_called, 'expected fetch to be called'
     end
 
     describe 'when process_one tracing is enabled' do

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'rails'
 require 'active_job'
 require 'sidekiq/rails'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
   gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
   gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -382,29 +382,31 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         propagator = OpenTelemetry::Instrumentation::Trilogy::Instrumentation.instance.propagator
 
         arg_cache = {} # maintain handles to args
-        allow(client).to receive(:query).and_wrap_original do |m, *args|
+        original_query = client.method(:query)
+        client.stub(:query, ->(*args) {
           arg_cache[:query_input] = args[0]
           assert(args[0].frozen?)
-          m.call(args[0])
+          original_query.call(args[0])
+        }) do
+          original_inject = propagator.method(:inject)
+          propagator.stub(:inject, ->(*args) {
+            arg_cache[:inject_input] = args[0]
+            refute(args[0].frozen?)
+            assert_match(sql, args[0])
+            original_inject.call(args[0], context: args[1][:context])
+          }) do
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            # arg_cache[:inject_input] _was_ a mutable string, so it has the context injected
+            encoded = Base64.strict_encode64("{\"uber-trace-id\":\"#{span.hex_trace_id}:#{span.hex_span_id}:0:1\"}")
+            assert_equal(arg_cache[:inject_input], "/*VT_SPAN_CONTEXT=#{encoded}*/#{sql}")
+
+            # arg_cache[:inject_input] is now frozen
+            assert(arg_cache[:inject_input].frozen?)
+          end
         end
-
-        allow(propagator).to receive(:inject).and_wrap_original do |m, *args|
-          arg_cache[:inject_input] = args[0]
-          refute(args[0].frozen?)
-          assert_match(sql, args[0])
-          m.call(args[0], context: args[1][:context])
-        end
-
-        expect do
-          client.query(sql)
-        end.must_raise Trilogy::Error
-
-        # arg_cache[:inject_input] _was_ a mutable string, so it has the context injected
-        encoded = Base64.strict_encode64("{\"uber-trace-id\":\"#{span.hex_trace_id}:#{span.hex_span_id}:0:1\"}")
-        assert_equal(arg_cache[:inject_input], "/*VT_SPAN_CONTEXT=#{encoded}*/#{sql}")
-
-        # arg_cache[:inject_input] is now frozen
-        assert(arg_cache[:inject_input].frozen?)
       end
 
       it 'does inject context on unfrozen strings' do
@@ -434,29 +436,31 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         propagator = OpenTelemetry::Instrumentation::Trilogy::Instrumentation.instance.propagator
 
         arg_cache = {} # maintain handles to args
-        allow(client).to receive(:query).and_wrap_original do |m, *args|
+        original_query = client.method(:query)
+        client.stub(:query, ->(*args) {
           arg_cache[:query_input] = args[0]
           _(args[0]).must_be :frozen?
-          m.call(args[0])
+          original_query.call(args[0])
+        }) do
+          original_inject = propagator.method(:inject)
+          propagator.stub(:inject, ->(*args) {
+            arg_cache[:inject_input] = args[0]
+            _(args[0]).wont_be :frozen?
+            _(args[0]).must_match(sql)
+            original_inject.call(args[0], context: args[1][:context])
+          }) do
+            expect do
+              client.query(sql)
+            end.must_raise Trilogy::Error
+
+            # arg_cache[:inject_input] _was_ a mutable string, so it has the context injected
+            # The tracecontext propagator injects traceparent and tracestate headers as SQL comments
+            _(arg_cache[:inject_input]).must_match(%r{/\*traceparent='00-#{span.hex_trace_id}-#{span.hex_span_id}-01'\*/})
+
+            # arg_cache[:inject_input] is now frozen
+            _(arg_cache[:inject_input]).must_be :frozen?
+          end
         end
-
-        allow(propagator).to receive(:inject).and_wrap_original do |m, *args|
-          arg_cache[:inject_input] = args[0]
-          _(args[0]).wont_be :frozen?
-          _(args[0]).must_match(sql)
-          m.call(args[0], context: args[1][:context])
-        end
-
-        expect do
-          client.query(sql)
-        end.must_raise Trilogy::Error
-
-        # arg_cache[:inject_input] _was_ a mutable string, so it has the context injected
-        # The tracecontext propagator injects traceparent and tracestate headers as SQL comments
-        _(arg_cache[:inject_input]).must_match(%r{/\*traceparent='00-#{span.hex_trace_id}-#{span.hex_span_id}-01'\*/})
-
-        # arg_cache[:inject_input] is now frozen
-        _(arg_cache[:inject_input]).must_be :frozen?
       end
 
       it 'injects context on unfrozen strings' do

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'

--- a/resources/container/test/opentelemetry/resource/detector/container_test.rb
+++ b/resources/container/test/opentelemetry/resource/detector/container_test.rb
@@ -111,24 +111,30 @@ describe OpenTelemetry::Resource::Detector::Container do
       end
 
       it 'returns a resource with container id for cgroup v1' do
-        allow(File).to receive(:readable?) { |arg| arg == cgroup_v1_path }
-        allow(File).to receive(:readlines).and_return(cgroup_v1)
-        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-        _(detected_resource_attributes).must_equal(expected_resource_attributes_v1)
+        File.stub(:readable?, ->(arg) { arg == cgroup_v1_path }) do
+          File.stub(:readlines, cgroup_v1) do
+            _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+            _(detected_resource_attributes).must_equal(expected_resource_attributes_v1)
+          end
+        end
       end
 
       it 'returns a resource with container id for cgroup v2 using docker' do
-        allow(File).to receive(:readable?) { |arg| arg == cgroup_v2_path }
-        allow(File).to receive(:readlines).and_return(cgroup_v2)
-        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-        _(detected_resource_attributes).must_equal(expected_resource_attributes_v2)
+        File.stub(:readable?, ->(arg) { arg == cgroup_v2_path }) do
+          File.stub(:readlines, cgroup_v2) do
+            _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+            _(detected_resource_attributes).must_equal(expected_resource_attributes_v2)
+          end
+        end
       end
 
       it 'returns a resource with container id for cgroup v2 using podman' do
-        allow(File).to receive(:readable?) { |arg| arg == cgroup_v2_path }
-        allow(File).to receive(:readlines).and_return(cgroup_v2_podman)
-        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-        _(detected_resource_attributes).must_equal(expected_resource_attributes_v2)
+        File.stub(:readable?, ->(arg) { arg == cgroup_v2_path }) do
+          File.stub(:readlines, cgroup_v2_podman) do
+            _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+            _(detected_resource_attributes).must_equal(expected_resource_attributes_v2)
+          end
+        end
       end
 
       describe 'and a nil resource value is detected' do

--- a/resources/container/test/test_helper.rb
+++ b/resources/container/test/test_helper.rb
@@ -10,6 +10,6 @@ Bundler.require(:default, :development, :test)
 
 require 'opentelemetry-resource-detector-container'
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'rspec-mocks', '~> 3.13.7'
+  gem 'minitest-mock', '~> 1.0'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'minitest-mock', '~> 1.0'
+  gem 'minitest-mock', '~> 5.0'
   gem 'rake', '>= 13'
   gem 'rubocop', '~> 1.85.0'
   gem 'rubocop-performance', '~> 1.26.0'

--- a/resources/google_cloud_platform/test/opentelemetry/resource/detector/google_cloud_platform_test.rb
+++ b/resources/google_cloud_platform/test/opentelemetry/resource/detector/google_cloud_platform_test.rb
@@ -57,14 +57,16 @@ describe OpenTelemetry::Resource::Detector::GoogleCloudPlatform do
         gcp_env_mock.expect(:knative_service_revision, '2')
         gcp_env_mock.expect(:instance_zone, 'us-central1-a')
 
-        allow(Socket).to receive(:gethostname).and_return('opentelemetry-test')
-        old_hostname = ENV.fetch('HOSTNAME', nil)
-        ENV['HOSTNAME'] = 'opentelemetry-host-name-1'
-        begin
-          allow(Google::Cloud::Env).to receive(:new).and_return(gcp_env_mock)
-          detected_resource
-        ensure
-          ENV['HOSTNAME'] = old_hostname
+        Socket.stub(:gethostname, 'opentelemetry-test') do
+          old_hostname = ENV.fetch('HOSTNAME', nil)
+          ENV['HOSTNAME'] = 'opentelemetry-host-name-1'
+          begin
+            Google::Cloud::Env.stub(:new, gcp_env_mock) do
+              detected_resource
+            end
+          ensure
+            ENV['HOSTNAME'] = old_hostname
+          end
         end
       end
 

--- a/resources/google_cloud_platform/test/test_helper.rb
+++ b/resources/google_cloud_platform/test/test_helper.rb
@@ -10,7 +10,7 @@ Bundler.require(:default, :development, :test)
 
 require 'opentelemetry-resource-detector-google_cloud_platform'
 require 'minitest/autorun'
-require 'rspec/mocks/minitest_integration'
+require 'minitest/mock'
 require 'webmock/minitest'
 
 OpenTelemetry.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)


### PR DESCRIPTION
## ⚠️ This PR was generated using copilot 

_The tests are currently failing with System Stack errors. This PR is a placeholder for what it would look like if we chose minitest mocks over rspec._ 

## AI Generated comments below 

Minitest 6 extracted test doubles into its own gem (`minitest-mock`).

This is an **alternative approach** to #2011 (which used `rspec-mocks`) for comparison purposes. Instead of adding `rspec-mocks`, this PR uses the official `minitest-mock` gem — the extracted version of Minitest's built-in mock/stub functionality.

cc: #1908

## Changes

- Replace `rspec-mocks ~> 3.13.7` with `minitest-mock ~> 5.0` in 30 Gemfiles
- Update 29 `test_helper.rb` files to `require 'minitest/mock'` instead of `rspec/mocks/minitest_integration`
- Convert all `allow`/`expect` RSpec Mocks patterns to Minitest `stub` blocks across 25 test files

## Conversion Patterns

| RSpec Mocks | minitest-mock |
|---|---|
| `allow(X).to receive(:m).and_return(v)` | `X.stub(:m, v) { ... }` |
| `allow(X).to receive(:m) { block }` | `X.stub(:m, ->() { block }) { ... }` |
| `expect(X).not_to receive(:m)` | `X.stub(:m, ->(*) { flunk }) { ... }` |
| `expect(X).to receive(:m).exactly(N).times` | Counter variable + `assert_equal N, count` |
| `and_wrap_original` | Capture `.method(:name)` + lambda stub |
| `and_call_original` | Implicit via stub block scope |

## Trade-offs vs #2011 (RSpec Mocks)

**Pros:**
- Stays within the Minitest ecosystem — no RSpec dependency
- `minitest-mock` is the official extraction maintained by the Minitest team
- Same API as Minitest 5's built-in stubs (familiar to existing contributors)

**Cons:**
- Block-scoped stubs increase nesting (each stub wraps remaining test code)
- No built-in spy/verification — requires manual tracking variables
- No `and_wrap_original` equivalent — requires capturing `.method(:name)` manually

## For Reviewers

The main structural difference is block-scoped stubs. I recommend reviewing with **Hide whitespace changes**:

https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/new/fix/minitest-6-minitest-mock?w=1