### PR TITLE
ci: Split docker compose

### DIFF
--- a/.docker/infra/kafka/docker-compose.yml
+++ b/.docker/infra/kafka/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.9.6@sha256:d3294ad2b353ac5a155ad9abe37884f75c482f387af553679210303b7118a0d3
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.9.6@sha256:9e178783dba8cf44cd8b1d260f548a587a21235921957edd4ed7aa7d060b0852
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper

--- a/.docker/infra/memcached/docker-compose.yml
+++ b/.docker/infra/memcached/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  memcached:
+    image: memcached:1.6.40-alpine@sha256:8a82a3927694e42bc52679dc81532244de51e5faed5f9541a1283e3ad7271db1
+    command: memcached -m 64
+    ports:
+      - "11211:11211"

--- a/.docker/infra/mongo/docker-compose.yml
+++ b/.docker/infra/mongo/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  mongo:
+    image: mongo:6.0.27@sha256:03cda579c8caad6573cb98c2b3d5ff5ead452a6450561129b89595b4b9c18de2
+    expose:
+      - "27017"
+    ports:
+      - "27017:27017"

--- a/.docker/infra/mysql/docker-compose.yml
+++ b/.docker/infra/mysql/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  mysql:
+    image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614
+    command: mysqld --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_DATABASE=mysql
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_PASSWORD=mysql
+      - MYSQL_USER=mysql
+    expose:
+      - "3306"
+    ports:
+      - "3306:3306"

--- a/.docker/infra/postgres/docker-compose.yml
+++ b/.docker/infra/postgres/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  postgres:
+    image: postgres:14.22@sha256:705a5d5b5836f3fcba0d02c4d281e6a7dd9ed2dd4078640f08a1e1e9896e097d
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_socket:/var/run/postgresql

--- a/.docker/infra/rabbitmq/docker-compose.yml
+++ b/.docker/infra/rabbitmq/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  rabbitmq:
+    image: rabbitmq:4.2.5-alpine@sha256:53e51f8469ef13d0a1a2b03c0d36dcf4efbf13089f552440ec5620ca07f2c64e
+    ports:
+      - "5672:5672"

--- a/.docker/infra/redis/docker-compose.yml
+++ b/.docker/infra/redis/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  redis:
+    image: redis:8.6.2@sha256:009cc37796fbdbe1b631b4cc0582bed167e5e403ed8bcd06f77eb6cb5aeb6f93
+    command: ["redis-server", "--requirepass", "passw0rd"]
+    volumes:
+      - redis_data:/data
+    ports:
+      - "16379:6379"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -72,6 +72,7 @@ instrumentation-bunny:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/bunny/**"
+          - ".docker/infra/rabbitmq/**"
 instrumentation-concurrent_ruby:
   - changed-files:
       - any-glob-to-any-file:
@@ -80,6 +81,8 @@ instrumentation-dalli:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/dalli/**"
+          - ".docker/infra/memcached/**"
+          - ".docker/infra/mongo/**"
 instrumentation-delayed_job:
   - changed-files:
       - any-glob-to-any-file:
@@ -144,10 +147,12 @@ instrumentation-mongo:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/mongo/**"
+          - ".docker/infra/mongo/**"
 instrumentation-mysql2:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/mysql2/**"
+          - ".docker/infra/mysql/**"
 instrumentation-net_http:
   - changed-files:
       - any-glob-to-any-file:
@@ -160,14 +165,17 @@ instrumentation-pg:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/pg/**"
+          - ".docker/infra/postgres/**"
 instrumentation-que:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/que/**"
+          - ".docker/infra/postgres/**"
 instrumentation-racecar:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/racecar/**"
+          - ".docker/infra/kafka/**"
 instrumentation-rack:
   - changed-files:
       - any-glob-to-any-file:
@@ -180,14 +188,17 @@ instrumentation-rdkafka:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/rdkafka/**"
+          - ".docker/infra/kafka/**"
 instrumentation-redis:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/redis/**"
+          - ".docker/infra/redis/**"
 instrumentation-resque:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/resque/**"
+          - ".docker/infra/redis/**"
 instrumentation-restclient:
   - changed-files:
       - any-glob-to-any-file:
@@ -200,10 +211,12 @@ instrumentation-ruby_kafka:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/ruby_kafka/**"
+          - ".docker/infra/kafka/**"
 instrumentation-sidekiq:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/sidekiq/**"
+          - ".docker/infra/redis/**"
 instrumentation-sinatra:
   - changed-files:
       - any-glob-to-any-file:
@@ -212,6 +225,7 @@ instrumentation-trilogy:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/trilogy/**"
+          - ".docker/infra/mysql/**"
 
 processor-baggage:
   - changed-files:

--- a/.github/workflows/ci-build-docker.yml
+++ b/.github/workflows/ci-build-docker.yml
@@ -1,0 +1,24 @@
+name: CI Docker compose build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths: &path_filters
+      - ".docker/**"
+      - "docker-compose.yml"
+      - ".github/workflows/ci-build-docker.yml"
+  pull_request:
+    branches:
+      - main
+    paths: *path_filters
+  merge_group:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Build Docker image
+      run: docker compose -f docker-compose.yml up -d

--- a/.github/workflows/ci-build-docker.yml
+++ b/.github/workflows/ci-build-docker.yml
@@ -19,6 +19,6 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Build Docker image
-      run: docker compose -f docker-compose.yml up -d
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build Docker image
+        run: docker compose -f docker-compose.yml up -d

--- a/.github/workflows/ci-build-docker.yml
+++ b/.github/workflows/ci-build-docker.yml
@@ -1,4 +1,4 @@
-name: CI Docker compose build
+name: Build / Docker
 
 on:
   workflow_dispatch:
@@ -18,6 +18,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    name: Combined Docker Compose
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Docker image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,12 @@
+include:
+  - ./.docker/infra/kafka/docker-compose.yml
+  - ./.docker/infra/memcached/docker-compose.yml
+  - ./.docker/infra/mongo/docker-compose.yml
+  - ./.docker/infra/mysql/docker-compose.yml
+  - ./.docker/infra/postgres/docker-compose.yml
+  - ./.docker/infra/rabbitmq/docker-compose.yml
+  - ./.docker/infra/redis/docker-compose.yml
+
 x-shared-config:
   base: &base
     command: /bin/bash
@@ -169,79 +178,6 @@ services:
     working_dir: /app/processor/baggage
     command: |
       bash -c "bundle install && rake"
-
-  mongo:
-    image: mongo:6.0.27@sha256:03cda579c8caad6573cb98c2b3d5ff5ead452a6450561129b89595b4b9c18de2
-    expose:
-      - "27017"
-    ports:
-      - "27017:27017"
-
-  mysql:
-    image: mysql:8.0.31@sha256:3d7ae561cf6095f6aca8eb7830e1d14734227b1fb4748092f2be2cfbccf7d614
-    command: mysqld --default-authentication-plugin=mysql_native_password
-    environment:
-      - MYSQL_DATABASE=mysql
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_PASSWORD=mysql
-      - MYSQL_USER=mysql
-    expose:
-      - "3306"
-    ports:
-      - "3306:3306"
-
-  postgres:
-    image: postgres:14.22@sha256:705a5d5b5836f3fcba0d02c4d281e6a7dd9ed2dd4078640f08a1e1e9896e097d
-    environment:
-      - POSTGRES_PASSWORD=postgres
-    expose:
-      - "5432"
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_socket:/var/run/postgresql
-
-  redis:
-    image: redis:8.6.2@sha256:009cc37796fbdbe1b631b4cc0582bed167e5e403ed8bcd06f77eb6cb5aeb6f93
-    command: ["redis-server", "--requirepass", "passw0rd"]
-    volumes:
-      - redis_data:/data
-    ports:
-      - "16379:6379"
-
-  rabbitmq:
-    image: rabbitmq:4.2.5-alpine@sha256:53e51f8469ef13d0a1a2b03c0d36dcf4efbf13089f552440ec5620ca07f2c64e
-    ports:
-      - "5672:5672"
-
-  memcached:
-    image: memcached:1.6.40-alpine@sha256:8a82a3927694e42bc52679dc81532244de51e5faed5f9541a1283e3ad7271db1
-    command: memcached -m 64
-    ports:
-      - "11211:11211"
-
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.6@sha256:d3294ad2b353ac5a155ad9abe37884f75c482f387af553679210303b7118a0d3
-    ports:
-      - 2181:2181
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  kafka:
-    image: confluentinc/cp-kafka:7.9.6@sha256:9e178783dba8cf44cd8b1d260f548a587a21235921957edd4ed7aa7d060b0852
-    ports:
-      - "9092:9092"
-      - "29092:29092"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://kafka:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-    depends_on:
-      - zookeeper
 
   jaeger:
     image: jaegertracing/jaeger:2.16.0@sha256:bf7f805da4c2bc8d58a6c81ee650fdb6b8e4287698f95fbe231c09c865bc397f

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -309,6 +309,8 @@ instrumentation_kafka:
         - ubuntu-latest
 ```
 
+The final step is adding the path to the docker-compose.yml snippet to the path list for your instrumentation in `.github/labeler.yml` which is necessary for the build system.
+
 #### Adding a New Service
 
 Assuming your external service is not supported, you may consider adding it as a new job in the `/.github/workflows/ci-service-instrumentation.yml` file, however we will accept new services on a case-by-case basis.


### PR DESCRIPTION
This splits the docker compose into infrastructure files which gives us the advantage that PR's can now be labelled based on the services which are being updated due to the dedicated files.

Having these labels on the pr's is a necessary step to reduce redundant ci cycles as once we have confirmed pr's are being correctly labeled we can use the labels to control which gems are tested. 

Note I have compared the docker compose output and it is no different.