### PR TITLE
chore: Remove otel gems from top level  gem

### DIFF
--- a/.github/workflows/ci-contrib.yml
+++ b/.github/workflows/ci-contrib.yml
@@ -13,9 +13,7 @@ on:
       - "sampler/**"
       - ".github/workflows/ci-contrib.yml"
       - ".github/actions/**"
-      - "Gemfile"
       - "Rakefile"
-      - ".rubocop.yml"
       - "gemspecs/**"
   pull_request:
     branches:

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -45,9 +45,7 @@ on:
       - "instrumentation/sinatra/**"
       - ".github/workflows/ci-instrumentation-full.yml"
       - ".github/actions/**"
-      - "Gemfile"
       - "Rakefile"
-      - ".rubocop.yml"
       - "gemspecs/**"
   pull_request:
     branches:

--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -23,9 +23,7 @@ on:
       - "instrumentation/trilogy/**"
       - ".github/workflows/ci-instrumentation-with-services.yml"
       - ".github/actions/**"
-      - "Gemfile"
       - "Rakefile"
-      - ".rubocop.yml"
       - "gemspecs/**"
   pull_request:
     branches:

--- a/Gemfile
+++ b/Gemfile
@@ -6,16 +6,6 @@
 
 source 'https://rubygems.org'
 
-# Due to a bug in Dependabot Core, we cannot update instrumentation gems because
-# they reference each other using local paths in their Gemfiles.
-#
-# This list of gems will be tracked and updated by Dependabot and we can then update them manually
-# bin/update-dependencies <gem-name> <new-version>
-gem 'opentelemetry-api', '~> 1.7'
-gem 'opentelemetry-common', '~> 0.21'
-gem 'opentelemetry-registry', '~> 0.1'
-gem 'opentelemetry-sdk', '~> 1.1'
-
 gem 'rake', '>= 13'
 gem 'rubocop', '~> 1.86.0'
 gem 'rubocop-performance', '~> 1.26.0'


### PR DESCRIPTION
It is not necessary to explicitly list the otel gems in the top level gem as renovate will update all occurances hence custom script doesn't need to be used.

This also decreases the packages needing to be installed as a part of the rubocop CI check.

Further this reduces the number of checks needing to be run for rubocop updates as due to source code not changing the test suite doesn't need to be run.