### PR TITLE
ci: only build when gem changes

### DIFF
--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+    paths: &path_filters
+      - "instrumentation/all/**"
+      - ".github/workflows/ci-instrumentation.yml"
+      - ".github/actions/**"
+      - "gemspecs/**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - main
+    paths: *path_filters
   merge_group:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - main
     paths: &path_filters
-      - "instrumentation/all/**"
+      - "helpers/**"
+      - "instrumentation/**"
       - ".github/workflows/ci-instrumentation.yml"
       - ".github/actions/**"
       - "gemspecs/**"


### PR DESCRIPTION
This ensures that the all instrumentation gem is only built when it changes as opposed to always.