### PR TITLE
test: update gruf appraisals

### DIFF
--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -20,10 +20,12 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
   end
 end
 
-# Gruf requires a max Ruby version of 3.4
-# https://github.com/bigcommerce/gruf/blob/541dd40372d4c01b45612d8019bac9c69fb9be88/gruf.gemspec#L39C45-L39C48
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
-  appraise 'gruf-latest' do
-    gem 'gruf'
+  appraise 'gruf-2.21' do
+    gem 'gruf', '~> 2.21.0'
   end
+end
+
+appraise 'gruf-latest' do
+  gem 'gruf'
 end

--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -20,6 +20,8 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
   end
 end
 
-appraise 'gruf-latest' do
-  gem 'gruf'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('5')
+  appraise 'gruf-latest' do
+    gem 'gruf'
+  end
 end

--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -8,13 +8,13 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
   appraise 'gruf-2.19' do
     gem 'gruf', '~> 2.19.0'
   end
-end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
   appraise 'gruf-2.20' do
     gem 'gruf', '~> 2.20.0'
   end
+end
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
   appraise 'gruf-2.21' do
     gem 'gruf', '~> 2.21.0'
   end

--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -4,16 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.3')
-  appraise 'gruf-2.17' do
-    gem 'gruf', '~> 2.17.0'
-  end
-
-  appraise 'gruf-2.18' do
-    gem 'gruf', '~> 2.18.0'
-  end
-end
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
   appraise 'gruf-2.19' do
     gem 'gruf', '~> 2.19.0'
@@ -21,6 +11,10 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
+  appraise 'gruf-2.20' do
+    gem 'gruf', '~> 2.20.0'
+  end
+
   appraise 'gruf-2.21' do
     gem 'gruf', '~> 2.21.0'
   end


### PR DESCRIPTION
This removes appraisals for ruby 3.2 and adds a latest appraisal to support ruby 4.

Unblocks #2136