### PR TITLE
chore: Remove version_constant from net_ldap instrumentation

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -163,7 +163,6 @@ gems:
   - name: opentelemetry-instrumentation-net_ldap
     directory: instrumentation/net_ldap
     version_rb_path: lib/opentelemetry/instrumentation/net/ldap/version.rb
-    version_constant: [OpenTelemetry, Instrumentation, Net, LDAP, VERSION]
 
   - name: opentelemetry-instrumentation-pg
     directory: instrumentation/pg


### PR DESCRIPTION
This replicates the changes from https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1997 with net_ldap being missed due to not being available yet but already in review.