### PR TITLE
fix: deprecation of sql obfuscation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,10 +6,10 @@ ci:
 deprecated:
   - changed-files:
       - any-glob-to-any-file:
-          - "helpers/sql-obfuscation/**",
-          - "instrumentation/dalli/**",
-          - "instrumentation/mongo/**",
-          - "instrumentation/restclient/**",
+          - "helpers/sql-obfuscation/**"
+          - "instrumentation/dalli/**"
+          - "instrumentation/mongo/**"
+          - "instrumentation/restclient/**"
           - "instrumentation/ruby_kafka/**"
 
 helpers-mysql:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,11 +6,11 @@ ci:
 deprecated:
   - changed-files:
       - any-glob-to-any-file:
-         - "helpers/sql-obfuscation/**"
-         - "instrumentation/dalli/**",
-         - "instrumentation/mongo/**",
-         - "instrumentation/restclient/**",
-         - "instrumentation/ruby_kafka/**",
+          - "helpers/sql-obfuscation/**"
+          - "instrumentation/dalli/**",
+          - "instrumentation/mongo/**",
+          - "instrumentation/restclient/**",
+          - "instrumentation/ruby_kafka/**"
 
 helpers-mysql:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ ci:
 deprecated:
   - changed-files:
       - any-glob-to-any-file:
-          - "helpers/sql-obfuscation/**"
+          - "helpers/sql-obfuscation/**",
           - "instrumentation/dalli/**",
           - "instrumentation/mongo/**",
           - "instrumentation/restclient/**",

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,15 @@ ci:
       - any-glob-to-any-file:
           - ".github/**"
 
+deprecated:
+  - changed-files:
+      - any-glob-to-any-file:
+         - "helpers/sql-obfuscation/**"
+         - "instrumentation/dalli/**",
+         - "instrumentation/mongo/**",
+         - "instrumentation/restclient/**",
+         - "instrumentation/ruby_kafka/**",
+
 helpers-mysql:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -163,6 +163,7 @@
   ignorePaths: [
     "**/example/Gemfile",
     "releases/Gemfile",
+    "helpers/sql-obfuscation/**",
     "instrumentation/dalli/**",
     "instrumentation/mongo/**",
     "instrumentation/restclient/**",

--- a/helpers/sql-obfuscation/README.md
+++ b/helpers/sql-obfuscation/README.md
@@ -1,14 +1,15 @@
-# Deprecation Notice
-
-**This gem (`opentelemetry-helpers-sql-obfuscation`) is deprecated and no longer maintained.**
-
-It has been replaced by **`opentelemetry-helpers-sql-processor`**.
-
-All future development, bug fixes, and feature releases will occur in the new gem.
-
-## OpenTelemetry Instrumentation Helpers: SQL Obfuscation
+# OpenTelemetry Instrumentation Helpers: SQL Obfuscation
 
 This Ruby gem contains logic to obfuscate SQL. It's intended for use by gem authors instrumenting SQL adapter libraries, such as mysql2, pg, and trilogy.
+
+> [!IMPORTANT]
+>
+> **Deprecation Notice:**
+> This gem `opentelemetry-helpers-sql-obfuscation` is deprecated and no longer maintained.
+>
+> It has been replaced by `opentelemetry-helpers-sql-processor`.
+>
+> All future development, bug fixes, and feature releases will occur in the new gem.
 
 The logic is largely drawn from the [New Relic Ruby agent's SQL Obfuscation Helpers module][new-relic-obfuscation-helpers].
 

--- a/helpers/sql-obfuscation/opentelemetry-helpers-sql-obfuscation.gemspec
+++ b/helpers/sql-obfuscation/opentelemetry-helpers-sql-obfuscation.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.3'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
 


### PR DESCRIPTION
This excludes sql obfuscation from renovate updates and rolls back the ruby 3.3 update.

To help avoid issue again, changes to deprecated will be labelled accordingly.