### PR TITLE
chore: cleanup gemfiles

### DIFF
--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -21,6 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -21,7 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/helpers/sql-processor/Gemfile
+++ b/helpers/sql-processor/Gemfile
@@ -21,6 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/helpers/sql-processor/Gemfile
+++ b/helpers/sql-processor/Gemfile
@@ -21,7 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/helpers/sql/Gemfile
+++ b/helpers/sql/Gemfile
@@ -20,7 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/helpers/sql/Gemfile
+++ b/helpers/sql/Gemfile
@@ -20,6 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -20,8 +20,7 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 
   Dir.entries('../../helpers')

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -20,7 +20,7 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 
   Dir.entries('../../helpers')

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -19,7 +19,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -19,6 +19,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -21,6 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -21,7 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -21,6 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -21,7 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -22,6 +22,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -22,7 +22,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -22,6 +22,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -22,7 +22,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/factory_bot/Gemfile
+++ b/instrumentation/factory_bot/Gemfile
@@ -22,9 +22,8 @@ group :test do
   gem 'yard', '~> 0.9'
   if RUBY_VERSION >= '3.4'
     gem 'base64' # Required for activesupport < 7.1 on Ruby 3.4+
-    gem 'logger' # Required for Ruby 3.4+
-    gem 'mutex_m' # Required for activesupport < 7.1 on Ruby 3.4+
     gem 'logger'
+    gem 'mutex_m' # Required for activesupport < 7.1 on Ruby 3.4+
     gem 'observer' # Required for factory_bot 4.x on Ruby 3.4+
   end
 end

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -25,7 +25,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -25,6 +25,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -26,6 +26,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -26,7 +26,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -24,6 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -24,7 +24,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -26,7 +26,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -26,6 +26,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -26,7 +26,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -26,6 +26,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -23,6 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -23,7 +23,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -21,6 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -21,7 +21,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -25,7 +25,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -25,6 +25,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -23,7 +23,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -23,6 +23,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -28,6 +28,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -28,7 +28,6 @@ group :test do
     gem 'base64'
     gem 'bigdecimal'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/processor/baggage/Gemfile
+++ b/processor/baggage/Gemfile
@@ -16,6 +16,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/processor/baggage/Gemfile
+++ b/processor/baggage/Gemfile
@@ -16,7 +16,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/propagator/google_cloud_trace_context/Gemfile
+++ b/propagator/google_cloud_trace_context/Gemfile
@@ -14,6 +14,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/propagator/google_cloud_trace_context/Gemfile
+++ b/propagator/google_cloud_trace_context/Gemfile
@@ -14,7 +14,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -15,6 +15,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -15,7 +15,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -15,6 +15,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -15,7 +15,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -18,6 +18,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -18,7 +18,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/resources/aws/Gemfile
+++ b/resources/aws/Gemfile
@@ -20,7 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/resources/aws/Gemfile
+++ b/resources/aws/Gemfile
@@ -20,6 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -20,7 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -20,6 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -20,7 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -20,6 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end

--- a/sampler/xray/Gemfile
+++ b/sampler/xray/Gemfile
@@ -20,7 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
-    gem 'logger'
+    gem 'mutex_m'
   end
 end

--- a/sampler/xray/Gemfile
+++ b/sampler/xray/Gemfile
@@ -20,6 +20,6 @@ group :test do
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'
-    gem 'mutex_m'
+    gem 'mutex_m'
   end
 end


### PR DESCRIPTION
This removes the duplicate references to the logger gem in the gemfiles which are currently generating warnings.