### PR TITLE
ci: skip anthropic instrumentation on JRuby CI

### DIFF
--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -158,6 +158,7 @@ jobs:
           [[ "${{ matrix.gem }}" == "rails"                    ]] && echo "skip=true" >> $GITHUB_OUTPUT
           [[ "${{ matrix.gem }}" == "grpc"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
           [[ "${{ matrix.gem }}" == "gruf"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "anthropic"                 ]] && echo "skip=true" >> $GITHUB_OUTPUT
           [[ "${{ matrix.gem }}" == "net_ldap"                 ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true


### PR DESCRIPTION
## Summary

Add `anthropic` to the JRuby skip list in CI, fixing nightly build failures.

## Motivation

The upstream `anthropic` gem (v1.31.0) has a JRuby load-order bug where `Anthropic::Beta` is not yet defined when `BetaManagedAgentsFileResourceParams` references it at require time, causing `NameError: uninitialized constant Anthropic::Beta`.

This is the same pattern used for 19 other JRuby-incompatible instrumentations.

## Testing

CI-only change — no instrumentation code modified.

## Rollout / Risks

None. Can be reverted if the upstream gem adds JRuby support.

Closes #2187