### PR TITLE
chore: Update Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,7 @@
       matchDepNames: ["ruby"],
       matchFileNames: [
         ".github/workflows/ci-markdown-checks.yml",
+        ".github/workflows/ci-checks-local.yml"
         "**/*.gemspec",
       ],
       matchUpdateTypes: ["minor", "major"],
@@ -154,8 +155,6 @@
     "bigdecimal",
     "drb",
     "logger",
-    "memcached",
-    "mongo",
     "mutex_m",
     "observer",
     "ostruct",
@@ -163,6 +162,8 @@
   ignorePaths: [
     "**/example/Gemfile",
     "releases/Gemfile",
+    ".docker/infra/memcached/**",
+    ".docker/infra/mongo/**",
     "instrumentation/dalli/**",
     "instrumentation/mongo/**",
     "instrumentation/restclient/**",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,7 +37,7 @@
       matchDepNames: ["ruby"],
       matchFileNames: [
         ".github/workflows/ci-markdown-checks.yml",
-        ".github/workflows/ci-checks-local.yml"
+        ".github/workflows/ci-checks-local.yml",
         "**/*.gemspec",
       ],
       matchUpdateTypes: ["minor", "major"],


### PR DESCRIPTION
Added paths to ignore for memcached and mongo in Renovate configuration rather than dependency.

Ensure local cli tests use min version.