### PR TITLE
ci: Remove auto replace strings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -110,7 +110,6 @@
       versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
       extractVersionTemplate: "^(?<version>[0-9.]+)-alpine{{alpineVersion}}$",
-      autoReplaceStringTemplate: "FROM {{packageName}}:{{newVersion}}-alpine{{alpineVersion}}@{{newDigest}} ",
     },
     {
       customType: "regex",
@@ -128,7 +127,6 @@
       currentValueTemplate: "{{alpineVersion}}",
       extractVersionTemplate: "^{{depVersion}}-alpine(?<version>[0-9.]+)$",
       depNameTemplate: "{{packageName}}-alpine",
-      autoReplaceStringTemplate: "FROM {{packageName}}:{{depVersion}}-alpine{{newVersion}}@{{newDigest}} ",
     },
     {
       customType: "regex",
@@ -143,7 +141,6 @@
       datasourceTemplate: "docker",
       versioningTemplate: "docker",
       currentValueTemplate: "{{depVersion}}",
-      autoReplaceStringTemplate: "entrypoint sh {{packageName}}:{{newVersion}}@{{newDigest}} -c",
     },
     {
       customType: "regex",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -453,7 +453,7 @@ If you are wanting to test the creation of PR's to ensure that the custom manage
 LOG_LEVEL=debug renovate --platform=github --token="{{token}}" --package-rules='[]' --pr-hourly-limit 0 {{githubUsername}}/opentelemetry-ruby-contrib  > test.log
 ```
 
->! [TIP]
+> [!TIP]
 >
 > The token can also be set as an environment variable to passing it via the cli arguments.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,6 +447,16 @@ LOG_LEVEL=debug npx renovate --platform=local > test.log
 This will produce a detailed log which will include a json object describing all the matched dependencies
 and of more interest what updates are available for each of the dependencies.
 
+If you are wanting to test the creation of PR's to ensure that the custom managers are updating correctly. The below command can be used
+
+```sh
+LOG_LEVEL=debug renovate --platform=github --token="{{token}}" --package-rules='[]' --pr-hourly-limit 0 {{githubUsername}}/opentelemetry-ruby-contrib  > test.log
+```
+
+>! [TIP]
+>
+> The token can also be set as an environment variable to passing it via the cli arguments.
+
 ## Updating Ruby version requirements
 
 To update the minimum Ruby version requirement across all gems in the repository, use the `bin/update-ruby-version` script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -455,7 +455,7 @@ LOG_LEVEL=debug renovate --platform=github --token="{{token}}" --package-rules='
 
 > [!TIP]
 >
-> The token can also be set as an environment variable to passing it via the cli arguments.
+> The token can also be set as an environment variable to avoid passing it via the cli arguments.
 
 ## Updating Ruby version requirements
 


### PR DESCRIPTION
This removes the renovate AutoReplaceStrings which are not actually necessary based on testing in my fork and in fact they are causing issues.