### PR TITLE
chore: Remove grpc mock

### DIFF
--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -18,7 +18,6 @@ group :test do
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'
   gem 'yard', '~> 0.9'
-  gem 'grpc_mock', '~> 0.4.6'
   gem 'opentelemetry-test-helpers', '~> 0.7.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'


### PR DESCRIPTION
This removes the grpc-mock dependency from gruf due to being abandoned as per #1803 with the last release occurring 2022-07-24