### PR TITLE
chore: remove unused `yard-doctest`

### DIFF
--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -17,7 +17,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'yard-doctest', '~> 0.1.6'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/helpers/sql-obfuscation/Gemfile
+++ b/helpers/sql-obfuscation/Gemfile
@@ -16,7 +16,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'yard-doctest', '~> 0.1.6'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/helpers/sql-processor/Gemfile
+++ b/helpers/sql-processor/Gemfile
@@ -17,7 +17,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'
-  gem 'yard-doctest', '~> 0.1.6'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'


### PR DESCRIPTION
This removes the unused deprected yard-doctest dependency from the offending gemfiles as shown in https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1803 with the last release being 2019-09-12.