### PR TITLE
ci: Add additional linters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
-plugins: rubocop-performance
+plugins:
+  - rubocop-minitest
+  - rubocop-rspec
+  - rubocop-rake
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 3.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,13 +77,7 @@ Layout/LineLength:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
-# we want to remove the below
-Minitest/AssertPredicate:
-  Enabled: false
-Minitest/AssertTruthy:
-  Enabled: false
-Minitest/RefuteFalse:
-  Enabled: false
+# we need to reviee the below
 Minitest/LiteralAsActualArgument:
   Enabled: false
 Minitest/EmptyLineBeforeAssertionMethods:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Layout/LineLength:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
-# we need to reviee the below
+# we need to review the below
 Minitest/LiteralAsActualArgument:
   Enabled: false
 Minitest/EmptyLineBeforeAssertionMethods:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,9 @@ Layout/LineLength:
   Max: 250
 Layout/EndOfLine:
   EnforcedStyle: lf
+
+# we want to remove the below
+Minitest/LiteralAsActualArgument:
+  Enabled: false
+Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,7 +78,15 @@ Layout/EndOfLine:
   EnforcedStyle: lf
 
 # we want to remove the below
+Minitest/AssertPredicate:
+  Enabled: false
+Minitest/AssertTruthy:
+  Enabled: false
+Minitest/RefuteFalse:
+  Enabled: false
 Minitest/LiteralAsActualArgument:
   Enabled: false
 Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: false
+Rake/DuplicateTask:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '>= 13'
 gem 'rubocop', '~> 1.86.0'
+gem 'rubocop-minitest', '~> 0.38.0'
 gem 'rubocop-performance', '~> 1.26.0'
+gem 'rubocop-rake', '~> 0.7.1'
+gem 'rubocop-rspec', '~> 3.5'

--- a/instrumentation/aws_sdk/.rubocop.yml
+++ b/instrumentation/aws_sdk/.rubocop.yml
@@ -1,1 +1,6 @@
 inherit_from: ../../.rubocop.yml
+
+Minitest/GlobalExpectations:
+  Enabled: true
+  Exclude:
+    - instrumentation/aws_sdk/test/test_helper.rb

--- a/instrumentation/aws_sdk/.rubocop.yml
+++ b/instrumentation/aws_sdk/.rubocop.yml
@@ -3,4 +3,4 @@ inherit_from: ../../.rubocop.yml
 Minitest/GlobalExpectations:
   Enabled: true
   Exclude:
-    - instrumentation/aws_sdk/test/test_helper.rb
+    - test/test_helper.rb

--- a/instrumentation/httpx/.rubocop.yml
+++ b/instrumentation/httpx/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: ../../.rubocop.yml
 
-Minitest/AssertRaisesCompoundBody:
+Minitest/AssertKindOf:
   Enabled: false

--- a/instrumentation/httpx/.rubocop.yml
+++ b/instrumentation/httpx/.rubocop.yml
@@ -1,4 +1,1 @@
 inherit_from: ../../.rubocop.yml
-
-Minitest/AssertKindOf:
-  Enabled: false

--- a/instrumentation/httpx/test/instrumentation/dup/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/dup/plugin_test.rb
@@ -106,8 +106,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Dup::Plugin do
 
     it 'after request timeout' do
       response = HTTPX.get('http://example.com/timeout')
-      assert response.is_a?(HTTPX::ErrorResponse)
-      assert response.error.is_a?(HTTPX::TimeoutError)
+      assert_kind_of(HTTPX::ErrorResponse, response)
+      assert_kind_of(HTTPX::TimeoutError, response.error)
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'GET'

--- a/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
@@ -93,8 +93,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Old::Plugin do
 
     it 'after request timeout' do
       response = HTTPX.get('http://example.com/timeout')
-      assert response.is_a?(HTTPX::ErrorResponse)
-      assert response.error.is_a?(HTTPX::TimeoutError)
+      assert_kind_of(HTTPX::ErrorResponse, response)
+      assert_kind_of(HTTPX::TimeoutError, response.error)
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'

--- a/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
@@ -90,8 +90,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Stable::Plugin do
 
     it 'after request timeout' do
       response = HTTPX.get('http://example.com/timeout')
-      assert response.is_a?(HTTPX::ErrorResponse)
-      assert response.error.is_a?(HTTPX::TimeoutError)
+      assert_kind_of(HTTPX::ErrorResponse, response)
+      assert_kind_of(HTTPX::TimeoutError, response.error)
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'GET'

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
@@ -29,7 +29,7 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
 
       assert_includes(LOG_STREAM.string, body)
       assert_includes(BROADCASTED_STREAM.string, body)
-      assert_equal true, return_value
+      assert return_value
     end
 
     it 'emits only one OpenTelemetry log record' do
@@ -51,7 +51,7 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
 
       assert_includes(LOG_STREAM.string, body)
       assert_includes(BROADCASTED_STREAM.string, body)
-      assert_equal true, return_value
+      assert return_value
     end
 
     it 'emits only one OpenTelemetry log record' do
@@ -75,7 +75,7 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
 
         assert_includes(LOG_STREAM.string, body)
         assert_includes(BROADCASTED_STREAM.string, body)
-        assert_equal true, return_value
+        assert return_value
       end
 
       it 'emits only one OpenTelemetry log record' do

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -163,7 +163,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
-      refute(span.events.first.attributes['exception.message'].nil?)
+      refute_nil(span.events.first.attributes['exception.message'])
       refute(span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
@@ -198,7 +198,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
-      refute(span.events.first.attributes['exception.message'].nil?)
+      refute_nil(span.events.first.attributes['exception.message'])
       refute(span.events.first.attributes['exception.stacktrace'].nil?)
     end
 

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -164,7 +164,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
       refute_nil(span.events.first.attributes['exception.message'])
-      refute(span.events.first.attributes['exception.stacktrace'].nil?)
+      refute_nil(span.events.first.attributes['exception.stacktrace'])
     end
 
     it 'extracts statement type that begins the query' do
@@ -199,7 +199,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
       refute_nil(span.events.first.attributes['exception.message'])
-      refute(span.events.first.attributes['exception.stacktrace'].nil?)
+      refute_nil(span.events.first.attributes['exception.stacktrace'])
     end
 
     describe 'when db_statement set as obfuscate' do

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -163,8 +163,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
-      assert(!span.events.first.attributes['exception.message'].nil?)
-      assert(!span.events.first.attributes['exception.stacktrace'].nil?)
+      refute(span.events.first.attributes['exception.message'].nil?)
+      refute(span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
     it 'extracts statement type that begins the query' do
@@ -198,8 +198,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
-      assert(!span.events.first.attributes['exception.message'].nil?)
-      assert(!span.events.first.attributes['exception.stacktrace'].nil?)
+      refute(span.events.first.attributes['exception.message'].nil?)
+      refute(span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
     describe 'when db_statement set as obfuscate' do

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -319,7 +319,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::UndefinedColumn'
       refute_nil(last_span.events.first.attributes['exception.message'])
-      refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
+      refute_nil(last_span.events.first.attributes['exception.stacktrace'])
     end
 
     it 'extracts statement type that begins the query' do
@@ -356,7 +356,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::SyntaxError'
       refute_nil(last_span.events.first.attributes['exception.message'])
-      refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
+      refute_nil(last_span.events.first.attributes['exception.stacktrace'])
     end
 
     it 'extracts table name' do

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -318,7 +318,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       )
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::UndefinedColumn'
-      refute(last_span.events.first.attributes['exception.message'].nil?)
+      refute_nil(last_span.events.first.attributes['exception.message'])
       refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
@@ -355,7 +355,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       )
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::SyntaxError'
-      refute(last_span.events.first.attributes['exception.message'].nil?)
+      refute_nil(last_span.events.first.attributes['exception.message'])
       refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
     end
 

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -318,8 +318,8 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       )
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::UndefinedColumn'
-      assert(!last_span.events.first.attributes['exception.message'].nil?)
-      assert(!last_span.events.first.attributes['exception.stacktrace'].nil?)
+      refute(last_span.events.first.attributes['exception.message'].nil?)
+      refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
     it 'extracts statement type that begins the query' do
@@ -355,8 +355,8 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       )
       _(last_span.events.first.name).must_equal 'exception'
       _(last_span.events.first.attributes['exception.type']).must_equal 'PG::SyntaxError'
-      assert(!last_span.events.first.attributes['exception.message'].nil?)
-      assert(!last_span.events.first.attributes['exception.stacktrace'].nil?)
+      refute(last_span.events.first.attributes['exception.message'].nil?)
+      refute(last_span.events.first.attributes['exception.stacktrace'].nil?)
     end
 
     it 'extracts table name' do

--- a/instrumentation/rails/Rakefile
+++ b/instrumentation/rails/Rakefile
@@ -24,6 +24,7 @@ namespace :test do
     t.test_files = FileList['test/railtie/**/*_test.rb']
   end
 
+  desc 'Start simplecov coverage'
   task :start_coverage do
     require 'simplecov'
   end

--- a/instrumentation/rdkafka/.rubocop.yml
+++ b/instrumentation/rdkafka/.rubocop.yml
@@ -9,3 +9,5 @@ Metrics/ParameterLists:
   Enabled: true
   Exclude:
     - lib/opentelemetry/instrumentation/rdkafka/patches/producer.rb
+Minitest/SkipEnsure:
+  Enabled: false

--- a/instrumentation/redis/Rakefile
+++ b/instrumentation/redis/Rakefile
@@ -11,6 +11,7 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
+desc 'Start Redis'
 task :start_redis do
   redis_exists = `which redis-server`.lines.any?
   @redis_pid = Process.spawn('redis-server test/redis.conf') if redis_exists

--- a/instrumentation/resque/Rakefile
+++ b/instrumentation/resque/Rakefile
@@ -11,6 +11,7 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
+desc 'Start Redis'
 task :start_redis do
   redis_exists = `which redis-server`.lines.any?
   @redis_pid = Process.spawn('redis-server test/redis.conf') if redis_exists

--- a/instrumentation/sidekiq/Rakefile
+++ b/instrumentation/sidekiq/Rakefile
@@ -11,6 +11,7 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
+desc 'Start Redis'
 task :start_redis do
   redis_exists = `which redis-server`.lines.any?
   @redis_pid = Process.spawn('redis-server test/redis.conf') if redis_exists

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -384,7 +384,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         arg_cache = {} # maintain handles to args
         allow(client).to receive(:query).and_wrap_original do |m, *args|
           arg_cache[:query_input] = args[0]
-          refute_predicate(args[0], :frozen?)
+          assert(args[0].frozen?)
           m.call(args[0])
         end
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -378,13 +378,13 @@ describe OpenTelemetry::Instrumentation::Trilogy do
 
       it 'does inject context on frozen strings' do
         sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
-        assert(sql.frozen?)
+        assert_predicate(sql, :frozen?)
         propagator = OpenTelemetry::Instrumentation::Trilogy::Instrumentation.instance.propagator
 
         arg_cache = {} # maintain handles to args
         allow(client).to receive(:query).and_wrap_original do |m, *args|
           arg_cache[:query_input] = args[0]
-          assert(args[0].frozen?)
+          assert_predicate(args[0], :frozen?)
           m.call(args[0])
         end
 
@@ -404,7 +404,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         assert_equal(arg_cache[:inject_input], "/*VT_SPAN_CONTEXT=#{encoded}*/#{sql}")
 
         # arg_cache[:inject_input] is now frozen
-        assert(arg_cache[:inject_input].frozen?)
+        assert_predicate(arg_cache[:inject_input], :frozen?)
       end
 
       it 'does inject context on unfrozen strings' do

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -384,13 +384,13 @@ describe OpenTelemetry::Instrumentation::Trilogy do
         arg_cache = {} # maintain handles to args
         allow(client).to receive(:query).and_wrap_original do |m, *args|
           arg_cache[:query_input] = args[0]
-          assert(args[0].frozen?)
+          refute_predicate(args[0], :frozen?)
           m.call(args[0])
         end
 
         allow(propagator).to receive(:inject).and_wrap_original do |m, *args|
           arg_cache[:inject_input] = args[0]
-          refute(args[0].frozen?)
+          refute_predicate(args[0], :frozen?)
           assert_match(sql, args[0])
           m.call(args[0], context: args[1][:context])
         end
@@ -410,7 +410,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
       it 'does inject context on unfrozen strings' do
         # inbound SQL is not frozen (string prefixed with +)
         sql = +'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
-        refute(sql.frozen?)
+        refute_predicate(sql, :frozen?)
 
         # dup sql for comparison purposes, since propagator  mutates it
         cached_sql = sql.dup
@@ -421,7 +421,7 @@ describe OpenTelemetry::Instrumentation::Trilogy do
 
         encoded = Base64.strict_encode64("{\"uber-trace-id\":\"#{span.hex_trace_id}:#{span.hex_span_id}:0:1\"}")
         assert_equal(sql, "/*VT_SPAN_CONTEXT=#{encoded}*/#{cached_sql}")
-        refute(sql.frozen?)
+        refute_predicate(sql, :frozen?)
       end
     end
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:lint:renovate": "renovate-config-validator",
     "check:lint:ruby": "rubocop --only Lint,Naming,Style",
     "check:source": "npm run check:source:ruby",
-    "check:source:ruby": "rubocop --only Bundler,Gemspec,Metrics,Migration,MiniTest,Performance,Rake,RSpec,Security",
+    "check:source:ruby": "rubocop --only Bundler,Gemspec,Metrics,Migration,Minitest,Performance,Rake,RSpec,Security",
     "check:spelling": "cspell -c .cspell.yml .",
     "write": "npm run write:lint && npm run write:format && npm run write:source:ruby",
     "write:format": "npm run write:format:ruby && prettier . --write",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:lint:renovate": "renovate-config-validator",
     "check:lint:ruby": "rubocop --only Lint,Naming,Style",
     "check:source": "npm run check:source:ruby",
-    "check:source:ruby": "rubocop --only Bundler,Gemspec,Metrics,Migration,Security",
+    "check:source:ruby": "rubocop --only Bundler,Gemspec,Metrics,Migration,MiniTest,Performance,Rake,RSpec,Security",
     "check:spelling": "cspell -c .cspell.yml .",
     "write": "npm run write:lint && npm run write:format && npm run write:source:ruby",
     "write:format": "npm run write:format:ruby && prettier . --write",

--- a/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
+++ b/processor/baggage/test/opentelemetry/processor/baggage/baggage_span_processor_test.rb
@@ -91,31 +91,25 @@ describe OpenTelemetry::Processor::Baggage::BaggageSpanProcessor do
     end
 
     it 'does not blow up when given nil context' do
-      processor.on_start(span, nil)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_start(span, nil) }
     end
     it 'does not blow up when given nil span' do
-      processor.on_start(nil, context_with_baggage)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_start(nil, context_with_baggage) }
     end
     it 'does not blow up when given nil span and context' do
-      processor.on_start(nil, nil)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_start(nil, nil) }
     end
     it 'does not blow up when given a context that is not a Context' do
-      processor.on_start(span, :not_a_context)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_start(span, :not_a_context) }
     end
     it 'does not blow up when given a span that is not a Span' do
-      processor.on_start(:not_a_span, context_with_baggage)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_start(:not_a_span, context_with_baggage) }
     end
   end
 
   describe 'satisfies the SpanProcessor duck type with no-op methods' do
     it 'implements #on_finish' do
-      processor.on_finish(span)
-      assert true # nothing above raised an exception
+      assert_silent { processor.on_finish(span) }
     end
 
     it 'implements #force_flush' do

--- a/sampler/xray/test/aws_xray_remote_sampler_test.rb
+++ b/sampler/xray/test/aws_xray_remote_sampler_test.rb
@@ -39,7 +39,7 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
     )
     sampler = OpenTelemetry::Sampler::XRay::InternalAWSXRayRemoteSampler.new(resource: resource)
 
-    refute sampler.instance_variable_get(:@rule_poller).nil?
+    refute_nil sampler.instance_variable_get(:@rule_poller)
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 300 * 1000)
     refute_nil sampler.instance_variable_get(:@sampling_client)
     refute_nil sampler.instance_variable_get(:@rule_cache)

--- a/sampler/xray/test/aws_xray_remote_sampler_test.rb
+++ b/sampler/xray/test/aws_xray_remote_sampler_test.rb
@@ -20,10 +20,10 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
 
     sampler = OpenTelemetry::Sampler::XRay::InternalAWSXRayRemoteSampler.new(resource: OpenTelemetry::SDK::Resources::Resource.create)
 
-    assert !sampler.instance_variable_get(:@rule_poller).nil?
+    refute sampler.instance_variable_get(:@rule_poller).nil?
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 300 * 1000)
-    assert !sampler.instance_variable_get(:@sampling_client).nil?
-    assert !sampler.instance_variable_get(:@rule_cache).nil?
+    refute sampler.instance_variable_get(:@sampling_client).nil?
+    refute sampler.instance_variable_get(:@rule_cache).nil?
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))
   end
 
@@ -39,10 +39,10 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
     )
     sampler = OpenTelemetry::Sampler::XRay::InternalAWSXRayRemoteSampler.new(resource: resource)
 
-    assert !sampler.instance_variable_get(:@rule_poller).nil?
+    refute sampler.instance_variable_get(:@rule_poller).nil?
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 300 * 1000)
-    assert !sampler.instance_variable_get(:@sampling_client).nil?
-    assert !sampler.instance_variable_get(:@rule_cache).nil?
+    refute sampler.instance_variable_get(:@sampling_client).nil?
+    refute sampler.instance_variable_get(:@rule_cache).nil?
     assert_equal(sampler.instance_variable_get(:@rule_cache).instance_variable_get(:@sampler_resource), resource)
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))
   end
@@ -63,10 +63,10 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
       polling_interval: 120
     )
 
-    assert !sampler.instance_variable_get(:@rule_poller).nil?
+    refute sampler.instance_variable_get(:@rule_poller).nil?
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 120 * 1000)
-    assert !sampler.instance_variable_get(:@sampling_client).nil?
-    assert !sampler.instance_variable_get(:@rule_cache).nil?
+    refute sampler.instance_variable_get(:@sampling_client).nil?
+    refute sampler.instance_variable_get(:@rule_cache).nil?
     assert_equal(sampler.instance_variable_get(:@rule_cache).instance_variable_get(:@sampler_resource), resource)
     assert_equal(sampler.instance_variable_get(:@aws_proxy_endpoint), 'abc.com')
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))

--- a/sampler/xray/test/aws_xray_remote_sampler_test.rb
+++ b/sampler/xray/test/aws_xray_remote_sampler_test.rb
@@ -65,7 +65,7 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
 
     refute_nil sampler.instance_variable_get(:@rule_poller)
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 120 * 1000)
-    refute sampler.instance_variable_get(:@sampling_client)
+    refute_nil sampler.instance_variable_get(:@sampling_client)
     refute_nil sampler.instance_variable_get(:@rule_cache)
     assert_equal(sampler.instance_variable_get(:@rule_cache).instance_variable_get(:@sampler_resource), resource)
     assert_equal(sampler.instance_variable_get(:@aws_proxy_endpoint), 'abc.com')

--- a/sampler/xray/test/aws_xray_remote_sampler_test.rb
+++ b/sampler/xray/test/aws_xray_remote_sampler_test.rb
@@ -20,10 +20,10 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
 
     sampler = OpenTelemetry::Sampler::XRay::InternalAWSXRayRemoteSampler.new(resource: OpenTelemetry::SDK::Resources::Resource.create)
 
-    refute sampler.instance_variable_get(:@rule_poller).nil?
+    refute_nil sampler.instance_variable_get(:@rule_poller).nil?
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 300 * 1000)
-    refute sampler.instance_variable_get(:@sampling_client).nil?
-    refute sampler.instance_variable_get(:@rule_cache).nil?
+    refute_nil sampler.instance_variable_get(:@sampling_client)
+    refute_nil sampler.instance_variable_get(:@rule_cache)
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))
   end
 
@@ -41,8 +41,8 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
 
     refute sampler.instance_variable_get(:@rule_poller).nil?
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 300 * 1000)
-    refute sampler.instance_variable_get(:@sampling_client).nil?
-    refute sampler.instance_variable_get(:@rule_cache).nil?
+    refute_nil sampler.instance_variable_get(:@sampling_client)
+    refute_nil sampler.instance_variable_get(:@rule_cache)
     assert_equal(sampler.instance_variable_get(:@rule_cache).instance_variable_get(:@sampler_resource), resource)
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))
   end
@@ -63,10 +63,10 @@ describe OpenTelemetry::Sampler::XRay::AWSXRayRemoteSampler do
       polling_interval: 120
     )
 
-    refute sampler.instance_variable_get(:@rule_poller).nil?
+    refute_nil sampler.instance_variable_get(:@rule_poller)
     assert_equal(sampler.instance_variable_get(:@rule_polling_interval_millis), 120 * 1000)
-    refute sampler.instance_variable_get(:@sampling_client).nil?
-    refute sampler.instance_variable_get(:@rule_cache).nil?
+    refute sampler.instance_variable_get(:@sampling_client)
+    refute_nil sampler.instance_variable_get(:@rule_cache)
     assert_equal(sampler.instance_variable_get(:@rule_cache).instance_variable_get(:@sampler_resource), resource)
     assert_equal(sampler.instance_variable_get(:@aws_proxy_endpoint), 'abc.com')
     assert_match(/[a-f0-9]{24}/, sampler.instance_variable_get(:@client_id))

--- a/sampler/xray/test/rule_cache_test.rb
+++ b/sampler/xray/test/rule_cache_test.rb
@@ -67,7 +67,7 @@ describe OpenTelemetry::Sampler::XRay::RuleCache do
       cache.update_rules([default_rule])
 
       Timecop.freeze(current_time + (2 * 60 * 60)) # Travel 2 hours into the future
-      assert cache.expired?
+      assert_predicate(cache, :expired?)
     end
   end
 

--- a/sampler/xray/test/sampling_rule_test.rb
+++ b/sampler/xray/test/sampling_rule_test.rb
@@ -72,8 +72,8 @@ describe OpenTelemetry::Sampler::XRay::SamplingRule do
       'Version' => 1
     )
 
-    assert_equal true, rule.equals?(rule_unordered_attributes)
-    assert_equal false, rule.equals?(rule_updated)
-    assert_equal false, rule.equals?(rule_updated_two)
+    assert rule.equals?(rule_unordered_attributes)
+    refute rule.equals?(rule_updated)
+    refute rule.equals?(rule_updated_two)
   end
 end


### PR DESCRIPTION
Closes #1392 

Adds in additional linters:
- rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)
- rubocop-rake (https://rubygems.org/gems/rubocop-rake)
- rubocop-rspec (https://rubygems.org/gems/rubocop-rspec)

When violations are occurring, exclusions have been added if large volume or if only few instances and easy change the violations have been corrected.