### PR TITLE
ci: Add linkspector config file

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -3,6 +3,11 @@ dirs:
   - .
 excludedFiles:
 excludedDirs:
+  - helpers/sql-obfuscation/
+  - instrumentation/dalli/
+  - instrumentation/mongo/
+  - instrumentation/restclient/
+  - instrumentation/ruby_kafka/
 ignorePatterns:
 useGitIgnore: true
 followRedirects: true

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,13 +1,11 @@
 # linkspector config file is described at https://github.com/UmbrellaDocs/linkspector/blob/main/README.md#configuration
 dirs:
   - .
-excludedFiles:
 excludedDirs:
   - helpers/sql-obfuscation/
   - instrumentation/dalli/
   - instrumentation/mongo/
   - instrumentation/restclient/
   - instrumentation/ruby_kafka/
-ignorePatterns:
 useGitIgnore: true
 followRedirects: true

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,8 @@
+# linkspector config file is described at https://github.com/UmbrellaDocs/linkspector/blob/main/README.md#configuration
+dirs:
+  - .
+excludedFiles:
+excludedDirs:
+ignorePatterns:
+useGitIgnore: true
+followRedirects: true


### PR DESCRIPTION
This adds a linkspector config file which we are to add to as part of the development freeze process to eliminate chance of outdated links on deprecated gems causing ci issues. This also removes this also ensures both cli & ci use same config.