### PR TITLE
ci: OpenSSF scorecard remedies

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,11 +5,13 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       issues: write # required for creating labels
       pull-requests: write # required for adding labels to pr
     steps:

--- a/.github/workflows/ci-build-docker.yml
+++ b/.github/workflows/ci-build-docker.yml
@@ -15,6 +15,9 @@ on:
     paths: *path_filters
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -2,12 +2,6 @@ name: File Checks
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - edited
-      - ready_for_review
   merge_group:
 
 permissions:
@@ -133,11 +127,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Extract PR title
-        id: pr
-        run: |
-          TITLE=${{ toJSON(github.event.pull_request.title) }}
-          echo "Title: $TITLE" > pr_title.md
       - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           config: .cspell.yml

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -136,7 +136,8 @@ jobs:
       - name: Extract PR title
         id: pr
         run: |
-          echo "${{ github.event.pull_request.title }}" > pr_title.md
+          TITLE=${{ toJSON(github.event.pull_request.title) }}
+          echo "Title: $TITLE" > pr_title.md
       - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           config: .cspell.yml

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # restrict checks to pull requests to avoid issues blocking the merge queue
-      - if: ${{ github.event_name == 'pull_request' }}
+      - name: Validate PR Title
+        if: ${{ github.event_name == 'pull_request' }}
         uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
         env:
           FORCE_COLOR: 3
@@ -34,12 +35,13 @@ jobs:
           include-commits: false
           update-labels: false
           config: ".commit-me.json"
-      - name: Extract PR title
+      - name: Extract PR Title
         id: pr
         run: |
           TITLE=${{ toJSON(github.event.pull_request.title) }}
           echo "Title: $TITLE" > pr_title.md
-      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
+      - name: Check PR Title spelling
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           config: .cspell.yml
           suggestions: true

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -23,6 +23,7 @@ jobs:
     name: Conventional Commits Validation
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # restrict checks to pull requests to avoid issues blocking the merge queue
       - if: ${{ github.event_name == 'pull_request' }}
         uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
@@ -33,3 +34,16 @@ jobs:
           include-commits: false
           update-labels: false
           config: ".commit-me.json"
+      - name: Extract PR title
+        id: pr
+        run: |
+          TITLE=${{ toJSON(github.event.pull_request.title) }}
+          echo "Title: $TITLE" > pr_title.md
+      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
+        with:
+          config: .cspell.yml
+          suggestions: true
+          treat_flagged_words_as_errors: true
+          incremental_files_only: false
+          files: |
+            pr_title.md


### PR DESCRIPTION
Address low scoring items in https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-ruby-contrib, introduced by recent changes.

The SAST would be addressed by #2202, 2 out of 3 branch permissions could be addressed without impact. Suggest turning off require branch to be up to date & enable last push approval.

Note the pr title step has been relocated to reduce un-necessary ci cycles in particular pr link checks