### PR TITLE
chore: Add Dockerfile to Renovate min sdk

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,7 @@
         ".github/workflows/ci-markdown-checks.yml",
         ".github/workflows/ci-checks-local.yml",
         "**/*.gemspec",
+        "Dockerfile",
       ],
       matchUpdateTypes: ["minor", "major"],
       dependencyDashboardApproval: true,


### PR DESCRIPTION
This restricts the dockerfile to follow the rules for min ruby sdk/runtime and not target latest.