### PR TITLE
fix: (actions) interpolate into env vars

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -37,8 +37,9 @@ jobs:
           config: ".commit-me.json"
       - name: Extract PR Title
         id: pr
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE=${{ toJSON(github.event.pull_request.title) }}
           echo "Title: $TITLE" > pr_title.md
       - name: Check PR Title spelling
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -39,9 +39,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RELEASE_REF: ${{ github.sha }}
+          RELEASE_FLAGS: ${{ github.event.inputs.flags }}
+          RELEASE_NAME: ${{ github.event.inputs.name }}
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
         run: |
           bundle exec toys release perform --yes --verbose \
-            "--release-ref=${{ github.sha }}" \
-            ${{ github.event.inputs.flags }} \
-            "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" \
+            "--release-ref=$RELEASE_REF" \
+            $RELEASE_FLAGS \
+            "$RELEASE_NAME" "$RELEASE_VERSION" \
             < /dev/null

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Open release pull request
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ github.ref }}
+          RELEASE_NAMES: ${{ github.event.inputs.names }}
         run: |
           bundle exec toys release request --yes --verbose \
-            "--target-branch=${{ github.ref }}" \
-            ${{ github.event.inputs.names }} \
+            "--target-branch=$TARGET_BRANCH" \
+            $RELEASE_NAMES \
             < /dev/null

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -38,8 +38,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RELEASE_FLAGS: ${{ github.event.inputs.flags }}
+          RELEASE_PR: ${{ github.event.inputs.release_pr }}
         run: |
           bundle exec toys release retry --yes --verbose \
-            ${{ github.event.inputs.flags }} \
-            "${{ github.event.inputs.release_pr }}" \
+            $RELEASE_FLAGS \
+            "$RELEASE_PR" \
             < /dev/null


### PR DESCRIPTION
Move ${{ ... }} interpolations from 'run:' scripts to env vars to avoid shell injection shenanigans. These workflows had low exposure before (one's read-only, the other only available to trusted users), but now the exposure is even lower.