### PR TITLE
fix: Set simplecov command name based on appraisal name

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -109,9 +109,9 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
-            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
-            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
-            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
             echo "::endgroup::"
           done
         else

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -109,9 +109,9 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
-            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
-            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
-            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
+            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
+            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
+            RUBYOPT="-rsimplecov" SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
             echo "::endgroup::"
           done
         else

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -158,6 +158,7 @@ runs:
     - name: Cleanup coverage artifacts
       shell: bash
       run: rm -rf coverage
+      working-directory: "${{ steps.setup.outputs.gem_dir }}"
 
     - name: Build Gem
       shell: bash

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -109,11 +109,9 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
-            export SIMPLECOV_COMMAND_NAME="appraisal_${i}"
-
-            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
-            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
-            BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
+            SIMPLECOV_COMMAND_NAME="appraisal_${i}" BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit
             echo "::endgroup::"
           done
         else

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -109,6 +109,8 @@ runs:
         if [[ -f "Appraisals" ]]; then
           for i in `bundle exec appraisal list | sed 's/-/_/g' `; do
             echo "::group::🔎 Appraising ${i}"
+            export SIMPLECOV_COMMAND_NAME="appraisal_${i}"
+
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle install --quiet --jobs=3 --retry=4 && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle show && \
             BUNDLE_GEMFILE=gemfiles/${i}.gemfile bundle exec rake test || exit

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -155,6 +155,10 @@ runs:
       run: 'bundle exec ruby -e ''require "simplecov"; SimpleCov.minimum_coverage(${{ inputs.minimum_coverage || 85 }}); SimpleCov.collate Dir["coverage/**/.resultset.json"];'''
       working-directory: "${{ steps.setup.outputs.gem_dir }}"
 
+    - name: Cleanup coverage artifacts
+      shell: bash
+      run: rm -rf coverage
+
     - name: Build Gem
       shell: bash
       if: "${{ inputs.build == 'true' }}"

--- a/.simplecov
+++ b/.simplecov
@@ -9,7 +9,7 @@ digest.update(ENV.fetch('BUNDLE_GEMFILE', 'gemfile')) if ENV['APPRAISAL_INITIALI
 ENV['ENABLE_COVERAGE'] ||= '1'
 
 if ENV['ENABLE_COVERAGE'].to_i.positive?
-  SimpleCov.command_name(digest.hexdigest)
+  SimpleCov.command_name(ENV['SIMPLECOV_COMMAND_NAME'] || digest.hexdigest)
   SimpleCov.start do
     add_filter %r{^/test/}
   end


### PR DESCRIPTION
This sets a name for the simplecov command via environment so that collate has a collection of reports to collate rather than the last one. This is necessary because otherwise each run gets the same guid.