### PR TITLE
ci: Use gem env variables to specify if Jruby is not supported

### DIFF
--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -153,7 +153,7 @@ jobs:
           build: true
           minimum_coverage: ${{ env.minimum_coverage }}
       - name: "Test JRuby"
-        if: "${{ startsWith(matrix.os, 'ubuntu') && !contains(env.unsupportedInterpreters, split(matrix.ruby, '-')[0]) }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') &&  !contains(env.unsupportedInterpreters, 'jruby') }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -154,7 +154,7 @@ jobs:
           build: true
           minimum_coverage: ${{ env.minimum_coverage }}
       - name: "Test JRuby"
-        if: "${{ startsWith(matrix.os, 'ubuntu') && !contains(env.unsupportedInterpreters, 'jruby') }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') && !contains(env.unsupported_interpreters, 'jruby') }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -69,6 +69,7 @@ jobs:
     steps:
       - run: echo "Repository check passed"
   instrumentation:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -153,7 +154,7 @@ jobs:
           build: true
           minimum_coverage: ${{ env.minimum_coverage }}
       - name: "Test JRuby"
-        if: "${{ startsWith(matrix.os, 'ubuntu') &&  !contains(env.unsupportedInterpreters, 'jruby') }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') && !contains(env.unsupportedInterpreters, 'jruby') }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -69,7 +69,6 @@ jobs:
     steps:
       - run: echo "Repository check passed"
   instrumentation:
-    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -153,35 +152,8 @@ jobs:
           yard: true
           build: true
           minimum_coverage: ${{ env.minimum_coverage }}
-      - name: "JRuby Filter"
-        id: jruby_skip
-        shell: bash
-        run: |
-          echo "skip=false" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "action_pack"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "action_view"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "active_model_serializers" ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "active_record"            ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "active_storage"           ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "active_support"           ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "aws_sdk"                  ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "aws_lambda"               ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "delayed_job"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "graphql"                  ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "http"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "http_client"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "koala"                    ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "lmdb"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "rack"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "rails"                    ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "grpc"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "gruf"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "anthropic"                 ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "net_ldap"                 ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-          true
       - name: "Test JRuby"
-        if: "${{ startsWith(matrix.os, 'ubuntu') && steps.jruby_skip.outputs.skip == 'false' }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"

--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -153,7 +153,7 @@ jobs:
           build: true
           minimum_coverage: ${{ env.minimum_coverage }}
       - name: "Test JRuby"
-        if: "${{ startsWith(matrix.os, 'ubuntu') }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') && !contains(env.unsupportedInterpreters, split(matrix.ruby, '-')[0]) }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "opentelemetry-instrumentation-${{ matrix.gem }}"

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -263,7 +263,7 @@ jobs:
 #### JRuby Compatibility
 
 If your gem is incompatible with `JRuby`, you can exclude it from the matrix by ensuring the gem folder contains a `.github-ci.yml` file which specifies the gem specific environment variables.
-The key for unsupported interupters is `unsupportedInterpreters` and tge value containing jruby,
+The key for unsupported interpreters is `unsupportedInterpreters` and tge value containing jruby,
 a complete example of the file is below.
 
 ```yaml

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -263,7 +263,7 @@ jobs:
 #### JRuby Compatibility
 
 If your gem is incompatible with `JRuby`, you can exclude it from the matrix by ensuring the gem folder contains a `.github-ci.yml` file which specifies the gem specific environment variables.
-The key for unsupported interpreters is `unsupportedInterpreters` and tge value containing jruby,
+The key for unsupported interpreters is `unsupportedInterpreters` and the value is to contain jruby,
 a complete example of the file is below.
 
 ```yaml

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -262,19 +262,13 @@ jobs:
 
 #### JRuby Compatibility
 
-If your gem is incompatible with `JRuby`, you can exclude it from the matrix by adding an entry to the `/.github/workflows/ci-instrumentation-full.yml` file under `jobs/instrumentation/steps/[name="JRuby Filter"]`:
+If your gem is incompatible with `JRuby`, you can exclude it from the matrix by ensuring the gem folder contains a `.github-ci.yml` file which specifies the gem specific environment variables.
+The key for unsupported interupters is `unsupportedInterpreters` and tge value containing jruby,
+a complete example of the file is below.
 
 ```yaml
-- name: "JRuby Filter"
-  id: jruby_skip
-  shell: bash
-  run: |
-    echo "skip=false" >> $GITHUB_OUTPUT
-    [[ "${{ matrix.gem }}" == "action_pack"              ]] && echo "skip=true" >> $GITHUB_OUTPUT
-    # ...
-    [[ "${{ matrix.gem }}" == "werewolf"                     ]] && echo "skip=true" >> $GITHUB_OUTPUT
-    # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
-    true
+env:
+  unsupportedInterpreters: jruby
 ```
 
 ### External service instrumentations

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -263,12 +263,12 @@ jobs:
 #### JRuby Compatibility
 
 If your gem is incompatible with `JRuby`, you can exclude it from the matrix by ensuring the gem folder contains a `.github-ci.yml` file which specifies the gem specific environment variables.
-The key for unsupported interpreters is `unsupportedInterpreters` and the value is to contain jruby,
+The key for unsupported interpreters is `unsupported_interpreters` and the value is to contain jruby,
 a complete example of the file is below.
 
 ```yaml
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby
 ```
 
 ### External service instrumentations

--- a/instrumentation/active_record/.github-ci.yml
+++ b/instrumentation/active_record/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/active_record/.github-ci.yml
+++ b/instrumentation/active_record/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/active_storage/.github-ci.yml
+++ b/instrumentation/active_storage/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/active_storage/.github-ci.yml
+++ b/instrumentation/active_storage/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/anthropic/.github-ci.yml
+++ b/instrumentation/anthropic/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/anthropic/.github-ci.yml
+++ b/instrumentation/anthropic/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/delayed_job/.github-ci.yml
+++ b/instrumentation/delayed_job/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/delayed_job/.github-ci.yml
+++ b/instrumentation/delayed_job/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/graphql/.github-ci.yml
+++ b/instrumentation/graphql/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/graphql/.github-ci.yml
+++ b/instrumentation/graphql/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/grpc/.github-ci.yml
+++ b/instrumentation/grpc/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/grpc/.github-ci.yml
+++ b/instrumentation/grpc/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/gruf/.github-ci.yml
+++ b/instrumentation/gruf/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/gruf/.github-ci.yml
+++ b/instrumentation/gruf/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/lmdb/.github-ci.yml
+++ b/instrumentation/lmdb/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/lmdb/.github-ci.yml
+++ b/instrumentation/lmdb/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby

--- a/instrumentation/net_ldap/.github-ci.yml
+++ b/instrumentation/net_ldap/.github-ci.yml
@@ -1,0 +1,2 @@
+env:
+  unsupportedInterpreters: jruby

--- a/instrumentation/net_ldap/.github-ci.yml
+++ b/instrumentation/net_ldap/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  unsupportedInterpreters: jruby
+  unsupported_interpreters: jruby


### PR DESCRIPTION
This moves the control of if jruby is not supported out of the Workflow file & into the gem environment variables file.

This ensure workflows are generic with any specifics for a. Gem defined via environment variables listed alongside the source code.

This improves readability and maintainable due to not needing to alter ci when adding/removing a gem. The appropriate code owners can be identified when adding/removing interpreters. Also helps with only building/testing what has changed.

Note this is resulting in more gems being tested on jruby as only those needing an exclusion were added rather than those which had needed it in the past.

Related pr's:
- #2203 
- #2282 
