### PR TITLE
feat!: Min Rails 7.1 (enforced this time)

### DIFF
--- a/instrumentation/action_mailer/lib/opentelemetry/instrumentation/action_mailer/instrumentation.rb
+++ b/instrumentation/action_mailer/lib/opentelemetry/instrumentation/action_mailer/instrumentation.rb
@@ -55,7 +55,7 @@ module OpenTelemetry
       #     })
       #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
         EMAIL_ATTRIBUTE = %w[email.to.address email.from.address email.cc.address email.bcc.address].freeze
 
         install do |_config|

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/instrumentation.rb
@@ -33,7 +33,7 @@ module OpenTelemetry
       #     })
       #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         install do |_config|
           require_railtie

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
@@ -44,7 +44,7 @@ module OpenTelemetry
       #     })
       #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
         install do |_config|
           require_dependencies
         end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
     module ActiveJob
       # The Instrumentation class contains logic to detect and install the ActiveJob instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         install do |_config|
           require_dependencies

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
     module ActiveRecord
       # The Instrumentation class contains logic to detect and install the ActiveRecord instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         install do |_config|
           require_dependencies

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/querying.rb
@@ -18,11 +18,9 @@ module OpenTelemetry
 
           # Contains ActiveRecord::Querying to be patched
           module ClassMethods
-            method_name = ::ActiveRecord.version >= Gem::Version.new('7.0.0') ? :_query_by_sql : :find_by_sql
-
-            define_method(method_name) do |*args, **kwargs, &block|
+            def _query_by_sql(...)
               tracer.in_span("#{self} query") do
-                super(*args, **kwargs, &block)
+                super
               end
             end
 

--- a/instrumentation/active_storage/lib/opentelemetry/instrumentation/active_storage/instrumentation.rb
+++ b/instrumentation/active_storage/lib/opentelemetry/instrumentation/active_storage/instrumentation.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
       #     })
       #   end
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7.0.0')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         install do |_config|
           resolve_key

--- a/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/instrumentation.rb
+++ b/instrumentation/active_support/lib/opentelemetry/instrumentation/active_support/instrumentation.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
     module ActiveSupport
       # The Instrumentation class contains logic to detect and install the ActiveSupport instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         install do |_config|
           require_dependencies

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
@@ -12,7 +12,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the Rails
       # instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        MINIMUM_VERSION = Gem::Version.new('7')
+        MINIMUM_VERSION = Gem::Version.new('7.1')
 
         # This gem requires the instrumentation gems for the different
         # components of Rails, as a result it does not have any explicit


### PR DESCRIPTION
[feat!: bump runtime MINIMUM_VERSION to Rails 7.1](https://github.com/open-telemetry/opentelemetry-ruby-contrib/commit/bb5116b1b8df503442a5d39b33833dae156d55ce) 

PR https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1701 dropped Rails 7.0 from the Appraisals test matrix and declared
Rails 7.1 as the new minimum, but did not update the MINIMUM_VERSION
constants used by each instrumentation's compatible { ... } check at
runtime. As a result, consumers on Rails 7.0 would still have these
instrumentations install successfully despite being on an unsupported
and untested Rails version.

Bump MINIMUM_VERSION to 7.1 across all Rails-family instrumentations
(rails, action_pack, action_view, action_mailer, active_job,
active_record, active_support, active_storage), mirroring the pattern
established in PR https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1231 (the 6.1 -> 7.0 drop). active_storage previously
used the '7.0.0' format; it is normalized to '7.1' for consistency
(Gem::Version treats '7.1' and '7.1.0' as equal).

---

[refactor(active_record): simplify querying patch](https://github.com/open-telemetry/opentelemetry-ruby-contrib/commit/7ba2a53b882ba1bd78662cdc11ef53e6d4e532aa) 

The querying patch chose between :_query_by_sql (Rails 7+) and
:find_by_sql (Rails 6.1) via a runtime Gem::Version comparison and
define_method. Since the minimum supported Rails version is now 7.1,
the :find_by_sql branch is unreachable and the dynamic dispatch is
unnecessary.

Replace define_method with a plain def, and use (...) forwarding to
match the convention used elsewhere in the repo.