### PR TITLE
test: remove simplecov overwrites

### DIFF
--- a/instrumentation/faraday/.github-ci.yml
+++ b/instrumentation/faraday/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  minimum_coverage: 65

--- a/instrumentation/http/.github-ci.yml
+++ b/instrumentation/http/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  minimum_coverage: 59

--- a/instrumentation/http_client/.github-ci.yml
+++ b/instrumentation/http_client/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  minimum_coverage: 85

--- a/instrumentation/http_client/.github-ci.yml
+++ b/instrumentation/http_client/.github-ci.yml
@@ -1,2 +1,2 @@
 env:
-  minimum_coverage: 62
+  minimum_coverage: 85

--- a/instrumentation/net_http/.github-ci.yml
+++ b/instrumentation/net_http/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  minimum_coverage: 57

--- a/instrumentation/rack/.github-ci.yml
+++ b/instrumentation/rack/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  minimum_coverage: 58


### PR DESCRIPTION
After merging https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2272, code coverage is now accurately calculated and all are above 85%. We can now remove the overwrite files.

- faraday: 96.46%
- http_client: 100.0%
- http: 96.84%
- net_http: 100.0%
- rack: 96.84%