### PR TITLE
chore: Adjust support policy for kafka 8.x

### DIFF
--- a/.docker/infra/kafka/docker-compose.yml
+++ b/.docker/infra/kafka/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: confluentinc/cp-kafka:8.0.4@sha256:66dba34b08f8dd69b8513daff49cb57846333e82c7900a4e2597f9f652553565
+    image: confluentinc/cp-kafka:8.1.1@sha256:d20bd62f01826c454e88530efc6d73654cb4697182f37206742b96c7b947236e
     ports:
       - "9093:9093"
       - "29092:29092"

--- a/.docker/infra/kafka/docker-compose.yml
+++ b/.docker/infra/kafka/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: confluentinc/cp-kafka:8.1.1@sha256:d20bd62f01826c454e88530efc6d73654cb4697182f37206742b96c7b947236e
+    image: confluentinc/cp-kafka:8.0.4@sha256:66dba34b08f8dd69b8513daff49cb57846333e82c7900a4e2597f9f652553565
     ports:
       - "9093:9093"
       - "29092:29092"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
       separateMinorPatch: true,
     },
     {
-      description: "Seperate multiple minor updates so we gain visibility to what is in the queue",
+      description: "Separate multiple minor updates so we gain visibility to what is in the queue",
       matchDepNames: ["confluentinc/cp-kafka"],
       separateMultipleMinor: true,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,7 +76,8 @@
       dependencyDashboardCategory: "Min Docker service",
       matchUpdateTypes: ["major", "minor"],
       matchDepNames: ["confluentinc/cp-kafka"],
-      minimumReleaseAge: "730 days",
+      minimumReleaseAge: "240 days",
+      separateMultipleMinor: true,
     },
     {
       description: "Wait until current major mysql is EoL before updating",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,11 @@
       separateMinorPatch: true,
     },
     {
+      description: "Seperate multiple minor updates so we gain visibility to what is in the queue",
+      matchDepNames: ["confluentinc/cp-kafka"],
+      separateMultipleMinor: true,
+    },
+    {
       description: "Group min ruby updates into a single update which needs to be approved via the dashboard.",
       groupName: "Min-Ruby-sdk",
       dependencyDashboardCategory: "Min Ruby Runtime",
@@ -77,7 +82,6 @@
       matchUpdateTypes: ["major", "minor"],
       matchDepNames: ["confluentinc/cp-kafka"],
       minimumReleaseAge: "240 days",
-      separateMultipleMinor: true,
     },
     {
       description: "Wait until current major mysql is EoL before updating",


### PR DESCRIPTION
The renovate rule for kafka has been adjusted to reflect the changed support policy for 8.x kafka https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility 

Note we could've dropped version to 8.0.x but that would've introduced additional maintenance due to needing custom entry command for 2 months until 8.1 becomes the min version.