### PR TITLE
chore: Replace exclude with disablement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,11 +14,6 @@ AllCops:
     - "bin/instrumentation_generator"
     - "**/**/vendor/bundle/**/*"
     - "**/proto/**"
-    - "helpers/sql-obfuscation/**"
-    - "instrumentation/dalli/**"
-    - "instrumentation/mongo/**"
-    - "instrumentation/restclient/**"
-    - "instrumentation/ruby_kafka/**"
 Bundler/OrderedGems:
   Enabled: false
 Lint/ConstantDefinitionInBlock:

--- a/helpers/sql-obfuscation/.rubocop.yml
+++ b/helpers/sql-obfuscation/.rubocop.yml
@@ -1,8 +1,7 @@
 AllCops:
   DisabledByDefault: true
-
-Lint/Syntax:
-  Enabled: false
+  Exclude:
+    - "**/*"
 
 Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/helpers/sql-obfuscation/.rubocop.yml
+++ b/helpers/sql-obfuscation/.rubocop.yml
@@ -1,4 +1,8 @@
-inherit_from: ../../.rubocop.yml
+AllCops:
+  DisabledByDefault: true
+
+Lint/Syntax:
+  Enabled: false
 
 Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/instrumentation/dalli/.rubocop.yml
+++ b/instrumentation/dalli/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
   DisabledByDefault: true
-
-Lint/Syntax:
-  Enabled: false
+  Exclude:
+    - "**/*"

--- a/instrumentation/dalli/.rubocop.yml
+++ b/instrumentation/dalli/.rubocop.yml
@@ -1,1 +1,5 @@
-inherit_from: ../../.rubocop.yml
+AllCops:
+  DisabledByDefault: true
+
+Lint/Syntax:
+  Enabled: false

--- a/instrumentation/mongo/.rubocop.yml
+++ b/instrumentation/mongo/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
   DisabledByDefault: true
-
-Lint/Syntax:
-  Enabled: false
+  Exclude:
+    - "**/*"

--- a/instrumentation/mongo/.rubocop.yml
+++ b/instrumentation/mongo/.rubocop.yml
@@ -1,1 +1,5 @@
-inherit_from: ../../.rubocop.yml
+AllCops:
+  DisabledByDefault: true
+
+Lint/Syntax:
+  Enabled: false

--- a/instrumentation/restclient/.rubocop.yml
+++ b/instrumentation/restclient/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
   DisabledByDefault: true
-
-Lint/Syntax:
-  Enabled: false
+  Exclude:
+    - "**/*"

--- a/instrumentation/restclient/.rubocop.yml
+++ b/instrumentation/restclient/.rubocop.yml
@@ -1,1 +1,5 @@
-inherit_from: ../../.rubocop.yml
+AllCops:
+  DisabledByDefault: true
+
+Lint/Syntax:
+  Enabled: false

--- a/instrumentation/ruby_kafka/.rubocop.yml
+++ b/instrumentation/ruby_kafka/.rubocop.yml
@@ -1,10 +1,10 @@
 AllCops:
   DisabledByDefault: true
-
-Lint/Syntax:
-  Enabled: false
+  Exclude:
+    - "**/*"
 
 Metrics/ParameterLists:
+  Enabled: true
   Exclude:
     - lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
     - lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb

--- a/instrumentation/ruby_kafka/.rubocop.yml
+++ b/instrumentation/ruby_kafka/.rubocop.yml
@@ -1,7 +1,10 @@
-inherit_from: ../../.rubocop.yml
+AllCops:
+  DisabledByDefault: true
+
+Lint/Syntax:
+  Enabled: false
 
 Metrics/ParameterLists:
-  Enabled: true
   Exclude:
     - lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
     - lib/opentelemetry/instrumentation/ruby_kafka/patches/producer.rb


### PR DESCRIPTION
This replaces excluding deprecated paths with disabling it at the sub config level. This reduces the changes needed at the root level when deprecating and eliminates changes needed as part of removal process.