### PR TITLE
ci: Adjust renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,7 +106,7 @@
       matchManagers: ["dockerfile"],
       matchUpdateTypes: ["digest"],
       enabled: false,
-    }
+    },
   ],
   customManagers: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,6 +99,14 @@
       matchFileNames: ["**/*.gemspec"],
       dependencyDashboardApproval: true,
     },
+    {
+      description: "Disable digest for ruby base image",
+      matchDepNames: ["Ruby"],
+      matchFileNames: ["Dockerfile"],
+      matchManagers: ["dockerfile"],
+      matchUpdateTypes: ["digest"],
+      enabled: false,
+    }
   ],
   customManagers: [
     {
@@ -172,7 +180,7 @@
   ],
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["before 8am on Monday"],
+    schedule: ["before 4am on Tuesday"],
   },
   labels: ["dependencies"],
   ignoreDeps: [


### PR DESCRIPTION
Move locks to tuesday and shorten time window to reduce chance of getting double pr's on monday like we are as well as conflicts with other pr's.

This also disable digest updates for ruby in the dockerfile to hopefully address the current warning caused by no release for the alpine edition. Note we will still get digest updates but only when they are for ruby-alpine.