### PR TITLE
chore: Update README with new badges/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenTelemetry Ruby Contrib
 
 [![Slack channel][slack-image]][slack-url]
+[![GitHub Discussions][discussions-image]][discussions-url]
 [![CI][ci-image]][ci-image]
 [![Apache License][license-image]][license-image]
 [![OpenSSF Scorecard for opentelemetry-ruby-contrib][openssf-scorecard-image]][openssf-scorecard-url]
@@ -114,6 +115,8 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [otel-ruby-releases]: https://github.com/open-telemetry/opentelemetry-ruby/releases
 [otel-ruby-contrib-releases]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/releases
 [ci-image]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/workflows/ci-contrib.yml/badge.svg?event=push
+[discussions-image]: https://img.shields.io/github/discussions/open-telemetry/opentelemetry-ruby-contrib?logo=github
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/discussions
 [fossa-license-image]: https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib.svg?type=shield&issueType=license
 [fossa-license-url]: https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib?ref=badge_shield&issueType=license
 [fossa-security-image]: https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib.svg?type=shield&issueType=security

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Slack channel][slack-image]][slack-url]
 [![CI][ci-image]][ci-image]
 [![Apache License][license-image]][license-image]
+[![OpenSSF Scorecard for opentelemetry-ruby-contrib][openssf-scorecard-image]][openssf-scorecard-url]
+[![FOSSA License Status][fossa-license-image]][fossa-license-url]
+[![FOSSA Security Status][fossa-security-image]][fossa-security-url]
 
 Contrib Packages for the [OpenTelemetry Ruby][otel-ruby] API and SDK implementation.
 
@@ -110,14 +113,20 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [otel-ruby]: https://github.com/open-telemetry/opentelemetry-ruby
 [otel-ruby-releases]: https://github.com/open-telemetry/opentelemetry-ruby/releases
 [otel-ruby-contrib-releases]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/releases
-[ci-image]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/workflows/CI%20Contrib/badge.svg?event=push
+[ci-image]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/workflows/ci-contrib.yml/badge.svg?event=push
+[fossa-license-image]: https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib.svg?type=shield&issueType=license
+[fossa-license-url]: https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib?ref=badge_shield&issueType=license
+[fossa-security-image]: https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib.svg?type=shield&issueType=security
+[fossa-security-url]: https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-ruby-contrib?ref=badge_shield&issueType=security
 [getting-started]: https://opentelemetry.io/docs/languages/ruby/getting-started/
 [issues-good-first-issue]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [issues-help-wanted]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [license-url]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/LICENSE
+[openssf-scorecard-image]: https://api.scorecard.dev/projects/github.com/open-telemetry/opentelemetry-ruby-contrib/badge
+[openssf-scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-ruby-contrib
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
-[slack-image]: https://img.shields.io/badge/slack-@cncf/otel/ruby-brightgreen.svg?logo=slack
+[slack-image]: https://img.shields.io/badge/slack-@cncf/%23otel--ruby-purple.svg
 [slack-url]: https://cloud-native.slack.com/archives/C01NWKKMKMY
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
 [otel-versioning]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md


### PR DESCRIPTION
This fixes the CI status Badge which is currently broken. While tweaking the badges, the openssf scorecard & fossa badges have been add with the links previously only available by digging into the actions log which contains them.

The slack badge now shows the actual channel name.