### PR TITLE
chore: Add missing blank line

### DIFF
--- a/instrumentation/trilogy/README.md
+++ b/instrumentation/trilogy/README.md
@@ -50,6 +50,7 @@ OpenTelemetry::Instrumentation::Trilogy.with_attributes('pizzatoppings' => 'mush
   client.query('SELECT 1')
 end
 ```
+
 ## Compatibility
 
 This gem requires Trilogy 2.11 or higher and will not work with a future Trilogy 3.x release.


### PR DESCRIPTION
The Trilogy PR was merged without the Local CLI Checks. The error showed up in the ruby/setup-ruby renovate PR.