### PR TITLE
chore: Fix path format for markdownlint configuration

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,3 @@
 config:
-  extends: .markdownlint.yaml
+  extends: "./.markdownlint.yaml"
 gitignore: "**/.{git,markdownlint}ignore"


### PR DESCRIPTION
This helps to ensure consistency between both the cli & action check.