### PR TITLE
feat: Replace obfuscate setting with an exclude attribute setting

### DIFF
--- a/instrumentation/trilogy/README.md
+++ b/instrumentation/trilogy/README.md
@@ -58,7 +58,8 @@ This gem requires Trilogy 2.11 or higher and will not work with a future Trilogy
 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
-| `db_statement` | `:obfuscate` | Controls how SQL queries appear in spans. `:obfuscate` replaces literal values with `?`, `:include` records the raw SQL, `:omit` excludes the attribute entirely. |
+| `db_statement` | `:obfuscate` | Deprecated, use `exclude_dbquerytext` on stable/dup. Controls how SQL queries appear in spans. `:obfuscate` replaces literal values with `?`, `:include` records the raw SQL, `:omit` excludes the attribute entirely. |
+| `exclude_dbquerytext` | false | Defines if the db.query.text attribute should be included. |
 | `obfuscation_limit` | `2000` | Maximum length of the obfuscated SQL statement. Statements exceeding this limit are truncated. |
 | `peer_service` | `nil` | Deprecated with no replacement. Sets the `peer.service` attribute on spans (old semantic conventions only). |
 | `propagator` | `'none'` | Propagator for injecting trace context into SQL comments. `'none'` disables propagation, `'tracecontext'` uses W3C Trace Context, `'vitess'` uses Vitess-style propagation (requires `opentelemetry-propagator-vitess` gem). |

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
@@ -92,6 +92,7 @@ module OpenTelemetry
         option :obfuscation_limit, default: 2000, validate: :integer
         option :propagator, default: 'none', validate: %w[none tracecontext vitess]
         option :record_exception, default: true, validate: :boolean
+        option :exclude_dbquerytext, default: false, validate: :boolean
 
         attr_reader :propagator, :semconv
 

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/dup/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/dup/client.rb
@@ -114,20 +114,12 @@ module OpenTelemetry
               # Old convention
               attributes['db.instance.id'] = @connected_host unless @connected_host.nil?
 
-              if sql
-                case config[:db_statement]
-                when :obfuscate
-                  obfuscated = OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql)
-                  # Old convention
-                  attributes[::OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT] = obfuscated
-                  # Stable convention
-                  attributes['db.query.text'] = obfuscated
-                when :include
-                  # Old convention
-                  attributes[::OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT] = sql
-                  # Stable convention
-                  attributes['db.query.text'] = sql
-                end
+              if sql && !config[:exclude_dbquerytext]
+                obfuscated = OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql)
+                # Old convention
+                attributes[::OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT] = obfuscated
+                # Stable convention
+                attributes['db.query.text'] = obfuscated
               end
 
               attributes

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/stable/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/stable/client.rb
@@ -95,14 +95,9 @@ module OpenTelemetry
             def client_attributes(sql = nil)
               attributes = @_otel_base_attributes.dup
 
-              if sql
-                case config[:db_statement]
-                when :obfuscate
-                  attributes['db.query.text'] =
-                    OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql)
-                when :include
-                  attributes['db.query.text'] = sql
-                end
+              if sql && !config[:exclude_dbquerytext]
+                attributes['db.query.text'] =
+                  OpenTelemetry::Helpers::SqlProcessor.obfuscate_sql(sql, obfuscation_limit: config[:obfuscation_limit], adapter: :mysql)
               end
 
               attributes

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/client_attributes_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/client_attributes_test.rb
@@ -42,7 +42,7 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Dup::Client do
     exporter.reset
     instrumentation.instance_variable_set(:@installed, false)
     instrumentation.install({
-                              db_statement: :omit,
+                              exclude_dbquerytext: true,
                               span_name: :statement_type,
                               propagator: 'none',
                               record_exception: true,
@@ -152,14 +152,14 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Dup::Client do
       refute b.key?('extra')
     end
 
-    describe 'with sql and db_statement config' do
+    describe 'with sql and exclude_dbquerytext config' do
       before do
         instrumentation.instance_variable_set(:@installed, false)
       end
 
-      it 'includes SQL in db.statement (old) when db_statement is :include' do
+      it 'includes SQL in db.statement (old) when exclude_dbquerytext is false' do
         instrumentation.install({
-                                  db_statement: :include,
+                                  exclude_dbquerytext: false,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -170,9 +170,9 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Dup::Client do
         assert_equal 'SELECT * FROM users', attrs[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]
       end
 
-      it 'includes SQL in db.query.text (stable) when db_statement is :include' do
+      it 'includes SQL in db.query.text (stable) when exclude_dbquerytext is false' do
         instrumentation.install({
-                                  db_statement: :include,
+                                  exclude_dbquerytext: false,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -183,9 +183,9 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Dup::Client do
         assert_equal 'SELECT * FROM users', attrs['db.query.text']
       end
 
-      it 'omits both db.statement and db.query.text when db_statement is :omit' do
+      it 'omits both db.statement and db.query.text when exclude_dbquerytext is true' do
         instrumentation.install({
-                                  db_statement: :omit,
+                                  exclude_dbquerytext: true,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -195,27 +195,6 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Dup::Client do
         attrs = client.send(:client_attributes, 'SELECT * FROM users')
         refute attrs.key?(OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT)
         refute attrs.key?('db.query.text')
-      end
-
-      it 'obfuscates SQL in both attributes when db_statement is :obfuscate' do
-        instrumentation.install({
-                                  db_statement: :obfuscate,
-                                  span_name: :statement_type,
-                                  propagator: 'none',
-                                  record_exception: true,
-                                  obfuscation_limit: 2000,
-                                  peer_service: nil
-                                })
-        attrs = client.send(:client_attributes, 'SELECT * FROM users WHERE id = 1')
-
-        old_stmt = attrs[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]
-        new_stmt = attrs['db.query.text']
-
-        assert old_stmt, 'expected db.statement to be present'
-        assert new_stmt, 'expected db.query.text to be present'
-        refute_includes old_stmt, '1'
-        refute_includes new_stmt, '1'
-        assert_equal old_stmt, new_stmt
       end
     end
   end

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/instrumentation_test.rb
@@ -125,7 +125,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
     end
 
     describe 'with default options' do
-      it 'obfuscates sql in both old and stable attributes' do
+      it 'removes sql in both old and stable attributes' do
         client.query('SELECT 1')
 
         _(span.name).must_equal 'select'
@@ -405,23 +405,8 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
       end
     end
 
-    describe 'when db_statement is set to include' do
-      let(:config) { { db_statement: :include } }
-
-      it 'includes the db query statement in both attributes' do
-        sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
-        expect do
-          client.query(sql)
-        end.must_raise Trilogy::Error
-
-        _(span.name).must_equal 'select'
-        _(span.attributes[OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT]).must_equal sql
-        _(span.attributes['db.query.text']).must_equal sql
-      end
-    end
-
-    describe 'when db_statement is set to obfuscate' do
-      let(:config) { { db_statement: :obfuscate } }
+    describe 'when exclude_dbquerytext is set to false' do
+      let(:config) { { exclude_dbquerytext: false } }
 
       it 'obfuscates SQL parameters in both attributes' do
         sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
@@ -450,7 +435,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
       end
 
       describe 'with obfuscation_limit' do
-        let(:config) { { db_statement: :obfuscate, obfuscation_limit: 10 } }
+        let(:config) { { exclude_dbquerytext: false, obfuscation_limit: 10 } }
 
         it 'returns a message when the limit is reached' do
           sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
@@ -592,8 +577,8 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
       end
     end
 
-    describe 'when db_statement is set to omit' do
-      let(:config) { { db_statement: :omit } }
+    describe 'when exclude_dbquerytext is set to true' do
+      let(:config) { { exclude_dbquerytext: true } }
 
       it 'does not include SQL statement in either attribute' do
         sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
@@ -607,10 +592,10 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
       end
     end
 
-    describe 'when db_statement is configured via environment variable' do
-      describe 'when db_statement set as omit' do
+    describe 'when dbquerytext is configured via environment variable' do
+      describe 'when exclude_dbquerytext set as true' do
         it 'omits both db.statement and db.query.text attributes' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=omit;') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=true;') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
             sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
@@ -627,9 +612,9 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
         end
       end
 
-      describe 'when db_statement set as obfuscate' do
+      describe 'when exclude_dbquerytext set as false' do
         it 'obfuscates SQL parameters in both attributes' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate;') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=false;') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
 
@@ -649,10 +634,10 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
       end
 
       describe 'when db_statement is set differently than local config' do
-        let(:config) { { db_statement: :omit } }
+        let(:config) { { exclude_dbquerytext: true } }
 
         it 'overrides local config and obfuscates SQL parameters in both attributes' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=false') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/client_attributes_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/client_attributes_test.rb
@@ -42,7 +42,7 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Stable::Client do
     exporter.reset
     instrumentation.instance_variable_set(:@installed, false)
     instrumentation.install({
-                              db_statement: :omit,
+                              exclude_dbquerytext: true,
                               span_name: :statement_type,
                               propagator: 'none',
                               record_exception: true,
@@ -124,14 +124,14 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Stable::Client do
       end
     end
 
-    describe 'with sql and db_statement config' do
+    describe 'with sql and exclude_dbquerytext config' do
       before do
         instrumentation.instance_variable_set(:@installed, false)
       end
 
-      it 'includes SQL as db.query.text when db_statement is :include' do
+      it 'includes SQL as db.query.text when exclude_dbquerytext is false' do
         instrumentation.install({
-                                  db_statement: :include,
+                                  exclude_dbquerytext: false,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -142,9 +142,9 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Stable::Client do
         assert_equal 'SELECT * FROM users', attrs['db.query.text']
       end
 
-      it 'does not include db.statement when db_statement is :include' do
+      it 'does not include db.statement when exclude_dbquerytext is false' do
         instrumentation.install({
-                                  db_statement: :include,
+                                  exclude_dbquerytext: false,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -155,9 +155,9 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Stable::Client do
         refute attrs.key?(OpenTelemetry::SemanticConventions::Trace::DB_STATEMENT)
       end
 
-      it 'omits db.query.text when db_statement is :omit' do
+      it 'omits db.query.text when exclude_dbquerytext is true' do
         instrumentation.install({
-                                  db_statement: :omit,
+                                  exclude_dbquerytext: true,
                                   span_name: :statement_type,
                                   propagator: 'none',
                                   record_exception: true,
@@ -166,21 +166,6 @@ describe OpenTelemetry::Instrumentation::Trilogy::Patches::Stable::Client do
                                 })
         attrs = client.send(:client_attributes, 'SELECT * FROM users')
         refute attrs.key?('db.query.text')
-      end
-
-      it 'obfuscates SQL in db.query.text when db_statement is :obfuscate' do
-        instrumentation.install({
-                                  db_statement: :obfuscate,
-                                  span_name: :statement_type,
-                                  propagator: 'none',
-                                  record_exception: true,
-                                  obfuscation_limit: 2000,
-                                  peer_service: nil
-                                })
-        attrs = client.send(:client_attributes, 'SELECT * FROM users WHERE id = 1')
-        stmt = attrs['db.query.text']
-        assert stmt, 'expected db.query.text to be present'
-        refute_includes stmt, '1'
       end
     end
   end

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/instrumentation_test.rb
@@ -107,7 +107,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
     end
 
     describe 'with default options' do
-      it 'obfuscates sql' do
+      it 'drops sql' do
         client.query('SELECT 1')
 
         _(span.name).must_equal 'select'
@@ -304,22 +304,8 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
       end
     end
 
-    describe 'when db_statement is set to include' do
-      let(:config) { { db_statement: :include } }
-
-      it 'includes the db query statement' do
-        sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
-        expect do
-          client.query(sql)
-        end.must_raise Trilogy::Error
-
-        _(span.name).must_equal 'select'
-        _(span.attributes['db.query.text']).must_equal sql
-      end
-    end
-
-    describe 'when db_statement is set to obfuscate' do
-      let(:config) { { db_statement: :obfuscate } }
+    describe 'when exclude_dbquerytext is set to false' do
+      let(:config) { { exclude_dbquerytext: false } }
 
       it 'obfuscates SQL parameters in db.query.text' do
         sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
@@ -346,7 +332,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
       end
 
       describe 'with obfuscation_limit' do
-        let(:config) { { db_statement: :obfuscate, obfuscation_limit: 10 } }
+        let(:config) { { exclude_dbquerytext: false, obfuscation_limit: 10 } }
 
         it 'returns a message when the limit is reached' do
           sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
@@ -487,8 +473,8 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
       end
     end
 
-    describe 'when db_statement is set to omit' do
-      let(:config) { { db_statement: :omit } }
+    describe 'when exclude_dbquerytext is set to true' do
+      let(:config) { { exclude_dbquerytext: true } }
 
       it 'does not include SQL statement as db.query.text attribute' do
         sql = 'SELECT * from users where users.id = 1 and users.email = "test@test.com"'
@@ -504,7 +490,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
     describe 'when db_statement is configured via environment variable' do
       describe 'when db_statement set as omit' do
         it 'omits db.query.text attribute' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=omit;') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=true;') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
             sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
@@ -521,7 +507,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
 
       describe 'when db_statement set as obfuscate' do
         it 'obfuscates SQL parameters in db.query.text' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate;') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=false;') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
 
@@ -539,10 +525,10 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
       end
 
       describe 'when db_statement is set differently than local config' do
-        let(:config) { { db_statement: :omit } }
+        let(:config) { { exclude_dbquerytext: true } }
 
         it 'overrides local config and obfuscates SQL parameters in db.query.text' do
-          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'db_statement=obfuscate') do
+          OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_INSTRUMENTATION_TRILOGY_CONFIG_OPTS' => 'exclude_dbquerytext=false') do
             instrumentation.instance_variable_set(:@installed, false)
             instrumentation.install
 


### PR DESCRIPTION
This introduces an exclude_dbquerytext setting which on stable/dup excludes the db.query.text attribute to the span, otherwise it is included.

This change is to bring closer alignment to how declarative config defines settings which is attributes are included/excluded. This change also ensures un-obfusicated queries can not be captured as per semconv.

It is important to follow semconv as close as possible for consistency and in the future leverage automation

Coverage report before change:

> Line Coverage: 98.31% (233 / 237)

Coverage report after change:

> Line Coverage: 98.28% (229 / 233)

Which is a marginal drop caused by less lines but no increase in uncovered lines.