### PR TITLE
feat: only emit span events by default on old semconv

### DIFF
--- a/instrumentation/trilogy/README.md
+++ b/instrumentation/trilogy/README.md
@@ -63,7 +63,7 @@ This gem requires Trilogy 2.11 or higher and will not work with a future Trilogy
 | `obfuscation_limit` | `2000` | Maximum length of the obfuscated SQL statement. Statements exceeding this limit are truncated. |
 | `peer_service` | `nil` | Deprecated with no replacement. Sets the `peer.service` attribute on spans (old semantic conventions only). |
 | `propagator` | `'none'` | Propagator for injecting trace context into SQL comments. `'none'` disables propagation, `'tracecontext'` uses W3C Trace Context, `'vitess'` uses Vitess-style propagation (requires `opentelemetry-propagator-vitess` gem). |
-| `record_exception` | `true` | Records exceptions as span events when an error occurs. |
+| `record_exception` | `true` when using old semconv, otherwise `false` | Records exceptions as span events when an error occurs. |
 | `span_name` | `:statement_type` | Controls span naming (old semantic conventions only). `:statement_type` uses the SQL operation (e.g., `SELECT`), `:db_name` uses the database name, `:db_operation_and_name` combines both. |
 
 ## Semantic Conventions

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb
@@ -46,7 +46,7 @@ module OpenTelemetry
       #
       # ### `:record_exception`
       #
-      # Records exceptions as span events when an error occurs. Default is `true`.
+      # Records exceptions as span events when an error occurs. Default is `true` for old semconv, otherwise `false`.
       #
       # ### `:span_name`
       #
@@ -91,7 +91,7 @@ module OpenTelemetry
         option :span_name, default: :statement_type, validate: %I[statement_type db_name db_operation_and_name]
         option :obfuscation_limit, default: 2000, validate: :integer
         option :propagator, default: 'none', validate: %w[none tracecontext vitess]
-        option :record_exception, default: true, validate: :boolean
+        option :record_exception, default: nil, validate: :boolean
 
         attr_reader :propagator, :semconv
 
@@ -99,6 +99,8 @@ module OpenTelemetry
 
         def require_dependencies
           @semconv = determine_semconv
+
+          @config[:record_exception] = (@semconv == :old) if @config[:record_exception].nil?
 
           case @semconv
           when :old

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/dup/instrumentation_test.rb
@@ -333,6 +333,7 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
     end
 
     describe 'when queries fail' do
+      let(:config) { { record_exception: true } }
       it 'sets span status to error' do
         expect do
           client.query('SELECT INVALID')
@@ -390,6 +391,18 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (dup semconv)' do
         expect { client.ping }.must_raise Trilogy::Error
 
         _(exporter.finished_spans.last.attributes['error.type']).must_equal 'Trilogy::ConnectionClosed'
+      end
+
+      describe 'when record_exception is default' do
+        let(:config) { {} }
+
+        it 'does not record exception when record_exception is default' do
+          expect do
+            client.query('SELECT INVALID')
+          end.must_raise Trilogy::Error
+
+          _(span.events).must_be_nil
+        end
       end
 
       describe 'when record_exception is false' do

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/patches/stable/instrumentation_test.rb
@@ -240,6 +240,8 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
     end
 
     describe 'when queries fail' do
+      let(:config) { { record_exception: true } }
+
       it 'sets span status to error' do
         expect do
           client.query('SELECT INVALID')
@@ -289,6 +291,17 @@ describe 'OpenTelemetry::Instrumentation::Trilogy (stable semconv)' do
         expect { client.ping }.must_raise Trilogy::Error
 
         _(exporter.finished_spans.last.attributes['error.type']).must_equal 'Trilogy::ConnectionClosed'
+      end
+
+      describe 'when record_exception is default' do
+        let(:config) { {} }
+        it 'does not record exception when record_exception is default' do
+          expect do
+            client.query('SELECT INVALID')
+          end.must_raise Trilogy::Error
+
+          _(span.events).must_be_nil
+        end
       end
 
       describe 'when record_exception is false' do


### PR DESCRIPTION
This switches span events to only be enabled by default on old semconv due to span events undergoing deprecation, the event name is not accurate & the definition is not stable.


Coverage report before change:

> Line Coverage: 98.31% (233 / 237)

Coverage report after change:

> Line Coverage: 98.32% (234 / 238)