### PR TITLE
fix: Make logs bridge broadcast suppression fiber-local

### DIFF
--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger.rb
@@ -4,50 +4,58 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require_relative 'broadcast_logger_context'
+
 module OpenTelemetry
   module Instrumentation
     module Logger
       module Patches
         # Patches for the ActiveSupport::BroadcastLogger class included in Rails 7.1+
         module ActiveSupportBroadcastLogger
-          def add(*args)
-            emit_one_broadcast(*args) { super }
+          def add(...)
+            emit_one_broadcast { super }
           end
 
-          def debug(*args)
-            emit_one_broadcast(*args) { super }
+          def debug(...)
+            emit_one_broadcast { super }
           end
 
-          def info(*args)
-            emit_one_broadcast(*args) { super }
+          def info(...)
+            emit_one_broadcast { super }
           end
 
-          def warn(*args)
-            emit_one_broadcast(*args) { super }
+          def warn(...)
+            emit_one_broadcast { super }
           end
 
-          def error(*args)
-            emit_one_broadcast(*args) { super }
+          def error(...)
+            emit_one_broadcast { super }
           end
 
-          def fatal(*args)
-            emit_one_broadcast(*args) { super }
+          def fatal(...)
+            emit_one_broadcast { super }
           end
 
-          def unknown(*args)
-            emit_one_broadcast(*args) { super }
+          def unknown(...)
+            emit_one_broadcast { super }
           end
 
           private
 
           # Emit logs from only one of the loggers in the broadcast.
-          # Set @skip_otel_emit to `true` to the rest of the loggers before emitting the logs.
-          # Set @skip_otel_emit to `false` after the log is emitted.
-          def emit_one_broadcast(*args)
-            broadcasts[1..-1].each { |broadcasted_logger| broadcasted_logger.instance_variable_set(:@skip_otel_emit, true) }
-            ret = yield
-            broadcasts.each { |broadcasted_logger| broadcasted_logger.instance_variable_set(:@skip_otel_emit, false) }
-            ret
+          def emit_one_broadcast
+            secondary_broadcasts = broadcasts.drop(1)
+            return yield if secondary_broadcasts.empty?
+
+            secondary_broadcasts.each do |logger|
+              BroadcastLoggerContext.skip_logger(logger)
+            end
+
+            yield
+          ensure
+            secondary_broadcasts&.each do |logger|
+              BroadcastLoggerContext.unskip_logger(logger)
+            end
           end
         end
       end

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/active_support_logger.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require_relative 'broadcast_logger_context'
+
 module OpenTelemetry
   module Instrumentation
     module Logger
@@ -11,12 +13,22 @@ module OpenTelemetry
         # Patches for the ActiveSupport::Logger class included in Rails
         module ActiveSupportLogger
           # The ActiveSupport::Logger.broadcast method emits identical logs to
-          # multiple destinations. This instance variable will prevent the broadcasted
-          # destinations from generating OpenTelemetry log record objects.
+          # multiple destinations. This prevents the broadcasted destinations from
+          # generating OpenTelemetry log record objects only during broadcast emission.
           # Available in Rails 7.0 and below
           def broadcast(logger)
-            logger.instance_variable_set(:@skip_otel_emit, true)
-            super
+            broadcast_module = super
+            broadcast_module.prepend(Module.new do
+              define_method(:add) do |*args, &block|
+                BroadcastLoggerContext.skip_logger(logger)
+                begin
+                  super(*args, &block)
+                ensure
+                  BroadcastLoggerContext.unskip_logger(logger)
+                end
+              end
+            end)
+            broadcast_module
           end
         end
       end

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/broadcast_logger_context.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/broadcast_logger_context.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module Logger
+      module Patches
+        # Tracks broadcast logger emission state for the current fiber.
+        module BroadcastLoggerContext
+          SKIP_LOGGERS_KEY = :_otel_broadcast_skip_loggers
+          private_constant :SKIP_LOGGERS_KEY
+
+          class << self
+            def skipped_logger?(logger)
+              skip_loggers&.key?(logger) || false
+            end
+
+            def skip_logger(logger)
+              skip_loggers_for_write[logger] += 1
+            end
+
+            def unskip_logger(logger)
+              skip_loggers = self.skip_loggers
+              return unless skip_loggers&.key?(logger)
+
+              skip_loggers[logger] -= 1
+              skip_loggers.delete(logger) if skip_loggers[logger].zero?
+              Fiber[SKIP_LOGGERS_KEY] = nil if skip_loggers.empty?
+            end
+
+            private
+
+            def skip_loggers
+              Fiber[SKIP_LOGGERS_KEY]
+            end
+
+            def skip_loggers_for_write
+              skip_loggers || Hash.new(0).compare_by_identity.tap do |skip_loggers|
+                Fiber[SKIP_LOGGERS_KEY] = skip_loggers
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require_relative 'broadcast_logger_context'
+
 module OpenTelemetry
   module Instrumentation
     module Logger
@@ -11,8 +13,6 @@ module OpenTelemetry
         # Instrumentation for methods from Ruby's Logger class
         module Logger
           IN_OTEL_EMIT_KEY = :in_otel_emit
-
-          attr_writer :skip_otel_emit
 
           def format_message(severity, datetime, progname, msg)
             formatted_message = super
@@ -25,7 +25,7 @@ module OpenTelemetry
           private
 
           def emit_to_otel(severity, datetime, body)
-            return if skip_otel_emit? || Thread.current[IN_OTEL_EMIT_KEY]
+            return if broadcast_logger_context_skipped? || Thread.current[IN_OTEL_EMIT_KEY]
 
             Thread.current[IN_OTEL_EMIT_KEY] = true
             begin
@@ -44,8 +44,8 @@ module OpenTelemetry
             end
           end
 
-          def skip_otel_emit?
-            @skip_otel_emit || false
+          def broadcast_logger_context_skipped?
+            BroadcastLoggerContext.skipped_logger?(self)
           end
 
           def severity_number(severity)

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger_test.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'test_helper'
+require 'timeout'
 
 require_relative '../../../../../lib/opentelemetry/instrumentation/logger/patches/active_support_broadcast_logger'
 
@@ -21,6 +22,71 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportBroadcast
   end
 
   after { instrumentation.instance_variable_set(:@installed, false) }
+
+  it 'does not suppress direct log records from other threads' do
+    started_queue = Queue.new
+    continue_queue = Queue.new
+    blocking_logger_class = Class.new(Logger) do
+      attr_accessor :started_queue, :continue_queue
+
+      def format_message(...)
+        started_queue << true
+        continue_queue.pop
+        super
+      end
+    end
+    blocking_logger = blocking_logger_class.new(LOG_STREAM)
+    blocking_logger.started_queue = started_queue
+    blocking_logger.continue_queue = continue_queue
+    blocking_broadcast = ActiveSupport::BroadcastLogger.new(blocking_logger, logger2)
+
+    broadcast_body = 'One hand washes the other'
+    direct_body = 'Other hand checks the thread'
+    broadcast_thread = Thread.new { blocking_broadcast.info(broadcast_body) }
+
+    begin
+      Timeout.timeout(5) { started_queue.pop }
+      logger2.info(direct_body)
+    ensure
+      continue_queue.push(true)
+      broadcast_thread.value
+    end
+
+    log_record_bodies = EXPORTER.emitted_log_records.map(&:body)
+    assert_equal 2, log_record_bodies.size
+    assert(log_record_bodies.any? { |body| body.include?(broadcast_body) })
+    assert(log_record_bodies.any? { |body| body.include?(direct_body) })
+  end
+
+  it 'does not suppress direct log records from other fibers' do
+    blocking_logger_class = Class.new(Logger) do
+      attr_accessor :on_format
+
+      def format_message(...)
+        on_format.call
+        super
+      end
+    end
+    blocking_logger = blocking_logger_class.new(LOG_STREAM)
+    blocking_logger.on_format = -> { Fiber.yield }
+    blocking_broadcast = ActiveSupport::BroadcastLogger.new(blocking_logger, logger2)
+
+    broadcast_body = 'Turn and face the strange'
+    direct_body = 'Different fiber keeps its voice'
+    broadcast_fiber = Fiber.new { blocking_broadcast.info(broadcast_body) }
+
+    begin
+      broadcast_fiber.resume
+      logger2.info(direct_body)
+    ensure
+      broadcast_fiber.resume if broadcast_fiber.alive?
+    end
+
+    log_record_bodies = EXPORTER.emitted_log_records.map(&:body)
+    assert_equal 2, log_record_bodies.size
+    assert(log_record_bodies.any? { |body| body.include?(broadcast_body) })
+    assert(log_record_bodies.any? { |body| body.include?(direct_body) })
+  end
 
   describe '#add' do
     it 'emits the log to the broadcasted loggers' do

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/active_support_logger_test.rb
@@ -16,8 +16,8 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportLogger do
   before do
     skip unless defined?(ActiveSupport::Logger) && !defined?(ActiveSupport::BroadcastLogger)
     EXPORTER.reset
-    Rails.logger = main_logger.extend(ActiveSupport::Logger.broadcast(broadcasted_logger))
     instrumentation.install
+    Rails.logger = main_logger.extend(ActiveSupport::Logger.broadcast(broadcasted_logger))
   end
 
   after { instrumentation.instance_variable_set(:@installed, false) }
@@ -52,6 +52,19 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::ActiveSupportLogger do
       log_records = EXPORTER.emitted_log_records
       assert_equal 1, log_records.size
       assert_match(/#{msg}/, log_records.first.body)
+    end
+
+    it 'does not suppress direct log records after a broadcast' do
+      broadcast_msg = "larch #{rand(6)}"
+      direct_msg = "maple #{rand(6)}"
+
+      Rails.logger.debug(broadcast_msg)
+      broadcasted_logger.debug(direct_msg)
+
+      log_record_bodies = EXPORTER.emitted_log_records.map(&:body)
+      assert_equal 2, log_record_bodies.size
+      assert(log_record_bodies.any? { |body| body.include?(broadcast_msg) })
+      assert(log_record_bodies.any? { |body| body.include?(direct_msg) })
     end
   end
 end

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
@@ -51,11 +51,12 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::Logger do
       assert_equal(5, log_record.severity_number)
       assert_equal(nano_timestamp, log_record.timestamp)
     end
-
-    it 'does not emit when @skip_otel_emit is true' do
-      ruby_logger.instance_variable_set(:@skip_otel_emit, true)
+    it 'does not emit when skipped by the broadcast logger context' do
+      OpenTelemetry::Instrumentation::Logger::Patches::BroadcastLoggerContext.skip_logger(ruby_logger)
       ruby_logger.debug(msg)
       assert_nil(log_record)
+    ensure
+      OpenTelemetry::Instrumentation::Logger::Patches::BroadcastLoggerContext.unskip_logger(ruby_logger)
     end
 
     it 'turns the severity into a number' do


### PR DESCRIPTION
We're running a patched copy of the bridge logger in our app, during code review thread safety concerns were raised about the shared @skip_otel_emit instance variable. This PR contains the changes we made to address that, we have been running in production successfully for the past couple of weeks.