### PR TITLE
docs: document payload-key and payload-transform options in action_mailer and active_storage READMEs

### DIFF
--- a/instrumentation/action_mailer/README.md
+++ b/instrumentation/action_mailer/README.md
@@ -36,6 +36,35 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+## Configuration Options
+
+The instrumentation supports the following configuration options:
+
+- **`disallowed_notification_payload_keys`:** Array of keys excluded from the `deliver.action_mailer` notification payload before they are recorded as span attributes. Keys are matched against the payload after the ECS-style transform documented under [Semantic Conventions](#semantic-conventions), so use the transformed names (e.g. `email.to.address`).
+  - Default: `[]`
+- **`disallowed_process_payload_keys`:** Array of keys excluded from the `process.action_mailer` notification payload before they are recorded as span attributes.
+  - Default: `[]`
+- **`notification_payload_transform`:** Custom `proc` used to extract span attributes from the `deliver.action_mailer` notification payload. The proc receives the payload after the built-in ECS-style transform has been applied and must return a `Hash`. Use this to rename keys, extract nested values, or perform any other custom logic.
+  - Default: `nil`
+- **`process_payload_transform`:** Custom `proc` used to extract span attributes from the `process.action_mailer` notification payload. Must return a `Hash`.
+  - Default: `nil`
+- **`email_address`:** Whether to include email addresses (`email.to.address`, `email.from.address`, `email.cc.address`, `email.bcc.address`) as span attributes. Valid values are `:omit` and `:include`. When set to `:omit`, these keys are appended to `disallowed_notification_payload_keys`.
+  - Default: `:omit`
+
+Example with all options set:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::ActionMailer', {
+    disallowed_notification_payload_keys: ['email.subject'],
+    disallowed_process_payload_keys: ['args'],
+    notification_payload_transform: ->(payload) { payload.merge('email.tenant' => payload['email.x_mailer']) },
+    process_payload_transform: ->(payload) { payload },
+    email_address: :include,
+  }
+end
+```
+
 ## Active Support Instrumentation
 
 This instrumentation relies entirely on `ActiveSupport::Notifications` and registers a custom Subscriber that listens to relevant events to report as spans.

--- a/instrumentation/active_storage/README.md
+++ b/instrumentation/active_storage/README.md
@@ -36,6 +36,32 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+## Configuration Options
+
+The instrumentation supports the following configuration options:
+
+- **`disallowed_notification_payload_keys`:** Array of keys excluded from notification payloads before they are recorded as span attributes. Keys are matched against the payload after the `active_storage.` prefix has been applied (e.g. `active_storage.url`).
+  - Default: `[]`
+- **`notification_payload_transform`:** Custom `proc` used to extract span attributes from notification payloads. The proc receives the payload after the built-in `active_storage.` prefix transform and must return a `Hash`. Use this to rename keys, extract nested values, or perform any other custom logic.
+  - Default: `nil`
+- **`key`:** Whether to include the secure token (`active_storage.key`) as a span attribute. Valid values are `:omit` and `:include`. When set to `:omit`, the key is appended to `disallowed_notification_payload_keys`.
+  - Default: `:omit`
+- **`url`:** Whether to include the URL (`active_storage.url`) as a span attribute. Valid values are `:omit` and `:include`. When set to `:omit`, the key is appended to `disallowed_notification_payload_keys`.
+  - Default: `:omit`
+
+Example with all options set:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::ActiveStorage', {
+    disallowed_notification_payload_keys: ['active_storage.checksum'],
+    notification_payload_transform: ->(payload) { payload },
+    key: :include,
+    url: :include,
+  }
+end
+```
+
 ## Active Support Instrumentation
 
 This instrumentation relies entirely on `ActiveSupport::Notifications` and registers a custom Subscriber that listens to relevant events to report as spans.


### PR DESCRIPTION
Adds a Configuration Options section to the action_mailer and active_storage READMEs covering disallowed_notification_payload_keys, disallowed_process_payload_keys, notification_payload_transform, process_payload_transform, email_address, key, and url. Mirrors the format already used by the action_view README.

Calls out that user-supplied transform procs receive the payload after the built-in ECS-style transform (action_mailer) and the active_storage. prefix transform (active_storage) have been applied, which is the part the existing class comments leave implicit.

Refs #969