### PR TITLE
chore: Add @thompson-tomo to Approvers list on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For more information about the maintainer role, see the [community repository](h
 - [Josef Šimánek](https://github.com/simi)
 - [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
 - [Hannah Ramadan](https://github.com/HannahRamadan), New Relic
+- [James Thompson](https://github.com/thompson-tomo)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
This aligns with our alias and other documentation.