### PR TITLE
chore: Swap app-id for client-id in otelbot token

### DIFF
--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.OTELBOT_RUBY_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_CONTRIB_PRIVATE_KEY }}
 
       - name: Open release pull request

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.OTELBOT_RUBY_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_CONTRIB_PRIVATE_KEY }}
 
       - name: Open release pull request


### PR DESCRIPTION
See warnings on this workflow run: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/26248549088 

<img width="800" height="529" alt="Screenshot 2026-05-21 at 12 37 21 PM" src="https://github.com/user-attachments/assets/bd6f0172-70e9-49fe-ae5d-7bfe12fb2c4c" />
