### PR TITLE
WIP: Active Job instrumentation stability progression. 

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/default.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/default.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
             job = payload.fetch(:job)
             event_name = name.delete_suffix(".#{EVENT_NAMESPACE}")
             span_name = span_name(job, event_name)
-            span = tracer.start_span(span_name, attributes: @mapper.call(payload))
+            span = tracer.start_span(span_name, attributes: @mapper.call(payload, @config[:use_semcomv]))
             token = OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))
 
             { span: span, ctx_token: token }
@@ -119,7 +119,11 @@ module OpenTelemetry
                        job.queue_name
                      end
 
-            "#{prefix} #{event_name}"
+            if @config[:use_semcomv]
+              "#{event_name} #{job.class.name}"
+            else
+              "#{prefix} #{event_name}"
+            end
           end
         end
       end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/enqueue.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       module Handlers
         # Handles `enqueue.active_job` and `enqueue_at.active_job` to generate egress spans
         class Enqueue < Default
-          EVENT_NAME = 'publish'
+          EVENT_NAME = 'enqueue'
 
           # Overrides the `Default#start_span` method to create an egress span
           # and registers it with the current context
@@ -22,8 +22,9 @@ module OpenTelemetry
           def start_span(name, _id, payload)
             job = payload.fetch(:job)
             span_name = span_name(job, EVENT_NAME)
-            span = tracer.start_span(span_name, kind: :producer, attributes: @mapper.call(payload))
+            span = tracer.start_span(span_name, kind: :producer, attributes: @mapper.call(payload, @config[:use_semcomv]))
             token = OpenTelemetry::Context.attach(OpenTelemetry::Trace.context_with_span(span))
+            OpenTelemetry::Baggage.set_value('job_span_id', span.context.span_id)
             OpenTelemetry.propagation.inject(job.__otel_headers) # This must be transmitted over the wire
             { span: span, ctx_token: token }
           end

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       module Handlers
         # Handles perform.active_job to generate ingress spans
         class Perform < Default
-          EVENT_NAME = 'process'
+          EVENT_NAME = 'execute'
 
           # Overrides the `Default#start_span` method to create an ingress span
           # and registers it with the current context
@@ -23,15 +23,36 @@ module OpenTelemetry
             job = payload.fetch(:job)
             span_name = span_name(job, EVENT_NAME)
             parent_context = OpenTelemetry.propagation.extract(job.__otel_headers)
+            job_span_id = OpenTelemetry::Baggage.value('job_span_id', context: parent_context)
+            links = nil
+            kind = :consumer
 
             # TODO: Refactor into a propagation strategy
             propagation_style = @config[:propagation_style]
-            if propagation_style == :child
-              span = tracer.start_span(span_name, with_parent: parent_context, kind: :consumer, attributes: @mapper.call(payload))
-            else
+
+            if job_span_id && @config[:use_semcomv] == true
+              kind = :internal
+              span_context = OpenTelemetry::Trace.current_span(parent_context).context
+              job_context = OpenTelemetry::Trace::SpanContext.new(
+                trace_id: span_context.trace_id,
+                span_id: job_span_id,
+                trace_flags: span_context.trace_flags,
+                trace_state: span_context.trace_state,
+                remote: true
+              )
+
+              links = [OpenTelemetry::Trace::Link.new(job_context)] if job_context.valid?
+            elsif @config[:use_semcomv] != true
               span_context = OpenTelemetry::Trace.current_span(parent_context).context
               links = [OpenTelemetry::Trace::Link.new(span_context)] if span_context.valid? && propagation_style == :link
-              span = tracer.start_root_span(span_name, kind: :consumer, attributes: @mapper.call(payload), links: links)
+            end
+
+            if propagation_style == :child
+              span = tracer.start_span(span_name, with_parent: parent_context, kind: :consumer, attributes: @mapper.call(payload, @config[:use_semcomv]))
+            elsif OpenTelemetry::Trace.current_span.context.valid? && @config[:use_semcomv] == true
+              span = tracer.start_span(span_name, kind: kind, attributes: @mapper.call(payload, @config[:use_semcomv]), links: links)
+            else
+              span = tracer.start_root_span(span_name, kind: kind, attributes: @mapper.call(payload, @config[:use_semcomv]), links: links)
             end
 
             { span: span, ctx_token: attach_consumer_context(span, parent_context) }

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/handlers/perform.rb
@@ -23,7 +23,7 @@ module OpenTelemetry
             job = payload.fetch(:job)
             span_name = span_name(job, EVENT_NAME)
             parent_context = OpenTelemetry.propagation.extract(job.__otel_headers)
-            job_span_id = OpenTelemetry::Baggage.value('job_span_id', context: parent_context)
+            job_span_id = nil # OpenTelemetry::Baggage.value('job_span_id', context: parent_context)
             links = nil
             kind = :consumer
 
@@ -32,24 +32,23 @@ module OpenTelemetry
 
             if job_span_id && @config[:use_semcomv] == true
               kind = :internal
-              span_context = OpenTelemetry::Trace.current_span(parent_context).context
               job_context = OpenTelemetry::Trace::SpanContext.new(
-                trace_id: span_context.trace_id,
+                trace_id: parent_context.trace_id,
                 span_id: job_span_id,
-                trace_flags: span_context.trace_flags,
-                trace_state: span_context.trace_state,
+                trace_flags: parent_context.trace_flags,
+                trace_state: parent_context.trace_state,
                 remote: true
               )
 
               links = [OpenTelemetry::Trace::Link.new(job_context)] if job_context.valid?
-            elsif @config[:use_semcomv] != true
+            elsif propagation_style == :link
               span_context = OpenTelemetry::Trace.current_span(parent_context).context
-              links = [OpenTelemetry::Trace::Link.new(span_context)] if span_context.valid? && propagation_style == :link
+              links = [OpenTelemetry::Trace::Link.new(span_context)] if span_context.valid?
             end
 
             if propagation_style == :child
               span = tracer.start_span(span_name, with_parent: parent_context, kind: :consumer, attributes: @mapper.call(payload, @config[:use_semcomv]))
-            elsif OpenTelemetry::Trace.current_span.context.valid? && @config[:use_semcomv] == true
+            elsif @config[:use_semcomv] == true
               span = tracer.start_span(span_name, kind: kind, attributes: @mapper.call(payload, @config[:use_semcomv]), links: links)
             else
               span = tracer.start_root_span(span_name, kind: kind, attributes: @mapper.call(payload, @config[:use_semcomv]), links: links)

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
@@ -55,6 +55,7 @@ module OpenTelemetry
         option :propagation_style, default: :link, validate: %i[link child none]
         option :force_flush, default: false, validate: :boolean
         option :span_naming, default: :queue, validate: %i[job_class queue]
+        option :use_semcomv, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/mappers/attribute.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/mappers/attribute.rb
@@ -11,13 +11,30 @@ module OpenTelemetry
         # Maps ActiveJob Attributes to Semantic Conventions
         class Attribute
           # Generates a set of attributes to add to a span using
-          # general and messaging semantic conventions as well as
-          # using `rails.active_job.*` namespace for custom attributes
+          # `rails.active_job.*` namespace for custom attributes
           #
           # @param payload [Hash] of an ActiveSupport::Notifications payload
           # @return [Hash<String, Object>] of semantic attributes
-          def call(payload)
+          def call(payload, semconv)
             job = payload.fetch(:job)
+
+            if semconv
+              otel_attributes = {
+                'rails.active_job.task.name' => job.class.name,
+                'rails.active_job.queue.name' => job.queue_name,
+                'rails.active_job.job.id' => job.job_id,
+                'rails.active_job.queue.adapter.name' => job.class.queue_adapter_name
+              }
+
+              # Not all adapters generate or provide back end specific ids for messages
+              otel_attributes['rails.active_job.job.external_id'] = job.provider_job_id.to_s if job.provider_job_id
+              # This can be problematic if programs use invalid attribute types like Symbols for priority instead of using Integers.
+              otel_attributes['rails.active_job.job.priority'] = job.priority.to_s if job.priority
+
+              otel_attributes.compact!
+
+              return otel_attributes
+            end
 
             otel_attributes = {
               'code.namespace' => job.class.name,


### PR DESCRIPTION
This is a proposal to move active job to follow/compliance with semantic conventions. This will be completed with defining the semantic conventions.

The core changes are:

- attribute rename to rails.active_job.* with the attributes added to semconv
- replacement of the propagation/linking functionality with just linking.

During the discussion on the issue the topic of messaging conventions came up. This approach takes the view of messaging being at a lower level to the job framework. To accommodate the potentially for this lower level ie messaging also being instrumented, the span id is propogated via baggage which is then used to create the link back to the enqueue span. In the process creating the new span as a child span has been removed due to it the uncertainty of it. This child span behaviour is better suited in the messaging instrumentation.

This PR is not complete but instead intending to represent the stable state/shape and the new behaviour will initially be available as opt-in.