### PR TITLE
chore: Remove duplicate discussions-url link

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
 [slack-image]: https://img.shields.io/badge/slack-@cncf/%23otel--ruby-purple.svg
 [slack-url]: https://cloud-native.slack.com/archives/C01NWKKMKMY
-[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
 [otel-versioning]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md


### PR DESCRIPTION
The second reference pointed to the core repo. We want all contrib discussions in the contrib repo.

This should fix the failures popping up in Renovate PRs. Example: https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/26789083096/job/78971345357?pr=2381#step:8:29