### PR TITLE
ci: Explicitly install apt packages to speed up grpc build

### DIFF
--- a/instrumentation/grpc/test/apt-packages.txt
+++ b/instrumentation/grpc/test/apt-packages.txt
@@ -1,0 +1,4 @@
+build-essential
+cmake
+pkg-config
+zlib1g-dev

--- a/instrumentation/grpc/test/apt-packages.txt
+++ b/instrumentation/grpc/test/apt-packages.txt
@@ -1,4 +1,6 @@
 build-essential
 cmake
+libprotobuf-dev
 pkg-config
+protobuf-compiler
 zlib1g-dev


### PR DESCRIPTION
This speeds up the grpc build by explicitly installing the apt packages before build.

prior to change ruby 4.0 build was taking over 16mins