### PR TITLE
chore: Update renovate schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,18 +12,18 @@
       groupName: "all patch versions",
       matchDepNames: ["!ruby"],
       matchUpdateTypes: ["patch"],
-      schedule: ["before 6am every weekday"],
+      schedule: ["before 6am every 4 weeks on Monday"],
     },
     {
       groupName: "all digest versions",
       matchDepNames: ["!ruby"],
       matchUpdateTypes: ["digest"],
-      schedule: ["before 6am every weekday"],
+      schedule: ["before 6am every 4 weeks on Monday"],
     },
     {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
-      schedule: ["before 6am every weekday"],
+      schedule: ["before 6am every 4 weeks on Monday"],
     },
     {
       description: "Separate ruby updates so that patches can be installed after new minor has been released.",
@@ -57,11 +57,11 @@
     },
     {
       matchUpdateTypes: ["minor"],
-      schedule: ["before 7am on Monday"],
+      schedule: ["before 7am every 4 weeks on Monday"],
     },
     {
       matchUpdateTypes: ["major"],
-      schedule: ["before 8am on Monday"],
+      schedule: ["before 8am every 2 weeks on Monday"],
     },
     {
       matchDepNames: ["actions/setup-node", "ruby/setup-ruby"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,7 @@
     },
     {
       matchDepNames: ["actions/setup-node", "ruby/setup-ruby"],
-      schedule: ["before 6am every weekday"],
+      schedule: ["before 6am every Monday"],
       prConcurrentLimit: 0,
       automerge: true,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,7 @@
     },
     {
       matchDepNames: ["actions/setup-node", "ruby/setup-ruby"],
-      schedule: ["before 6am every Monday"],
+      schedule: ["before 6am on Monday"],
       prConcurrentLimit: 0,
       automerge: true,
     },


### PR DESCRIPTION
We don't have any hard dependencies on our libraries, so I would like to turn down the frequency of renovate pull requests.

Every four weeks on Monday:
* patch versions
* digests
* ruby 
* minor updates

Every two weeks on Monday:
* major version updates

Every Monday:
* actions/setup-node, ruby/setup-ruby (to make sure we're testing against the latest Ruby versions)

Every Tuesday:
* lock file maintenance