### PR TITLE
fix(grape): detect code namespace for API instance endpoints

### DIFF
--- a/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
+++ b/instrumentation/grape/lib/opentelemetry/instrumentation/grape/event_handler.rb
@@ -67,10 +67,12 @@ module OpenTelemetry
           end
 
           def attributes_from_grape_endpoint(endpoint)
-            {
-              OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE => endpoint.options[:for]&.instance_variable_get(:@base)&.to_s,
+            attributes = {
               OpenTelemetry::SemanticConventions::Trace::HTTP_ROUTE => path(endpoint)
             }
+            code_namespace = code_namespace(endpoint)
+            attributes[OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE] = code_namespace if code_namespace
+            attributes
           end
 
           # ActiveSupport::Notifications will attach a `:exception_object` to the payload if there was
@@ -87,6 +89,14 @@ module OpenTelemetry
 
           def request_method(endpoint)
             endpoint.options[:method]&.first
+          end
+
+          def code_namespace(endpoint)
+            owner = endpoint.options[:for]
+            return unless owner
+
+            base = owner.instance_variable_get(:@base)
+            [owner.name, base&.to_s, owner.to_s].find { |value| value && !value.empty? }
           end
 
           def path(endpoint)

--- a/instrumentation/grape/test/opentelemetry/instrumentation/grape_test.rb
+++ b/instrumentation/grape/test/opentelemetry/instrumentation/grape_test.rb
@@ -75,6 +75,27 @@ describe OpenTelemetry::Instrumentation::Grape do
       end
     end
 
+    describe 'when a Grape::API::Instance endpoint receives a request' do
+      class InstanceAPI < Grape::API::Instance
+        format :json
+        get :hello do
+          { message: 'Hello, world!' }
+        end
+      end
+
+      let(:app) { build_rack_app(InstanceAPI) }
+      let(:request_path) { '/hello' }
+      let(:expected_span_name) { 'GET /hello' }
+
+      before { app.get request_path }
+
+      it 'sets code.namespace from the endpoint class name' do
+        _(span.name).must_equal expected_span_name
+        _(span.attributes['code.namespace']).must_equal 'InstanceAPI'
+        _(span.attributes['http.route']).must_equal '/hello'
+      end
+    end
+
     describe 'when an API endpoint with a route param receives a request' do
       class RouteParamAPI < Grape::API
         format :json


### PR DESCRIPTION
Direct `Grape::API::Instance` subclasses expose `endpoint.options[:for]` as the endpoint class itself rather than a generated mount instance with `@base` set. The previous instrumentation only read `@base`, which produced nil and caused the SDK to log invalid `code.namespace` attribute value errors.

We're subclassing `Grape::API::Instance` directly because we're using Sorbet in our Rails app, with our `grape_sorbet` gem for the signatures. The reason it works this way is documented here: https://github.com/thatch-health/grape_sorbet#subclassing-from-grapeapiinstance-instead-of-grapeapi