### PR TITLE
chore: Move Ariel to Emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 
 ### Maintainers
 
-- [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Daniel Azuma](https://github.com/dazuma), Google
 - [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 - [Robb Kidd](https://github.com/robbkidd), Honeycomb
@@ -49,6 +48,7 @@ For more information about the approver role, see the [community repository](htt
 
 ### Emeritus
 
+- [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Andrew Hayworth](https://github.com/ahayworth), Maintainer
 - [Eric Mustin](https://github.com/ericmustin), Maintainer
 - [Francis Bogsanyi](https://github.com/fbogsany), Maintainer


### PR DESCRIPTION
I will no longer be able to dedicate time to the project and am shifting my role to emeritus maintainer.

Thank you for all of your support!