### PR TITLE
feat(pg): add returned and affected rows attributes

### DIFF
--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -64,7 +64,12 @@ OpenTelemetry::SDK.configure do |c|
     # `db.response.returned_rows` semantic attribute. Set this option to true
     # to include the number of rows returned by the database operation when
     # available from PG::Result.
-    db_response_returned_rows: true
+    db_response_returned_rows: true,
+
+    # By default, this instrumentation does not emit the `db.response.affected_rows`
+    # attribute. Set this option to true to include the number of rows affected
+    # by mutation operations when available from PG::Result.
+    db_response_affected_rows: true
   }
 end
 ```

--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -58,7 +58,13 @@ OpenTelemetry::SDK.configure do |c|
     # When `db_statement` is enabled, this instrumentation obfuscates SQL queries. By default, it
     # obfuscates queries up to 2000 characters. You can override the default with a different
     # `obfuscation_limit`, but higher values may impact performance.
-    obfuscation_limit: 2000
+    obfuscation_limit: 2000,
+
+    # By default, this instrumentation does not emit the opt-in
+    # `db.response.returned_rows` semantic attribute. Set this option to true
+    # to include the number of rows returned by the database operation when
+    # available from PG::Result.
+    db_response_returned_rows: true
   }
 end
 ```

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -30,6 +30,7 @@ module OpenTelemetry
         option :obfuscation_limit, default: 2000, validate: :integer
         option :propagator, default: 'none', validate: %w[none tracecontext]
         option :db_response_returned_rows, default: false, validate: :boolean
+        option :db_response_affected_rows, default: false, validate: :boolean
 
         attr_reader :propagator
 

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -29,6 +29,7 @@ module OpenTelemetry
         option :db_statement, default: :obfuscate, validate: %I[omit include obfuscate]
         option :obfuscation_limit, default: 2000, validate: :integer
         option :propagator, default: 'none', validate: %w[none tracecontext]
+        option :db_response_returned_rows, default: false, validate: :boolean
 
         attr_reader :propagator
 

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -79,7 +79,7 @@ module OpenTelemetry
           PG::Constants::EXEC_ISH_METHODS.each do |method|
             define_method method do |*args, &block|
               span_name, attrs = span_attrs(:query, *args)
-              tracer.in_span(span_name, attributes: attrs, kind: :client) do |_span, context|
+              tracer.in_span(span_name, attributes: attrs, kind: :client) do |span, context|
                 # Inject propagator context into SQL if propagator is configured
                 if propagator && args[0].is_a?(String)
                   sql = args[0]
@@ -93,10 +93,14 @@ module OpenTelemetry
                   end
                 end
 
+                result = super(*args)
+                response_attrs = db_response_attributes(result, attrs)
+                span.add_attributes(response_attrs) unless response_attrs.empty?
+
                 if block
-                  block.call(super(*args))
+                  block.call(result)
                 else
-                  super(*args)
+                  result
                 end
               end
             end
@@ -105,7 +109,7 @@ module OpenTelemetry
           PG::Constants::PREPARE_ISH_METHODS.each do |method|
             define_method method do |*args|
               span_name, attrs = span_attrs(:prepare, *args)
-              tracer.in_span(span_name, attributes: attrs, kind: :client) do |_span, context|
+              tracer.in_span(span_name, attributes: attrs, kind: :client) do |span, context|
                 # Inject propagator context into SQL if propagator is configured
                 # For prepare, the SQL is in args[1]
                 if propagator && args[1].is_a?(String)
@@ -120,7 +124,10 @@ module OpenTelemetry
                   end
                 end
 
-                super(*args)
+                result = super(*args)
+                response_attrs = db_response_attributes(result, attrs)
+                span.add_attributes(response_attrs) unless response_attrs.empty?
+                result
               end
             end
           end
@@ -128,11 +135,15 @@ module OpenTelemetry
           PG::Constants::EXEC_PREPARED_ISH_METHODS.each do |method|
             define_method method do |*args, &block|
               span_name, attrs = span_attrs(:execute, *args)
-              tracer.in_span(span_name, attributes: attrs, kind: :client) do
+              tracer.in_span(span_name, attributes: attrs, kind: :client) do |span|
+                result = super(*args)
+                response_attrs = db_response_attributes(result, attrs)
+                span.add_attributes(response_attrs) unless response_attrs.empty?
+
                 if block
-                  block.call(super(*args))
+                  block.call(result)
                 else
-                  super(*args)
+                  result
                 end
               end
             end
@@ -156,6 +167,22 @@ module OpenTelemetry
 
           def config
             PG::Instrumentation.instance.config
+          end
+
+          def db_response_attributes(result, span_attrs)
+            attrs = {}
+            attrs['db.response.returned_rows'] = result.ntuples if db_response_returned_rows?(span_attrs)
+            attrs
+          rescue StandardError => e
+            OpenTelemetry.handle_error(message: 'Error setting DB response attributes', exception: e)
+            {}
+          end
+
+          def db_response_returned_rows?(attrs)
+            return false unless config[:db_response_returned_rows]
+            return false if attrs.key?('db.response.returned_rows')
+
+            true
           end
 
           def lru_cache

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -73,6 +73,8 @@ module OpenTelemetry
 
         # Module to prepend to PG::Connection for instrumentation
         module Connection # rubocop:disable Metrics/ModuleLength
+          AFFECTED_ROWS_COMMANDS = %w[DELETE INSERT MERGE UPDATE].freeze
+
           # Capture the first word (including letters, digits, underscores, & '.', ) that follows common table commands
           TABLE_NAME = /\b(?:FROM|INTO|UPDATE|CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|DROP\s+TABLE(?:\s+IF\s+EXISTS)?|ALTER\s+TABLE(?:\s+IF\s+EXISTS)?)\s+"?([\w\.]+)"?/i
 
@@ -172,6 +174,7 @@ module OpenTelemetry
           def db_response_attributes(result, span_attrs)
             attrs = {}
             attrs['db.response.returned_rows'] = result.ntuples if db_response_returned_rows?(span_attrs)
+            attrs['db.response.affected_rows'] = result.cmd_tuples if db_response_affected_rows?(result, span_attrs)
             attrs
           rescue StandardError => e
             OpenTelemetry.handle_error(message: 'Error setting DB response attributes', exception: e)
@@ -181,6 +184,14 @@ module OpenTelemetry
           def db_response_returned_rows?(attrs)
             return false unless config[:db_response_returned_rows]
             return false if attrs.key?('db.response.returned_rows')
+
+            true
+          end
+
+          def db_response_affected_rows?(result, attrs)
+            return false unless config[:db_response_affected_rows]
+            return false if attrs.key?('db.response.affected_rows')
+            return false unless AFFECTED_ROWS_COMMANDS.include?(result.cmd_status.to_s.split.first)
 
             true
           end

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -200,7 +200,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[exec query sync_exec async_exec].each do |method|
+    PG_QUERY_METHODS.each do |method|
       it "after request (with method: #{method})" do
         client.send(method, 'SELECT 1')
 
@@ -211,6 +211,57 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(last_span.attributes['db.operation']).must_equal 'SELECT'
         _(last_span.attributes['net.peer.name']).must_equal host.to_s
         _(last_span.attributes['net.peer.port']).must_equal port.to_i
+      end
+    end
+
+    it 'does not include db.response.returned_rows by default' do
+      client.exec('SELECT * FROM (VALUES (1), (2)) AS t(id)')
+
+      _(last_span.attributes['db.response.returned_rows']).must_be_nil
+    end
+
+    describe 'when db_response_returned_rows is enabled' do
+      let(:config) { { db_statement: :include, db_response_returned_rows: true } }
+
+      PG_QUERY_METHODS.each do |method|
+        it "sets db.response.returned_rows after request (with method: #{method})" do
+          client.send(method, 'SELECT * FROM (VALUES (1), (2)) AS t(id)')
+
+          _(last_span.attributes['db.response.returned_rows']).must_equal 2
+        end
+      end
+
+      %i[exec_params async_exec_params sync_exec_params].each do |method|
+        it "sets db.response.returned_rows after request (with method: #{method})" do
+          client.send(method, 'SELECT * FROM (VALUES ($1), ($2)) AS t(id)', [1, 2])
+
+          _(last_span.attributes['db.response.returned_rows']).must_equal 2
+        end
+      end
+
+      %i[prepare async_prepare sync_prepare].each do |method|
+        it "sets db.response.returned_rows after preparing a statement (with method: #{method})" do
+          client.send(method, 'foo', 'SELECT $1 AS a')
+
+          _(last_span.attributes['db.response.returned_rows']).must_equal 0
+        end
+      end
+
+      %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
+        it "sets db.response.returned_rows after executing prepared statement (with method: #{method})" do
+          client.prepare('foo', 'SELECT * FROM (VALUES ($1), ($2)) AS t(id)')
+          client.send(method, 'foo', [1, 2])
+
+          _(last_span.attributes['db.response.returned_rows']).must_equal 2
+        end
+      end
+
+      it 'does not overwrite db.response.returned_rows from with_attributes' do
+        OpenTelemetry::Instrumentation::PG.with_attributes('db.response.returned_rows' => 99) do
+          client.exec('SELECT * FROM (VALUES (1), (2)) AS t(id)')
+        end
+
+        _(last_span.attributes['db.response.returned_rows']).must_equal 99
       end
     end
 
@@ -259,7 +310,7 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
-    %i[exec query sync_exec async_exec].each do |method|
+    PG_QUERY_METHODS.each do |method|
       it "after request using Arel (with method: #{method})" do
         client.send(method, Arel.sql('SELECT 1'))
 

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -60,6 +60,10 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       instrumentation.install(config)
     end
 
+    def create_temp_table
+      client.exec('CREATE TEMP TABLE otel_affected_rows (id int)')
+    end
+
     it 'before request' do
       _(exporter.finished_spans.size).must_equal 0
     end
@@ -220,6 +224,13 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       _(last_span.attributes['db.response.returned_rows']).must_be_nil
     end
 
+    it 'does not include db.response.affected_rows by default' do
+      create_temp_table
+      client.exec('INSERT INTO otel_affected_rows (id) VALUES (1), (2), (3)')
+
+      _(last_span.attributes['db.response.affected_rows']).must_be_nil
+    end
+
     describe 'when db_response_returned_rows is enabled' do
       let(:config) { { db_statement: :include, db_response_returned_rows: true } }
 
@@ -262,6 +273,60 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         end
 
         _(last_span.attributes['db.response.returned_rows']).must_equal 99
+      end
+    end
+
+    describe 'when db_response_affected_rows is enabled' do
+      let(:config) { { db_statement: :include, db_response_affected_rows: true } }
+
+      it 'does not set db.response.affected_rows for SELECT statements' do
+        client.exec('SELECT * FROM (VALUES (1), (2)) AS t(id)')
+
+        _(last_span.attributes['db.response.affected_rows']).must_be_nil
+      end
+
+      PG_QUERY_METHODS.each do |method|
+        it "sets db.response.affected_rows after request (with method: #{method})" do
+          create_temp_table
+          client.send(method, 'INSERT INTO otel_affected_rows (id) VALUES (1), (2), (3)')
+
+          _(last_span.attributes['db.response.affected_rows']).must_equal 3
+        end
+      end
+
+      %i[exec_params async_exec_params sync_exec_params].each do |method|
+        it "sets db.response.affected_rows after request (with method: #{method})" do
+          create_temp_table
+          client.send(method, 'INSERT INTO otel_affected_rows (id) VALUES ($1), ($2), ($3)', [1, 2, 3])
+
+          _(last_span.attributes['db.response.affected_rows']).must_equal 3
+        end
+      end
+
+      it 'sets db.response.affected_rows for mutations that affect zero rows' do
+        create_temp_table
+        client.exec('UPDATE otel_affected_rows SET id = id WHERE id < 0')
+
+        _(last_span.attributes['db.response.affected_rows']).must_equal 0
+      end
+
+      %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
+        it "sets db.response.affected_rows after executing prepared statement (with method: #{method})" do
+          create_temp_table
+          client.prepare('foo', 'INSERT INTO otel_affected_rows (id) VALUES ($1), ($2), ($3)')
+          client.send(method, 'foo', [1, 2, 3])
+
+          _(last_span.attributes['db.response.affected_rows']).must_equal 3
+        end
+      end
+
+      it 'does not overwrite db.response.affected_rows from with_attributes' do
+        create_temp_table
+        OpenTelemetry::Instrumentation::PG.with_attributes('db.response.affected_rows' => 99) do
+          client.exec('INSERT INTO otel_affected_rows (id) VALUES (1), (2), (3)')
+        end
+
+        _(last_span.attributes['db.response.affected_rows']).must_equal 99
       end
     end
 

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/patches/connection_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/patches/connection_test.rb
@@ -30,7 +30,7 @@ describe OpenTelemetry::Instrumentation::PG::Patches do
   end
 
   describe 'patched PG::Connection' do
-    %i[exec query sync_exec async_exec].each do |method|
+    PG_QUERY_METHODS.each do |method|
       describe "method #{method}" do
         it 'responds with expected values when called with a block' do
           values = client.send(method, 'SELECT 1') { |result| result.column_values(0) }

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'minitest/autorun'
 
 # global opentelemetry-sdk setup:
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+PG_QUERY_METHODS = %i[exec query sync_exec async_exec].freeze
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|


### PR DESCRIPTION
Postgres counterpart of the MySQL Trilogy adapter: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1290

A semconv proposal for affected_rows is open at https://github.com/open-telemetry/semantic-conventions/issues/3094 (and already added for Azure Cosmos specifically). I've added it as a separate commit so it can be dropped if the maintainers prefer to wait for that go through the process, but IMO it's very useful to have. I'm using the `AFFECTED_ROWS_COMMANDS` array because cmd_tuples [always returns an integer](https://github.com/ged/ruby-pg/blob/633e16f9cde849976d6a235767423d19186a6b28/ext/pg_result.c#L1102-L1128), also for commands outside of the proposal's definition, and defaults to 0. An alternative would be to pass through the value from the `pg` gem unaltered, like [Active Record does](https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L174-L175).