### PR TITLE
chore: Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @dazuma @arielvalentin @robbkidd @simi @kaylareopelle @xuan-cao-swi @hannahramadan @thompson-tomo
+* @open-telemetry/ruby-contrib-maintainers @open-telemetry/ruby-contrib-approvers @dazuma @robbkidd @simi @kaylareopelle @xuan-cao-swi @hannahramadan @thompson-tomo


### PR DESCRIPTION
Remove @arielvalentin from CODEOWNERS to reflect his emeritus status 😭 