### PR TITLE
fix: ensure valid json message attribute value

### DIFF
--- a/instrumentation/net_ldap/.github-ci.yml
+++ b/instrumentation/net_ldap/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  unsupported_interpreters: jruby

--- a/instrumentation/net_ldap/lib/opentelemetry/instrumentation/net/ldap/instrumentation_service.rb
+++ b/instrumentation/net_ldap/lib/opentelemetry/instrumentation/net/ldap/instrumentation_service.rb
@@ -32,7 +32,8 @@ module OpenTelemetry
               'ldap.auth.username' => auth[:username].to_s,
               'ldap.operation.type' => operation_type,
               'ldap.request.message' => begin
-                payload.to_json
+                raw = payload.to_json
+                utf8_clean?(raw) ? raw : nil
               rescue JSON::GeneratorError
                 nil
               end,
@@ -98,6 +99,19 @@ module OpenTelemetry
             return if ::Net::LDAP::ResultCodesNonError.include?(status_code)
 
             span.status = OpenTelemetry::Trace::Status.error
+          end
+
+          def utf8_clean?(value)
+            case value
+            when String
+              value.scrub == value
+            when Hash
+              value.all? { |k, v| utf8_clean?(k) && utf8_clean?(v) }
+            when Array
+              value.all? { |v| utf8_clean?(v) }
+            else
+              true
+            end
           end
         end
       end

--- a/instrumentation/net_ldap/lib/opentelemetry/instrumentation/net/ldap/instrumentation_service.rb
+++ b/instrumentation/net_ldap/lib/opentelemetry/instrumentation/net/ldap/instrumentation_service.rb
@@ -33,7 +33,7 @@ module OpenTelemetry
               'ldap.operation.type' => operation_type,
               'ldap.request.message' => begin
                 raw = payload.to_json
-                utf8_clean?(raw) ? raw : nil
+                raw.scrub == raw ? raw : nil
               rescue JSON::GeneratorError
                 nil
               end,
@@ -99,19 +99,6 @@ module OpenTelemetry
             return if ::Net::LDAP::ResultCodesNonError.include?(status_code)
 
             span.status = OpenTelemetry::Trace::Status.error
-          end
-
-          def utf8_clean?(value)
-            case value
-            when String
-              value.scrub == value
-            when Hash
-              value.all? { |k, v| utf8_clean?(k) && utf8_clean?(v) }
-            when Array
-              value.all? { |v| utf8_clean?(v) }
-            else
-              true
-            end
           end
         end
       end


### PR DESCRIPTION
This ensures that the message attribute is consistently encoded across jruby and ruby.

This is achieved by adding a value check for the message value which is automatically done on ruby but not jruby.