### PR TITLE
feat: Extend rake span representation

### DIFF
--- a/instrumentation/rake/lib/opentelemetry/instrumentation/rake/instrumentation.rb
+++ b/instrumentation/rake/lib/opentelemetry/instrumentation/rake/instrumentation.rb
@@ -24,6 +24,8 @@ module OpenTelemetry
           gem_version >= MINIMUM_VERSION
         end
 
+        option :span_name, default: :execution_type_only, validate: %I[execution_type_only execution_type_and_task_name]
+
         private
 
         def gem_version

--- a/instrumentation/rake/lib/opentelemetry/instrumentation/rake/patches/task.rb
+++ b/instrumentation/rake/lib/opentelemetry/instrumentation/rake/patches/task.rb
@@ -7,7 +7,8 @@ module OpenTelemetry
         # Module to prepend to Rask::Task for instrumentation
         module Task
           def invoke(*args)
-            tracer.in_span('rake.invoke', attributes: { 'rake.task' => name, 'rake.execution.type' => 'invoke' }) do
+            span_name = rake_span_name('invoke', name)
+            tracer.in_span(span_name, attributes: { 'rake.task' => name, 'rake.execution.type' => 'invoke' }) do
               super
             end
           ensure
@@ -15,7 +16,8 @@ module OpenTelemetry
           end
 
           def execute(args = nil)
-            tracer.in_span('rake.execute', attributes: { 'rake.task' => name, 'rake.execution.type' => 'execute' }) do
+            span_name = rake_span_name('execute', name)
+            tracer.in_span(span_name, attributes: { 'rake.task' => name, 'rake.execution.type' => 'execute' }) do
               super
             end
           ensure
@@ -26,6 +28,18 @@ module OpenTelemetry
 
           def tracer
             Rake::Instrumentation.instance.tracer
+          end
+
+          def config
+            OpenTelemetry::Instrumentation::Rake::Instrumentation.instance.config
+          end
+
+          def rake_span_name(execution_type, task_name)
+            if config[:span_name] == :execution_type_and_task_name
+              "rake.#{execution_type} #{task_name}"
+            else
+              "rake.#{execution_type}"
+            end
           end
 
           def force_flush

--- a/instrumentation/rake/lib/opentelemetry/instrumentation/rake/patches/task.rb
+++ b/instrumentation/rake/lib/opentelemetry/instrumentation/rake/patches/task.rb
@@ -7,7 +7,7 @@ module OpenTelemetry
         # Module to prepend to Rask::Task for instrumentation
         module Task
           def invoke(*args)
-            tracer.in_span('rake.invoke', attributes: { 'rake.task' => name }) do
+            tracer.in_span('rake.invoke', attributes: { 'rake.task' => name, 'rake.execution.type' => 'invoke' }) do
               super
             end
           ensure
@@ -15,7 +15,7 @@ module OpenTelemetry
           end
 
           def execute(args = nil)
-            tracer.in_span('rake.execute', attributes: { 'rake.task' => name }) do
+            tracer.in_span('rake.execute', attributes: { 'rake.task' => name, 'rake.execution.type' => 'execute' }) do
               super
             end
           ensure

--- a/instrumentation/rake/test/opentelemetry/instrumentation/rake/patches/task_test.rb
+++ b/instrumentation/rake/test/opentelemetry/instrumentation/rake/patches/task_test.rb
@@ -17,12 +17,16 @@ describe OpenTelemetry::Instrumentation::Rake::Patches::Task do
   let(:task_name) { :test_rake_instrumentation }
   let(:task) { Rake::Task[task_name] }
 
-  let(:invoke_span) { spans.find { |s| s.name == 'rake.invoke' } }
-  let(:execute_span) { spans.find { |s| s.name == 'rake.execute' && s.attributes['rake.task'] == task_name.to_s } }
+  let(:invoke_span) { spans.find { |s| s.name.start_with?('rake.invoke') } }
+  let(:execute_span) { spans.find { |s| s.name.start_with?('rake.execute') && s.attributes['rake.task'] == task_name.to_s } }
+  let(:rake_span) { spans.find { |s| s.attributes.key?('rake.task') } }
+  let(:config) { {} }
 
   before do
     exporter.reset
-    instrumentation.install
+    # simulate a fresh install:
+    instrumentation.instance_variable_set(:@installed, false)
+    instrumentation.install(config)
 
     Rake::Task.define_task(task_name)
     task.reenable
@@ -37,6 +41,22 @@ describe OpenTelemetry::Instrumentation::Rake::Patches::Task do
       _(execute_span.kind).must_equal :internal
       _(execute_span.name).must_equal 'rake.execute'
       _(execute_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
+      _(execute_span.attributes['rake.execution.type']).must_equal 'execute'
+    end
+
+    describe 'with execution_type_and_task_name span_name' do
+      let(:config) { { span_name: :execution_type_and_task_name } }
+
+      it 'creates a properly named span' do
+        task.execute
+
+        _(spans.size).must_equal 1
+
+        _(rake_span.kind).must_equal :internal
+        _(rake_span.name).must_equal 'rake.execute test_rake_instrumentation'
+        _(rake_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
+        _(rake_span.attributes['rake.execution.type']).must_equal 'execute'
+      end
     end
   end
 
@@ -54,6 +74,42 @@ describe OpenTelemetry::Instrumentation::Rake::Patches::Task do
       _(execute_span.name).must_equal 'rake.execute'
       _(execute_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
       _(execute_span.parent_span_id).must_equal(invoke_span.span_id)
+    end
+
+    describe 'with execution_type_and_task_name span_name' do
+      let(:config) { { span_name: :execution_type_and_task_name } }
+
+      it 'create properly named spans' do
+        task.invoke
+
+        _(spans.size).must_equal 2
+
+        _(invoke_span.kind).must_equal :internal
+        _(invoke_span.name).must_equal 'rake.invoke test_rake_instrumentation'
+        _(invoke_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
+        _(invoke_span.attributes['rake.execution.type']).must_equal 'invoke'
+
+        _(execute_span.kind).must_equal :internal
+        _(execute_span.name).must_equal 'rake.execute test_rake_instrumentation'
+        _(execute_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
+        _(execute_span.attributes['rake.execution.type']).must_equal 'execute'
+        _(execute_span.parent_span_id).must_equal(invoke_span.span_id)
+      end
+    end
+
+    describe 'with execution_type_and_task_name span_name' do
+      let(:config) { { span_name: :execution_type_and_task_name } }
+
+      it 'creates a properly named span' do
+        task.execute
+
+        _(spans.size).must_equal 1
+
+        _(rake_span.kind).must_equal :internal
+        _(rake_span.name).must_equal 'rake.execute test_rake_instrumentation'
+        _(rake_span.attributes['rake.task']).must_equal 'test_rake_instrumentation'
+        _(rake_span.attributes['rake.execution.type']).must_equal 'execute'
+      end
     end
 
     describe 'with a task argument' do


### PR DESCRIPTION
During our adoption of OpenTelemetry we noticed that the Span Names weren't exactly useful as primary filters for Rake Tasks, due to them only including `rake.execute` or `rake.invoke` respectively. When generating Span Metrics from them we cannot easily distinguish between them without extracting the `rake.task` attribute.

This PR does the following:

* Adds a `rake.execution.type` attribute, which is either `execute` or `invoke` depending on the span
* Adds a `span_name` option to the instrumentation to enable consumers to switch to a `execution_type_and_task_name` span name.