### PR TITLE
fix: Use last in, first out Rack context stack

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/dup/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/dup/event_handler.rb
@@ -62,7 +62,7 @@ module OpenTelemetry
               span = create_span(parent_context, request)
               span_ctx = OpenTelemetry::Trace.context_with_span(span, parent_context: parent_context)
               rack_ctx = OpenTelemetry::Instrumentation::Rack.context_with_span(span, parent_context: span_ctx)
-              request.env[OTEL_TOKEN_AND_SPAN] = [OpenTelemetry::Context.attach(rack_ctx), span]
+              (request.env[OTEL_TOKEN_AND_SPAN] ||= []) << [OpenTelemetry::Context.attach(rack_ctx), span]
             rescue StandardError => e
               OpenTelemetry.handle_error(exception: e)
             end
@@ -209,9 +209,10 @@ module OpenTelemetry
             end
 
             def detach_context(request)
-              return nil unless request.env[OTEL_TOKEN_AND_SPAN]
+              stack = request.env[OTEL_TOKEN_AND_SPAN]
+              return nil if stack.nil? || stack.empty?
 
-              token, span = request.env[OTEL_TOKEN_AND_SPAN]
+              token, span = stack.pop
               span.finish
               OpenTelemetry::Context.detach(token)
             rescue StandardError => e

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/old/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/old/event_handler.rb
@@ -62,7 +62,7 @@ module OpenTelemetry
               span = create_span(parent_context, request)
               span_ctx = OpenTelemetry::Trace.context_with_span(span, parent_context: parent_context)
               rack_ctx = OpenTelemetry::Instrumentation::Rack.context_with_span(span, parent_context: span_ctx)
-              request.env[OTEL_TOKEN_AND_SPAN] = [OpenTelemetry::Context.attach(rack_ctx), span]
+              (request.env[OTEL_TOKEN_AND_SPAN] ||= []) << [OpenTelemetry::Context.attach(rack_ctx), span]
             rescue StandardError => e
               OpenTelemetry.handle_error(exception: e)
             end
@@ -198,9 +198,10 @@ module OpenTelemetry
             end
 
             def detach_context(request)
-              return nil unless request.env[OTEL_TOKEN_AND_SPAN]
+              stack = request.env[OTEL_TOKEN_AND_SPAN]
+              return nil if stack.nil? || stack.empty?
 
-              token, span = request.env[OTEL_TOKEN_AND_SPAN]
+              token, span = stack.pop
               span.finish
               OpenTelemetry::Context.detach(token)
             rescue StandardError => e

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/stable/event_handler.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/stable/event_handler.rb
@@ -62,7 +62,7 @@ module OpenTelemetry
               span = create_span(parent_context, request)
               span_ctx = OpenTelemetry::Trace.context_with_span(span, parent_context: parent_context)
               rack_ctx = OpenTelemetry::Instrumentation::Rack.context_with_span(span, parent_context: span_ctx)
-              request.env[OTEL_TOKEN_AND_SPAN] = [OpenTelemetry::Context.attach(rack_ctx), span]
+              (request.env[OTEL_TOKEN_AND_SPAN] ||= []) << [OpenTelemetry::Context.attach(rack_ctx), span]
             rescue StandardError => e
               OpenTelemetry.handle_error(exception: e)
             end
@@ -197,9 +197,10 @@ module OpenTelemetry
             end
 
             def detach_context(request)
-              return nil unless request.env[OTEL_TOKEN_AND_SPAN]
+              stack = request.env[OTEL_TOKEN_AND_SPAN]
+              return nil if stack.nil? || stack.empty?
 
-              token, span = request.env[OTEL_TOKEN_AND_SPAN]
+              token, span = stack.pop
               span.finish
               OpenTelemetry::Context.detach(token)
             rescue StandardError => e

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/dup/event_handler_test.rb
@@ -508,4 +508,38 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::EventHandler' 
       _(proxy_event).must_be_nil
     end
   end
+
+  # This might happen if one Sinatra app is called by another
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when nested inside another instance of this EventHandler on the same env' do
+    let(:inner_handler) { OpenTelemetry::Instrumentation::Rack::Middlewares::Dup::EventHandler.new }
+    let(:inner_app) do
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [inner_handler]
+        builder.run service
+      end
+    end
+    let(:app) do
+      inner = inner_app
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [handler]
+        builder.run inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces two correctly nested spans' do
+      expect(OpenTelemetry).not_to receive(:handle_error)
+
+      get uri, {}, headers
+
+      _(finished_spans.size).must_equal 2
+
+      outer_span = finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/old/event_handler_test.rb
@@ -483,4 +483,38 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler' 
       _(proxy_event).must_be_nil
     end
   end
+
+  # This might happen if one Sinatra app is called by another
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when nested inside another instance of this EventHandler on the same env' do
+    let(:inner_handler) { OpenTelemetry::Instrumentation::Rack::Middlewares::Old::EventHandler.new }
+    let(:inner_app) do
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [inner_handler]
+        builder.run service
+      end
+    end
+    let(:app) do
+      inner = inner_app
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [handler]
+        builder.run inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces two correctly nested spans' do
+      expect(OpenTelemetry).not_to receive(:handle_error)
+
+      get uri, {}, headers
+
+      _(finished_spans.size).must_equal 2
+
+      outer_span = finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/stable/event_handler_test.rb
@@ -479,4 +479,38 @@ describe 'OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandle
       _(proxy_event).must_be_nil
     end
   end
+
+  # This might happen if one Sinatra app is called by another
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when nested inside another instance of this EventHandler on the same env' do
+    let(:inner_handler) { OpenTelemetry::Instrumentation::Rack::Middlewares::Stable::EventHandler.new }
+    let(:inner_app) do
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [inner_handler]
+        builder.run service
+      end
+    end
+    let(:app) do
+      inner = inner_app
+      Rack::Builder.new.tap do |builder|
+        builder.use Rack::Events, [handler]
+        builder.run inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces two correctly nested spans' do
+      expect(OpenTelemetry).not_to receive(:handle_error)
+
+      get uri, {}, headers
+
+      _(finished_spans.size).must_equal 2
+
+      outer_span = finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_dup_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_dup_http_test.rb
@@ -252,4 +252,40 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       end
     end
   end
+
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when a Sinatra app uses another Sinatra app as middleware' do
+    let(:inner_app) do
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        get '/nested' do
+          'inner'
+        end
+      end
+    end
+
+    let(:app) do
+      inner = inner_app
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        use inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces a correctly nested trace' do
+      get '/nested'
+
+      _(last_response.status).must_equal 200
+      _(last_response.body).must_equal 'inner'
+
+      _(exporter.finished_spans.size).must_equal 2
+
+      outer_span = exporter.finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = exporter.finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_old_http_test.rb
@@ -231,4 +231,40 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       end
     end
   end
+
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when a Sinatra app uses another Sinatra app as middleware' do
+    let(:inner_app) do
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        get '/nested' do
+          'inner'
+        end
+      end
+    end
+
+    let(:app) do
+      inner = inner_app
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        use inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces a correctly nested trace' do
+      get '/nested'
+
+      _(last_response.status).must_equal 200
+      _(last_response.body).must_equal 'inner'
+
+      _(exporter.finished_spans.size).must_equal 2
+
+      outer_span = exporter.finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = exporter.finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_stable_http_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_stable_http_test.rb
@@ -226,4 +226,40 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       end
     end
   end
+
+  # See: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2425
+  describe 'when a Sinatra app uses another Sinatra app as middleware' do
+    let(:inner_app) do
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        get '/nested' do
+          'inner'
+        end
+      end
+    end
+
+    let(:app) do
+      inner = inner_app
+      Class.new(Sinatra::Base) do
+        set :raise_errors, false
+        use inner
+      end
+    end
+
+    it 'does not raise attach/detach errors and produces a correctly nested trace' do
+      get '/nested'
+
+      _(last_response.status).must_equal 200
+      _(last_response.body).must_equal 'inner'
+
+      _(exporter.finished_spans.size).must_equal 2
+
+      outer_span = exporter.finished_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+      inner_span = exporter.finished_spans.find { |s| s.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID }
+
+      _(outer_span).wont_be_nil
+      _(inner_span).wont_be_nil
+      _(inner_span.parent_span_id).must_equal outer_span.span_id
+    end
+  end
 end


### PR DESCRIPTION
This resolves #2425, where the SDK would throw errors when using multiple, nested Sinatra app classes.

This was caused because the Rack env hash only had a single slot for context. When multiple Rack apps existed in the same env, the nested app's call to on_start would overwrite the context token, removing the context for the outer app. When #finish was eventually called the "Calling finish" and "detach should match" errors would be raised and the parent span would disappear.

Now, the context lives in an array, so the most recent context received in the env will be the first one finished.