### PR TITLE
feat(pg): add untraced queries option

### DIFF
--- a/instrumentation/pg/README.md
+++ b/instrumentation/pg/README.md
@@ -69,7 +69,11 @@ OpenTelemetry::SDK.configure do |c|
     # By default, this instrumentation does not emit the `db.response.affected_rows`
     # attribute. Set this option to true to include the number of rows affected
     # by mutation operations when available from PG::Result.
-    db_response_affected_rows: true
+    db_response_affected_rows: true,
+
+    # Queries matching any String or Regexp in this array will not create spans or have
+    # trace context propagated. This can suppress Active Record’s PostgreSQLAdapter#active? check.
+    untraced_queries: [';']
   }
 end
 ```

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -31,6 +31,9 @@ module OpenTelemetry
         option :propagator, default: 'none', validate: %w[none tracecontext]
         option :db_response_returned_rows, default: false, validate: :boolean
         option :db_response_affected_rows, default: false, validate: :boolean
+        # If a query matches any String or Regexp in this array, the
+        # instrumentation will not record a client span or propagate context.
+        option :untraced_queries, default: [], validate: :array
 
         attr_reader :propagator
 

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/patches/connection.rb
@@ -80,6 +80,12 @@ module OpenTelemetry
 
           PG::Constants::EXEC_ISH_METHODS.each do |method|
             define_method method do |*args, &block|
+              if untraced_query?(args[0])
+                return block.call(super(*args)) if block
+
+                return super(*args)
+              end
+
               span_name, attrs = span_attrs(:query, *args)
               tracer.in_span(span_name, attributes: attrs, kind: :client) do |span, context|
                 # Inject propagator context into SQL if propagator is configured
@@ -194,6 +200,16 @@ module OpenTelemetry
             return false unless AFFECTED_ROWS_COMMANDS.include?(result.cmd_status.to_s.split.first)
 
             true
+          end
+
+          def untraced_query?(query)
+            matchers = config[:untraced_queries]
+            return false if matchers.empty?
+
+            query = query.to_s
+            matchers.any? do |matcher|
+              matcher.is_a?(Regexp) ? matcher.match?(query) : matcher == query
+            end
           end
 
           def lru_cache

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -330,6 +330,34 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
       end
     end
 
+    describe 'untraced_queries option' do
+      let(:config) { { db_statement: :include, untraced_queries: [';', /\ASELECT 2\z/] } }
+
+      before do
+        client
+        exporter.reset
+      end
+
+      it 'does not create a span for a matching query' do
+        client.query(';')
+
+        _(exporter.finished_spans).must_be_empty
+      end
+
+      it 'does not create a span for a query matching a regexp' do
+        client.exec('SELECT 2')
+
+        _(exporter.finished_spans).must_be_empty
+      end
+
+      it 'creates a span for a non-matching query' do
+        client.exec('SELECT 1')
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(last_span.attributes['db.statement']).must_equal 'SELECT 1'
+      end
+    end
+
     %i[exec_params async_exec_params sync_exec_params].each do |method|
       it "after request (with method: #{method}) " do
         client.send(method, 'SELECT $1 AS a', [1])


### PR DESCRIPTION
During a recent SIG call it was brought up someone noticed a lot of `;` query spans, we saw the same in our telemetry. This PR adds an option (inspired by net-http `untraced_hosts`) to ignore this.

Edit: fixes https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/2422

## AI summary

- add an opt-in `untraced_queries` configuration option accepting strings and regular expressions
- execute matching queries without creating client spans or propagating trace context
- document suppressing Active Record’s `PostgreSQLAdapter#active?` check