### PR TITLE
ci: remove obsolete JRuby rbs workaround

### DIFF
--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -24,8 +24,6 @@ group :test do
   # Add jar-dependencies gem only if the Ruby runtime is JRuby
   # https://github.com/jruby/jruby/issues/7262
   gem 'jar-dependencies', '0.5.7', platforms: :jruby
-  # workaround for https://github.com/ruby/rdoc/issues/1746
-  gem 'rbs', '4.1.0', platforms: :jruby # TODO: remove once stable version is available
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -21,8 +21,6 @@ group :test do
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
   gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
-  # workaround for https://github.com/ruby/rdoc/issues/1746
-  gem 'rbs', '4.1.0', platforms: :jruby # TODO: remove once stable version is available
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -21,8 +21,6 @@ group :test do
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  # workaround for https://github.com/ruby/rdoc/issues/1746
-  gem 'rbs', '4.1.0', platforms: :jruby # TODO: remove once stable version is available
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -20,7 +20,6 @@ group :test do
   gem 'simplecov', '~> 1.0.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'rbs', '4.1.0', platforms: :jruby
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'

--- a/instrumentation/logger/Gemfile
+++ b/instrumentation/logger/Gemfile
@@ -25,8 +25,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  # workaround for https://github.com/ruby/rdoc/issues/1746
-  gem 'rbs', '4.1.0', platforms: :jruby # TODO: remove once stable version is available
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -31,8 +31,6 @@ group :test do
   gem 'opentelemetry-instrumentation-active_storage', path: '../active_storage'
   gem 'opentelemetry-instrumentation-action_view', path: '../action_view'
   gem 'opentelemetry-instrumentation-rack', path: '../rack'
-  # workaround for https://github.com/ruby/rdoc/issues/1746
-  gem 'rbs', '4.1.0', platforms: :jruby # TODO: remove once stable version is available
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'drb'


### PR DESCRIPTION
- https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2486#discussion_r3687541328