### PR TITLE
chore: Re-activate persist-credentials for release jobs

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -72,6 +72,7 @@ ignoreWords:
   - Dockerfiles
   - autodiscover
 words:
+  - artipacked
   - AWSXRayTrace
   - AWSXRaySamplingClient
   - AWSXRayRemoteSampler

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push release tags and gh-pages
+          persist-credentials: true
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push version/changelog updates when auto-requesting releases
+          persist-credentials: true
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push release tags and gh-pages
+          persist-credentials: true
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push version/changelog updates
+          persist-credentials: true
 
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push version/changelog updates
+          persist-credentials: true
 
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required to push release tags and gh-pages
+          persist-credentials: true
 
       - name: Install Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0


### PR DESCRIPTION
The zizmor change (#2462) broke the release jobs by withholding git credentials and preventing git pushes. This change explicitly grants those credentials. I believe I've included the needed "disable" comments, but someone with more knowledge of zizmor might need to review.