### PR TITLE
test: Enable renovate to manage appraisal dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,13 @@
       schedule: ["before 6am every weekday"],
     },
     {
+      groupName: "test dependencies [minor]",
+      matchUpdateTypes: ["minor"],
+      matchDatasources: ["rubygems"],
+      matchDepTypes: ["testDependency"],
+      schedule: ["before 7am on Monday"],
+    },
+    {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
       schedule: ["before 6am every weekday"],
@@ -132,6 +139,7 @@
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
         "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>.+\\s[0-9.]+)'",
+        "\\n\\s%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",
       versioningTemplate: "ruby",

--- a/instrumentation/grape/Appraisals
+++ b/instrumentation/grape/Appraisals
@@ -4,13 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0 3.1.0].each do |version|
+%w[1.8.0 2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0 3.1.0].each do |version|
   appraise "grape-#{version}" do
     gem 'grape', "~> #{version}"
   end
-end
-
-appraise 'grape-1.x' do
-  gem 'rack', '~> 2.0'
-  gem 'grape', '~> 1.8'
 end

--- a/instrumentation/grape/Appraisals
+++ b/instrumentation/grape/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0].each do |version|
+%w[2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0 3.1.0].each do |version|
   appraise "grape-#{version}" do
     gem 'grape', "~> #{version}"
   end
@@ -13,8 +13,4 @@ end
 appraise 'grape-1.x' do
   gem 'rack', '~> 2.0'
   gem 'grape', '~> 1.8'
-end
-
-appraise 'grape-latest' do
-  gem 'grape'
 end

--- a/instrumentation/grape/Appraisals
+++ b/instrumentation/grape/Appraisals
@@ -4,8 +4,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[1.8.0 2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0 3.1.0].each do |version|
+%w[2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 3.0.0 3.1.0].each do |version|
   appraise "grape-#{version}" do
     gem 'grape', "~> #{version}"
   end
+end
+
+appraise 'grape-1.x' do
+  gem 'rack', '~> 2.0'
+  gem 'grape', '~> 1.8'
 end

--- a/instrumentation/net_ldap/Appraisals
+++ b/instrumentation/net_ldap/Appraisals
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# frozen set of Appraisals for net-ldap instrumentation
 %w[0.17.1 0.18.0 0.19.0].each do |version|
   appraise "net-ldap-#{version}" do
     gem 'net-ldap', "~> #{version}"
@@ -9,12 +10,8 @@
   end
 end
 
-%w[0.20.0].each do |version|
+%w[0.20.0 0.20.0].each do |version|
   appraise "net-ldap-#{version}" do
     gem 'net-ldap', "~> #{version}"
   end
-end
-
-appraise 'net-ldap-latest' do
-  gem 'net-ldap'
 end

--- a/instrumentation/redis/Appraisals
+++ b/instrumentation/redis/Appraisals
@@ -7,10 +7,8 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
   end
 end
 
-appraise 'redis-5.x' do
-  gem 'redis', '~> 5.0'
-end
-
-appraise 'redis-latest' do
-  gem 'redis'
+%w[5.0.0 5.4.1].each do |version|
+  appraise "redis-#{version}" do
+    gem 'redis', "~> #{version}"
+  end
 end


### PR DESCRIPTION
Progresses #2053
Progresses #2488

This enables renovate to update appraisal array of versions so that the need to use unpinned is decreased hence avoiding major bumps breaking our ci.

This only cleans up those gems which would already be managed, a future cleanup should update other instances.

The renovate rules will result in only 1 pr for all minor updates, patch updates will be added to the existing patches pr group. Major are kept seperate as there could be breaking & possibly the need to do manual steps.