### PR TITLE
fix(action_pack): prepend engine mount path to http.route for mounted Rails engines

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb
@@ -32,6 +32,8 @@ module OpenTelemetry
             # https://github.com/rails/rails/blob/747f85f200e7bb2c1a31b4e26e5a5655e2dc0cdc/actionpack/lib/action_dispatch/http/request.rb#L160
             http_route = request.route_uri_pattern&.chomp('(.:format)') if request.respond_to?(:route_uri_pattern)
 
+            http_route = "#{request.script_name}#{http_route}" if http_route && !request.script_name.empty?
+
             attributes = {
               OpenTelemetry::SemanticConventions::Trace::CODE_NAMESPACE => String(payload[:controller]),
               OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => String(payload[:action])

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/handlers/action_controller_test.rb
@@ -64,6 +64,32 @@ describe OpenTelemetry::Instrumentation::ActionPack::Handlers::ActionController 
     _(span.attributes['http.route']).must_equal '/items/:id'
   end
 
+  describe 'when mounted as a Rails engine' do
+    before { get '/engine/items/1234' }
+
+    it 'prepends the engine mount path to http.route' do
+      _(span.attributes['http.route']).must_equal '/engine/items/:id'
+    end
+
+    it 'includes the engine mount path in the semconv span name' do
+      _(span.name).must_equal 'GET /engine/items/:id'
+    end
+
+    it 'sets the controller and action attributes' do
+      _(span.attributes['code.namespace']).must_equal 'ExampleEngine::ItemsController'
+      _(span.attributes['code.function']).must_equal 'show'
+    end
+
+    describe 'when using class span_naming' do
+      let(:config) { { span_naming: :class } }
+
+      it 'sets http.route with the engine mount path but keeps class-based span name' do
+        _(span.name).must_equal 'ExampleEngine::ItemsController#show'
+        _(span.attributes['http.route']).must_equal '/engine/items/:id'
+      end
+    end
+  end
+
   it 'does not memoize data across requests' do
     get '/ok'
     get '/items/new'

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -8,6 +8,7 @@ require 'action_controller/railtie'
 class Application < Rails::Application; end
 require_relative 'middlewares'
 require_relative 'controllers'
+require_relative 'engine'
 require_relative 'routes'
 
 module AppConfig

--- a/instrumentation/action_pack/test/test_helpers/engine.rb
+++ b/instrumentation/action_pack/test/test_helpers/engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module ExampleEngine
+  class Engine < Rails::Engine; end
+end
+
+module ExampleEngine
+  class ItemsController < ActionController::Base
+    def show
+      render plain: "item #{params[:id]}"
+    end
+  end
+end

--- a/instrumentation/action_pack/test/test_helpers/routes.rb
+++ b/instrumentation/action_pack/test/test_helpers/routes.rb
@@ -11,5 +11,10 @@ def draw_routes(rails_app)
     get '/items/new', to: 'example#new_item'
     get '/items/:id', to: 'example#item'
     get '/internal_server_error', to: 'example#internal_server_error'
+    mount ExampleEngine::Engine, at: '/engine'
+  end
+
+  ExampleEngine::Engine.routes.draw do
+    get '/items/:id', to: 'example_engine/items#show'
   end
 end


### PR DESCRIPTION
## Problem

When a Rails application mounts an engine (e.g. mount AdminEngine, at: '/admin'), the route_uri_pattern returned by Rails is engine-relative — it does not include the mount prefix. As a result, the http.route attribute recorded in telemetry was /items/:id instead of /admin/items/:id

## Example

```ruby
get '/items', to: 'items#index'  # GET /items
mount EngineA, at: '/foo'        # GET /foo/items
mount EngineB, at: '/bar'        # GET /bar/items 
# all of them get instrumented with http.route = /items
```

This violates the [HTTP spans specification](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span):

> http.route - The matched route template for the request. This MUST be low-cardinality and include all static path segments, with dynamic path segments represented with placeholders.