### PR TITLE
chore: Delete jruby exclusion

### DIFF
--- a/instrumentation/anthropic/.github-ci.yml
+++ b/instrumentation/anthropic/.github-ci.yml
@@ -1,2 +1,0 @@
-env:
-  unsupported_interpreters: jruby


### PR DESCRIPTION
Remove the skipping of jruby as the issue in the Anthropic gem has been fixed.