### PR TITLE
chore: update last of appraisals

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -175,8 +175,8 @@
       description: "Update dependencies in Appraisals",
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
-        "gem\\s'(?<packageName>.+?)',\\s'=\\s(?<depVersion>[0-9.]+)'",
-        "\\n\\s%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
+        "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>=\\s[0-9.]+)'",
+        "\\n\\s*?%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",
       versioningTemplate: "ruby",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -175,7 +175,7 @@
       description: "Update dependencies in Appraisals",
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
-        "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>.+\\s[0-9.]+)'",
+        "gem\\s'(?<packageName>.+?)',\\s'=\\s(?<depVersion>[0-9.]+)'",
         "\\n\\s%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",

--- a/instrumentation/active_record/Appraisals
+++ b/instrumentation/active_record/Appraisals
@@ -7,7 +7,7 @@
 if RUBY_ENGINE == 'ruby'
   %w[7.1.0 7.2.0].each do |version|
     appraise "activerecord-#{version}" do
-      gem 'sqlite3', '~> 1.4'
+      gem 'sqlite3', '< 2.0.0'
       gem 'activerecord', "~> #{version}"
     end
   end

--- a/instrumentation/active_storage/Appraisals
+++ b/instrumentation/active_storage/Appraisals
@@ -4,17 +4,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[7.1.0 7.2.0].each do |version|
-  appraise "activestorage-#{version}" do
-    gem 'sqlite3', '< 2.0.0', platform: :mri
-    gem 'activerecord-jdbcsqlite3-adapter', '< 80.0', platform: :jruby
-    gem 'image_processing', '= 2.0.3'
-    gem 'mini_magick', '= 5.3.3'
-    gem 'rails', "~> #{version}"
-  end
-end
-
 if RUBY_ENGINE == 'ruby'
+  %w[7.1.0 7.2.0].each do |version|
+    appraise "activestorage-#{version}" do
+      gem 'sqlite3', '< 2.0.0'
+      gem 'image_processing', '= 2.0.3'
+      gem 'mini_magick', '= 5.3.3'
+      gem 'rails', "~> #{version}"
+    end
+  end
+
   %w[8.0.0 8.1.0].each do |version|
     appraise "activestorage-#{version}" do
       gem 'rails', "~> #{version}"
@@ -26,7 +25,7 @@ if RUBY_ENGINE == 'ruby'
 end
 
 if RUBY_ENGINE == 'jruby'
-  %w[80.0.pre1 80.0.pre1].each do |version|
+  %w[71.0 72.0 80.0.pre1].each do |version|
     appraise "jruby_activestorage-#{version}" do
       gem 'activerecord-jdbcsqlite3-adapter', "~> #{version}"
       gem 'image_processing', '= 2.0.3'

--- a/instrumentation/active_storage/Appraisals
+++ b/instrumentation/active_storage/Appraisals
@@ -4,17 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%w[7.1.0 7.2.0].each do |version|
-  appraise "activestorage-#{version}" do
-    gem 'sqlite3', '~> 1.4', platform: :mri
-    gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-    gem 'image_processing', '= 2.0.3'
-    gem 'mini_magick', '= 5.3.3'
-    gem 'rails', "~> #{version}"
-  end
-end
-
 if RUBY_ENGINE == 'ruby'
+  %w[7.1.0 7.2.0].each do |version|
+    appraise "activestorage-#{version}" do
+      gem 'sqlite3', '< 2.0.0', platform: :mri
+      gem 'image_processing', '= 2.0.3'
+      gem 'mini_magick', '= 5.3.3'
+      gem 'image_processing', '= 1.14.0'
+      gem 'rails', "~> #{version}"
+    end
+  end
+
   %w[8.0.0 8.1.0].each do |version|
     appraise "activestorage-#{version}" do
       gem 'rails', "~> #{version}"
@@ -26,12 +26,12 @@ if RUBY_ENGINE == 'ruby'
 end
 
 if RUBY_ENGINE == 'jruby'
-  %w[80.0.pre1].each do |version|
+  %w[71.0 72.0 80.0.pre1].each do |version|
     appraise "jruby_activestorage-#{version}" do
       gem 'activerecord-jdbcsqlite3-adapter', "~> #{version}"
       gem 'image_processing', '= 2.0.3'
       gem 'mini_magick', '= 5.3.3'
-      gem 'rails', '~> 8.0.0'
+      gem 'rails'
     end
   end
 end

--- a/instrumentation/active_storage/Appraisals
+++ b/instrumentation/active_storage/Appraisals
@@ -27,7 +27,7 @@ end
 if RUBY_ENGINE == 'jruby'
   %w[71.0 72.0 80.0.pre1].each do |version|
     appraise "jruby_activestorage-#{version}" do
-      gem 'activerecord-jdbcsqlite3-adapter', "~> #{version}"
+      gem 'activerecord-jdbcsqlite3-adapter', "= #{version}"
       gem 'image_processing', '= 2.0.3'
       gem 'mini_magick', '= 5.3.3'
       gem 'rails'

--- a/instrumentation/active_storage/Appraisals
+++ b/instrumentation/active_storage/Appraisals
@@ -4,17 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if RUBY_ENGINE == 'ruby'
-  %w[7.1.0 7.2.0].each do |version|
-    appraise "activestorage-#{version}" do
-      gem 'sqlite3', '< 2.0.0', platform: :mri
-      gem 'image_processing', '= 2.0.3'
-      gem 'mini_magick', '= 5.3.3'
-      gem 'image_processing', '= 1.14.0'
-      gem 'rails', "~> #{version}"
-    end
+%w[7.1.0 7.2.0].each do |version|
+  appraise "activestorage-#{version}" do
+    gem 'sqlite3', '< 2.0.0', platform: :mri
+    gem 'activerecord-jdbcsqlite3-adapter', '< 80.0', platform: :jruby
+    gem 'image_processing', '= 2.0.3'
+    gem 'mini_magick', '= 5.3.3'
+    gem 'rails', "~> #{version}"
   end
+end
 
+if RUBY_ENGINE == 'ruby'
   %w[8.0.0 8.1.0].each do |version|
     appraise "activestorage-#{version}" do
       gem 'rails', "~> #{version}"
@@ -26,7 +26,7 @@ if RUBY_ENGINE == 'ruby'
 end
 
 if RUBY_ENGINE == 'jruby'
-  %w[71.0 72.0 80.0.pre1].each do |version|
+  %w[80.0.pre1 80.0.pre1].each do |version|
     appraise "jruby_activestorage-#{version}" do
       gem 'activerecord-jdbcsqlite3-adapter', "~> #{version}"
       gem 'image_processing', '= 2.0.3'

--- a/instrumentation/anthropic/Appraisals
+++ b/instrumentation/anthropic/Appraisals
@@ -11,7 +11,7 @@
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
-  appraise 'anthropic-1.9.0' do
-    gem 'anthropic', '~> 1.9.0'
+  appraise 'anthropic-1.9.x' do
+    gem 'anthropic', '< 1.10.0'
   end
 end

--- a/instrumentation/delayed_job/Appraisals
+++ b/instrumentation/delayed_job/Appraisals
@@ -5,15 +5,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 %w[7.1.0 7.2.0 8.1.3.1].each do |version|
-  appraise "delayed_job-latest+activejob-#{version}" do
+  appraise "activejob-#{version}" do
     gem 'activejob', "~> #{version}"
     gem 'delayed_job', '= 4.2.0'
   end
 end
 
 %w[4.1.0 4.2.0].each do |version|
-  appraise "activejob-latest+delayed_job-#{version}" do
+  appraise "delayed_job-#{version}" do
     gem 'delayed_job', "~> #{version}"
-    gem 'activejob', "= 8.1.3.1"
+    gem 'activejob', '= 8.1.3.1'
+    gem 'benchmark', '= 0.5.0'
   end
 end

--- a/instrumentation/delayed_job/Appraisals
+++ b/instrumentation/delayed_job/Appraisals
@@ -5,13 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 %w[7.1.0 7.2.0 8.1.3.1].each do |version|
-  appraise "delayed_job_4.2-activejob-#{version}" do
+  appraise "delayed_job-latest+activejob-#{version}" do
     gem 'activejob', "~> #{version}"
-    gem 'delayed_job', '~> 4.2'
+    gem 'delayed_job', '= 4.2.0'
   end
 end
 
-appraise 'delayed_job-latest' do
-  gem 'activejob'
-  gem 'delayed_job'
+%w[4.1.0 4.2.0].each do |version|
+  appraise "activejob-latest+delayed_job-#{version}" do
+    gem 'delayed_job', "~> #{version}"
+    gem 'activejob', "= 8.1.3.1"
+  end
 end

--- a/instrumentation/factory_bot/Appraisals
+++ b/instrumentation/factory_bot/Appraisals
@@ -4,14 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'factory_bot-4' do
-  gem 'factory_bot', '~> 4.0'
-  gem 'activesupport', '~> 6.0' # factory_bot 4 requires activesupport < 7 on Ruby 3.4+
+appraise 'factory_bot-4.x' do
+  gem 'factory_bot', '< 5.0.0'
+  gem 'activesupport', '< 7.0.0' # factory_bot 4 requires activesupport < 7 on Ruby 3.4+
 end
 
-appraise 'factory_bot-5' do
-  gem 'factory_bot', '~> 5.0'
-  gem 'activesupport', '~> 6.0' # factory_bot 5 requires activesupport < 7 on Ruby 3.4+
+appraise 'factory_bot-5.x' do
+  gem 'factory_bot', '< 6.0.0'
+  gem 'activesupport', '< 7.0.0' # factory_bot 5 requires activesupport < 7 on Ruby 3.4+
 end
 
 %w[6.5.0 6.6.0].each do |version|

--- a/instrumentation/grape/Appraisals
+++ b/instrumentation/grape/Appraisals
@@ -11,6 +11,6 @@
 end
 
 appraise 'grape-1.x' do
-  gem 'rack', '~> 2.0'
-  gem 'grape', '~> 1.8'
+  gem 'rack', '< 3.0.0'
+  gem 'grape', '< 2.0.0'
 end

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -15,7 +15,7 @@ end
 if RUBY_ENGINE == 'ruby'
   appraise 'graphql-c_parser-1.0.x' do
     gem 'graphql', '< 2.3.1'
-    gem 'graphql-c_parser', '~> 1.0.0'
+    gem 'graphql-c_parser', '< 1.1.0'
   end
 
   %w[1.1.0 1.1.4].each do |version|

--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -14,7 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4') && RUBY_ENGINE == 'r
   end
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5') && && RUBY_ENGINE == 'ruby'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5') && RUBY_ENGINE == 'ruby'
   appraise 'gruf-2.21.x' do
     gem 'gruf', '< 2.22.0'
   end

--- a/instrumentation/gruf/Appraisals
+++ b/instrumentation/gruf/Appraisals
@@ -5,23 +5,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
-  appraise 'gruf-2.19' do
-    gem 'gruf', '~> 2.19.0'
+  appraise 'gruf-2.19.x' do
+    gem 'gruf', '< 2.20.0'
   end
 
-  appraise 'gruf-2.20' do
-    gem 'gruf', '~> 2.20.0'
+  appraise 'gruf-2.20.x' do
+    gem 'gruf', '< 2.21.0'
   end
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.5')
-  appraise 'gruf-2.21' do
-    gem 'gruf', '~> 2.21.0'
+  appraise 'gruf-2.21.x' do
+    gem 'gruf', '< 2.22.0'
   end
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('5')
-  appraise 'gruf-latest' do
-    gem 'gruf'
+# needs to be updated like above when ruby v5 is released
+
+%w[2.22.0 2.22.0].each do |version|
+  appraise "gruf-#{version}" do
+    gem 'gruf', "~> #{version}"
   end
 end

--- a/instrumentation/que/Appraisals
+++ b/instrumentation/que/Appraisals
@@ -4,14 +4,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'que-2.x' do
-  gem 'que', '~> 2.4'
-  gem 'activerecord', '~> 7.2.0'
-  gem 'pg', '~> 1.5'
+appraise 'que-2.4.x-with-activerecord-7.2.x' do
+  gem 'que', '< 2.5.0'
+  gem 'activerecord', '< 8.0.0'
+  gem 'pg', '< 2.0.0'
 end
 
-appraise 'que-latest' do
-  gem 'que'
-  gem 'activerecord'
-  gem 'pg'
+%w[2.4.0 2.4.1].each do |version|
+  appraise "que-#{version}-with-latest-pg" do
+    gem 'que', "~> #{version}"
+    gem 'activerecord'
+    gem 'pg'
+  end
 end

--- a/instrumentation/redis/Appraisals
+++ b/instrumentation/redis/Appraisals
@@ -2,8 +2,8 @@
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
   appraise 'redis-4.x' do
-    gem 'redis-client', '~> 0.22'
-    gem 'redis', '~> 4.8'
+    gem 'redis-client', '= 0.22.0'
+    gem 'redis', '< 5.0.0'
   end
 end
 


### PR DESCRIPTION
Move to renovate managable array versions to reduce chance of ci breakages.

Note this is part 4 of the switch with this the final pr excluding an aws sdk review.

Renovate rules are:

- patches get added to the patches pr with any other patch
- Minor appraisal updates are all grouped together in 1 pr
- Major updates are raised as individual pr's as they may contain breaking changes.

This also tightens the renovate detection rule to only look at explicit gem dependencies which specify a specific version ie =0.22.0. Also max versions are restricted using < as opposed ~> x.y.z to make intent clear.