### PR TITLE
test: Improve aws service gems being tested

### DIFF
--- a/instrumentation/aws_sdk/Appraisals
+++ b/instrumentation/aws_sdk/Appraisals
@@ -11,33 +11,52 @@
 
 semconv_modes = %w[old stable dup]
 
-semconv_modes.each do |mode|
-  appraise "aws-sdk-3-#{mode}" do
-    gem 'aws-sdk-core', '~> 3'
-    gem 'aws-sdk-lambda', '~> 1'
-    gem 'aws-sdk-dynamodb', '~> 1'
-    gem 'aws-sdk-sns', '~> 1'
-    gem 'aws-sdk-sqs', '~> 1'
+%w[3.202.0 3.254.1].each do |version|
+  appraise "aws-sdk-core-#{version}" do
+    gem 'aws-sdk-core', "~> #{version}"
+    gem 'aws-sdk-lambda'
+    gem 'aws-sdk-dynamodb'
+    gem 'aws-sdk-sns'
+    gem 'aws-sdk-sqs'
   end
+end
 
-  # pre-Observability support in V3 SDK
-  appraise "aws-sdk-3.202-#{mode}" do
-    gem 'aws-sdk-core', '~> 3.202'
-    gem 'aws-sdk-lambda', '~> 1.127'
-    gem 'aws-sdk-dynamodb', '~> 1.118'
-    gem 'aws-sdk-sns', '~> 1.82'
-    gem 'aws-sdk-sqs', '~> 1.80'
+%w[1.127.0 1.193.0].each do |version|
+  appraise "aws-sdk-lambda-#{version}" do
+    gem 'aws-sdk-lambda', "~> #{version}"
+  end
+end
+
+semconv_modes.each do |mode|
+  %w[1.118.0 1.172.0].each do |version|
+    appraise "aws-sdk-dynamodb-#{version}-#{mode}" do
+      gem 'aws-sdk-dynamodb', "~> #{version}"
+    end
+  end
+  
+  appraise "aws-sdk-dynamodb-1.118.x-with-core-3.202.x-#{mode}" do
+    gem 'aws-sdk-core', '< 3.203.0'
+    gem 'aws-sdk-dynamodb', '< 1.119.0'
+  end
+end
+
+%w[1.82.0 1.118.0].each do |version|
+  appraise "aws-sdk-sns-#{version}" do
+    gem 'aws-sdk-sns', "~> #{version}"
+  end
+end
+
+%w[1.80.0 1.117.0].each do |version|
+  appraise "aws-sdk-sqs-#{version}" do
+    gem 'aws-sdk-sqs', "~> #{version}"
+    gem 'aws-sdk-core'
   end
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('4')
   semconv_modes.each do |mode|
-    appraise "aws-sdk-2.11-#{mode}" do
-      gem 'aws-sdk', '~> 2.11'
-    end
-
-    appraise "aws-sdk-2.0-#{mode}" do
-      gem 'aws-sdk', '~> 2.0'
+    appraise "aws-sdk-2.11.x-#{mode}" do
+      gem 'aws-sdk', '< 2.12.0'
     end
   end
 end

--- a/instrumentation/aws_sdk/test/opentelemetry/handler_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/handler_test.rb
@@ -28,6 +28,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'Lambda' do
       let(:service_name) { 'Lambda' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::Lambda::Client.new(stub_responses: true) }
       let(:expected_attrs) do
         span_attrs.tap do |attrs|
@@ -37,8 +38,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'creates a span with all the supplied parameters' do
-        skip if TestHelper.telemetry_plugin?(service_name)
-
         client.list_functions
 
         _(span.name).must_equal('Lambda.ListFunctions')
@@ -47,8 +46,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'should have correct span attributes when error' do
-        skip if TestHelper.telemetry_plugin?(service_name)
-
         client.stub_responses(:list_functions, 'NotFound')
 
         begin
@@ -63,6 +60,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'SNS' do
       let(:service_name) { 'SNS' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::SNS::Client.new(stub_responses: true) }
       let(:expected_attrs) do
         span_attrs.tap do |attrs|
@@ -75,8 +73,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'creates a span with appropriate messaging attributes' do
-        skip if TestHelper.telemetry_plugin?(service_name)
-
         client.publish(
           message: 'msg',
           topic_arn: 'arn:aws:sns:fake:123:TopicName'
@@ -90,7 +86,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       it 'creates a span that includes a phone number' do
         # skip if using aws-sdk version before phone_number supported (v2.3.18)
         skip if Gem::Version.new('2.3.18') > instrumentation_gem_version
-        skip if TestHelper.telemetry_plugin?(service_name)
 
         client.publish(message: 'msg', phone_number: '123456')
 
@@ -101,6 +96,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'SQS' do
       let(:service_name) { 'SQS' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::SQS::Client.new(stub_responses: true) }
       let(:queue_url) { 'https://sqs.fake.amazonaws.com/1/QueueName' }
       let(:expected_base_attrs) do
@@ -121,8 +117,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates a span with appropriate messaging attributes' do
-          skip if TestHelper.telemetry_plugin?(service_name)
-
           client.send_message(message_body: 'msg', queue_url: queue_url)
 
           _(span.name).must_equal('QueueName publish')
@@ -139,8 +133,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates a span with appropriate messaging attributes' do
-          skip if TestHelper.telemetry_plugin?(service_name)
-
           client.send_message_batch(
             queue_url: queue_url,
             entries: [{ id: 'Message1', message_body: 'Body1' }]
@@ -161,8 +153,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates a span with appropriate messaging attributes' do
-          skip if TestHelper.telemetry_plugin?(service_name)
-
           client.receive_message(queue_url: queue_url)
 
           _(span.name).must_equal('QueueName receive')
@@ -173,8 +163,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
       describe '#GetQueueUrl' do
         it 'creates a span with appropriate messaging attributes' do
-          skip if TestHelper.telemetry_plugin?(service_name)
-
           client.get_queue_url(queue_name: 'queue-name')
 
           _(span.attributes['messaging.destination']).must_equal('unknown')
@@ -184,11 +172,12 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
     end
 
     describe 'DynamoDB' do
+      let(:service_name) { 'DynamoDB' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::DynamoDB::Client.new(stub_responses: true) }
 
       describe 'old semconv' do
         before do
-          skip if TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_old?
         end
 
@@ -204,7 +193,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
       describe 'stable semconv' do
         before do
-          skip if TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_stable?
         end
 
@@ -228,7 +216,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
       describe 'dup semconv' do
         before do
-          skip if TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_dup?
         end
 
@@ -250,6 +237,11 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
           _(span.attributes['db.collection.name']).must_equal('TestTable')
         end
       end
+    end
+
+    def check_target_service(service_name)
+      skip if TestHelper.telemetry_plugin?(service_name)
+      skip unless TestHelper.testing_service?(service_name)
     end
   end
 end

--- a/instrumentation/aws_sdk/test/opentelemetry/patches/telemetry_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/patches/telemetry_test.rb
@@ -27,6 +27,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'Lambda' do
       let(:service_name) { 'Lambda' }
+      before { check_target_service(service_name) }
       let(:service_uri) do
         'https://lambda.us-east-1.amazonaws.com/2015-03-31/functions'
       end
@@ -48,7 +49,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'create a client span with all the supplied parameters' do
-        skip unless TestHelper.telemetry_plugin?(service_name)
         client.list_functions
 
         _(client_span.name).must_equal('Lambda.ListFunctions')
@@ -57,7 +57,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'should have correct span attributes when error' do
-        skip unless TestHelper.telemetry_plugin?(service_name)
         stub_request(:get, 'foo').to_return(status: 400)
 
         begin
@@ -69,7 +68,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'creates internal spans when enabled' do
-        skip unless TestHelper.telemetry_plugin?(service_name)
         stub_request(:get, 'https://lambda.us-east-1.amazonaws.com/2015-03-31/functions')
         client = Aws::Lambda::Client.new(
           telemetry_provider: otel_provider,
@@ -101,6 +99,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'SNS' do
       let(:service_name) { 'SNS' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::SNS::Client.new(telemetry_provider: otel_provider, stub_responses: true) }
       let(:client_span) { spans.find { |s| s.name.include?('SNS.Publish') } }
 
@@ -116,8 +115,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       end
 
       it 'creates spans with appropriate messaging attributes' do
-        skip unless TestHelper.telemetry_plugin?(service_name)
-
         client.publish(message: 'msg', topic_arn: 'arn:aws:sns:fake:123:TopicName')
 
         _(client_span.name).must_equal('SNS.Publish.TopicName.Publish')
@@ -128,7 +125,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
       it 'creates a span that includes a phone number' do
         # skip if using aws-sdk version before phone_number supported (v2.3.18)
         skip if Gem::Version.new('2.3.18') > instrumentation_instance.gem_version
-        skip unless TestHelper.telemetry_plugin?(service_name)
 
         client.publish(message: 'msg', phone_number: '123456')
 
@@ -139,6 +135,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
     describe 'SQS' do
       let(:service_name) { 'SQS' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::SQS::Client.new(telemetry_provider: otel_provider, stub_responses: true) }
       let(:queue_url) { 'https://sqs.us-east-1.amazonaws.com/1/QueueName' }
       let(:expected_client_base_attrs) do
@@ -160,8 +157,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates spans with appropriate messaging attributes' do
-          skip unless TestHelper.telemetry_plugin?(service_name)
-
           client.send_message(message_body: 'msg', queue_url: queue_url)
 
           _(client_span.name).must_equal('SQS.SendMessage.QueueName.Publish')
@@ -179,8 +174,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates spans with appropriate messaging attributes' do
-          skip unless TestHelper.telemetry_plugin?(service_name)
-
           client.send_message_batch(
             queue_url: queue_url,
             entries: [{ id: 'Message1', message_body: 'Body1' }]
@@ -202,8 +195,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         end
 
         it 'creates spans with appropriate messaging attributes' do
-          skip unless TestHelper.telemetry_plugin?(service_name)
-
           client.receive_message(queue_url: queue_url)
 
           _(client_span.name).must_equal('SQS.ReceiveMessage.QueueName.Receive')
@@ -216,8 +207,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         let(:client_span) { spans.find { |s| s.name.include?('SQS.GetQueueUrl') } }
 
         it 'creates a span with appropriate messaging attributes' do
-          skip unless TestHelper.telemetry_plugin?(service_name)
-
           client.get_queue_url(queue_name: 'queue-name')
 
           _(client_span.attributes[otel_semantic::MESSAGING_DESTINATION]).must_equal('unknown')
@@ -227,13 +216,14 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
     end
 
     describe 'DynamoDB' do
+      let(:service_name) { 'DynamoDB' }
+      before { check_target_service(service_name) }
       let(:client) { Aws::DynamoDB::Client.new(telemetry_provider: otel_provider, stub_responses: true) }
       let(:client_span) { spans.find { |s| s.name == 'DynamoDB.ListTables' } }
       let(:describe_table_span) { spans.find { |s| s.name == 'DynamoDB.DescribeTable' } }
 
       describe 'old semconv' do
         before do
-          skip unless TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_old?
         end
 
@@ -249,7 +239,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
       describe 'stable semconv' do
         before do
-          skip unless TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_stable?
         end
 
@@ -273,7 +262,6 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
       describe 'dup semconv' do
         before do
-          skip unless TestHelper.telemetry_plugin?('DynamoDB')
           skip unless TestHelper.semconv_dup?
         end
 
@@ -295,6 +283,10 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
           _(describe_table_span.attributes['db.collection.name']).must_equal('TestTable')
         end
       end
+    end
+
+    def check_target_service(service_name)
+      skip unless TestHelper.telemetry_plugin?(service_name) && TestHelper.testing_service?(service_name)
     end
   end
 end

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -36,9 +36,17 @@ end
 class TestHelper
   class << self
     def telemetry_plugin?(service)
-      m = ::Aws.const_get(service).const_get(:Client)
+      return false unless Aws.const_defined?(service)
+
+      svc = ::Aws.const_get(service)
+      return false unless svc.const_defined?(:Client)
+
+      m = svc.const_get(:Client)
+
       Aws.const_defined?('Plugins::Telemetry') &&
         m.plugins.include?(Aws::Plugins::Telemetry)
+    rescue NameError
+      false
     end
 
     def match_span_attrs(expected_attrs, span, expect)
@@ -58,6 +66,14 @@ class TestHelper
 
     def semconv_dup?
       ENV.fetch('BUNDLE_GEMFILE', '').include?('dup')
+    end
+
+    def testing_service?(service)
+      target_service?(service) || target_service?('core') || target_service?('2')
+    end
+
+    def target_service?(service)
+      ENV.fetch('BUNDLE_GEMFILE', '').include?("aws_sdk_#{service}")
     end
   end
 end

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -73,7 +73,7 @@ class TestHelper
     end
 
     def target_service?(service)
-      ENV.fetch('BUNDLE_GEMFILE', '').include?("aws_sdk_#{service}")
+      ENV.fetch('BUNDLE_GEMFILE', '').downcase.include?("aws_sdk_#{service}".downcase)
     end
   end
 end


### PR DESCRIPTION
This updates the aws testing targets to ensure we are testing against a range. Previously multiple appraisals were generating to the same.

With this change the aws service tests are only performed in the core or dedicated service appraisal. This means we can explicitly target specific versions of the client library.

In the process of adjusting targets coverage for Ruby 4.0 has gone from

> Line coverage: 203 / 235 (86.38%)

Up to

> Line coverage: 224 / 235 (95.31%)

Which can be attributed to now testing a version without telemetry plugin.