### PR TITLE
test: accept httpx 1.8.2 timeout error message

### DIFF
--- a/instrumentation/httpx/test/instrumentation/dup/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/dup/plugin_test.rb
@@ -122,8 +122,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Dup::Plugin do
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
-      _(span.status.description).must_equal(
-        'Timed out'
+      _(span.status.description).must_match(
+        /\ATimed out/
       )
       assert_requested(
         :get,

--- a/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/old/plugin_test.rb
@@ -105,8 +105,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Old::Plugin do
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
-      _(span.status.description).must_equal(
-        'Timed out'
+      _(span.status.description).must_match(
+        /\ATimed out/
       )
       assert_requested(
         :get,

--- a/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
+++ b/instrumentation/httpx/test/instrumentation/stable/plugin_test.rb
@@ -102,8 +102,8 @@ describe OpenTelemetry::Instrumentation::HTTPX::Stable::Plugin do
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
-      _(span.status.description).must_equal(
-        'Timed out'
+      _(span.status.description).must_match(
+        /\ATimed out/
       )
       assert_requested(
         :get,


### PR DESCRIPTION
`httpx` 1.8.2 [changed](https://gitlab.com/os85/httpx/-/commit/b112ded233b97fbceae00cb7f43884e42a56e19c) its WebMock adapter so `.to_timeout` raises a `HTTPX::RequestTimeoutError` instead of a plain `HTTPX::TimeoutError`, which makes the span status description read `Timed out after 1 seconds` instead of `Timed out`. The `~> 1.8.1` appraisal picks up 1.8.2, so the timeout test started failing on every branch.

Match the description with a prefix regexp so both the 1.7 and 1.8 appraisals pass and there is no need to lock to newer version.

Fixes recent CI failures.