### PR TITLE
chore: Codeql default permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "25 3 * * 6"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: ${{ matrix.language }}


### PR DESCRIPTION
Set default permissions for codeql as identified by https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-ruby-contrib