### PR TITLE
chore: use gem groups

### DIFF
--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -8,8 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :test do
+group :local do
   gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
+group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
   gem 'opentelemetry-sdk', '~> 1.13.0'

--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
     - "bin/instrumentation_generator"
     - "**/**/vendor/bundle/**/*"
     - "**/proto/**"
+Bundler/DuplicatedGem:
+  Exclude:
+    - "**/Gemfile"
 Bundler/OrderedGems:
   Enabled: false
 Lint/ConstantDefinitionInBlock:

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,14 @@
 
 source 'https://rubygems.org'
 
-gem 'rake', '>= 13'
-gem 'rubocop', '~> 1.89.0'
-gem 'rubocop-minitest', '~> 0.40.0'
-gem 'rubocop-performance', '~> 1.27.0'
-gem 'rubocop-rake', '~> 0.7.1'
-gem 'rubocop-rspec', '~> 3.10.0'
+group :default do
+  gem 'rake', '~> 13.4.0'
+end
+
+group :development do
+  gem 'rubocop', '~> 1.89.0'
+  gem 'rubocop-minitest', '~> 0.40.0'
+  gem 'rubocop-performance', '~> 1.27.0'
+  gem 'rubocop-rake', '~> 0.7.1'
+  gem 'rubocop-rspec', '~> 3.10.0'
+end

--- a/helpers/mysql/test/test_helper.rb
+++ b/helpers/mysql/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry'
 require 'opentelemetry-helpers-mysql'

--- a/helpers/mysql/test/test_helper.rb
+++ b/helpers/mysql/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry'
 require 'opentelemetry-helpers-mysql'

--- a/helpers/sql-processor/test/test_helper.rb
+++ b/helpers/sql-processor/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'opentelemetry-helpers-sql-processor'

--- a/helpers/sql-processor/test/test_helper.rb
+++ b/helpers/sql-processor/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'opentelemetry-helpers-sql-processor'

--- a/helpers/sql/test/test_helper.rb
+++ b/helpers/sql/test/test_helper.rb
@@ -5,6 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'

--- a/helpers/sql/test/test_helper.rb
+++ b/helpers/sql/test/test_helper.rb
@@ -5,6 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'

--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-active_support'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,8 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   # Add jar-dependencies gem only if the Ruby runtime is JRuby
   # https://github.com/jruby/jruby/issues/7262
   gem 'jar-dependencies', '0.5.7', platforms: :jruby

--- a/instrumentation/action_mailer/test/test_helper.rb
+++ b/instrumentation/action_mailer/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'action_mailer'
 require 'opentelemetry-instrumentation-action_mailer'

--- a/instrumentation/action_mailer/test/test_helper.rb
+++ b/instrumentation/action_mailer/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'action_mailer'
 require 'opentelemetry-instrumentation-action_mailer'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,8 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-  gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-rack'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-rack', path: '../rack'
+  end
 end
 
 group :test do

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-instrumentation-action_pack'
 require 'minitest/autorun'

--- a/instrumentation/action_pack/test/test_helper.rb
+++ b/instrumentation/action_pack/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-instrumentation-action_pack'
 require 'minitest/autorun'

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-active_support'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,8 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/action_view/test/test_helper.rb
+++ b/instrumentation/action_view/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_support'
 require 'active_support/railtie'

--- a/instrumentation/action_view/test/test_helper.rb
+++ b/instrumentation/action_view/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_support'
 require 'active_support/railtie'

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_job'
 require 'active_support/core_ext/object/with'

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_job'
 require 'active_support/core_ext/object/with'

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-active_support'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,8 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_model_serializers/test/test_helper.rb
+++ b/instrumentation/active_model_serializers/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_support/all'
 require 'opentelemetry-instrumentation-active_model_serializers'

--- a/instrumentation/active_model_serializers/test/test_helper.rb
+++ b/instrumentation/active_model_serializers/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_support/all'
 require 'opentelemetry-instrumentation-active_model_serializers'

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_record'
 require 'opentelemetry-instrumentation-active_record'

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_record'
 require 'opentelemetry-instrumentation-active_record'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-active_support'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,8 +25,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_storage/test/test_helper.rb
+++ b/instrumentation/active_storage/test/test_helper.rb
@@ -8,7 +8,7 @@ ENV['RAILS_ENV'] = 'test'
 
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_storage'
 require 'minitest/autorun'

--- a/instrumentation/active_storage/test/test_helper.rb
+++ b/instrumentation/active_storage/test/test_helper.rb
@@ -8,7 +8,7 @@ ENV['RAILS_ENV'] = 'test'
 
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_storage'
 require 'minitest/autorun'

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-sdk', '~> 1.13.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/active_support/test/test_helper.rb
+++ b/instrumentation/active_support/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_support'
 require 'active_support/core_ext'

--- a/instrumentation/active_support/test/test_helper.rb
+++ b/instrumentation/active_support/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_support'
 require 'active_support/core_ext'

--- a/instrumentation/all/test/test_helper.rb
+++ b/instrumentation/all/test/test_helper.rb
@@ -6,6 +6,6 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'

--- a/instrumentation/all/test/test_helper.rb
+++ b/instrumentation/all/test/test_helper.rb
@@ -6,6 +6,6 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'

--- a/instrumentation/anthropic/Gemfile
+++ b/instrumentation/anthropic/Gemfile
@@ -8,10 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-net_http', path: '../net_http'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
-  gem 'opentelemetry-instrumentation-net_http', path: '../net_http'
   gem 'opentelemetry-sdk', '~> 1.13.0'
   gem 'opentelemetry-test-helpers', '~> 0.9.0'
   gem 'rake', '>= 13'
@@ -21,7 +25,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
 
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/anthropic/Gemfile
+++ b/instrumentation/anthropic/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-net_http', path: '../net_http'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-net_http'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-net_http', path: '../net_http'
+  end
 end
 
 group :test do

--- a/instrumentation/anthropic/test/test_helper.rb
+++ b/instrumentation/anthropic/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/anthropic/test/test_helper.rb
+++ b/instrumentation/anthropic/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.9.0'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/aws_lambda/test/test_helper.rb
+++ b/instrumentation/aws_lambda/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-instrumentation-aws_lambda'
 

--- a/instrumentation/aws_lambda/test/test_helper.rb
+++ b/instrumentation/aws_lambda/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-instrumentation-aws_lambda'
 

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'webrick', '~> 1.9.0'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 # Set OTEL_SEMCONV_STABILITY_OPT_IN based on appraisal name
 gemfile = ENV.fetch('BUNDLE_GEMFILE', '')

--- a/instrumentation/aws_sdk/test/test_helper.rb
+++ b/instrumentation/aws_sdk/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 # Set OTEL_SEMCONV_STABILITY_OPT_IN based on appraisal name
 gemfile = ENV.fetch('BUNDLE_GEMFILE', '')

--- a/instrumentation/base/test/test_helper.rb
+++ b/instrumentation/base/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-instrumentation-base'
 require 'minitest/autorun'

--- a/instrumentation/base/test/test_helper.rb
+++ b/instrumentation/base/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-instrumentation-base'
 require 'minitest/autorun'

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -18,7 +22,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/bunny/test/test_helper.rb
+++ b/instrumentation/bunny/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'securerandom'
 

--- a/instrumentation/bunny/test/test_helper.rb
+++ b/instrumentation/bunny/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'securerandom'
 

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -17,7 +21,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/concurrent_ruby/test/test_helper.rb
+++ b/instrumentation/concurrent_ruby/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'concurrent'
 

--- a/instrumentation/concurrent_ruby/test/test_helper.rb
+++ b/instrumentation/concurrent_ruby/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'concurrent'
 

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -21,7 +25,6 @@ group :test do
   gem 'rspec-mocks', '~> 3.13.7'
   gem 'sqlite3', '~> 2.9.0', platform: :mri
   gem 'jdbc-sqlite3', platform: :jruby
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 # These are dependencies that delayed job assumes are already loaded
 # We are compensating for that here in this test... that is a smell

--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 # These are dependencies that delayed job assumes are already loaded
 # We are compensating for that here in this test... that is a smell

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -18,7 +22,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/ethon/test/test_helper.rb
+++ b/instrumentation/ethon/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/ethon/test/test_helper.rb
+++ b/instrumentation/ethon/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/excon/test/test_helper.rb
+++ b/instrumentation/excon/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/factory_bot/Gemfile
+++ b/instrumentation/factory_bot/Gemfile
@@ -8,8 +8,17 @@ source 'https://rubygems.org'
 
 gemspec
 
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
+end
+
 group :test do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
   gem 'opentelemetry-sdk', '~> 1.13.0'

--- a/instrumentation/factory_bot/test/test_helper.rb
+++ b/instrumentation/factory_bot/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_support/core_ext/time'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/instrumentation/factory_bot/test/test_helper.rb
+++ b/instrumentation/factory_bot/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_support/core_ext/time'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-rack'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-rack', path: '../rack'
+  end
 end
 
 group :test do

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -21,8 +26,6 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.9.0'
   gem 'rack-test', '~> 2.2.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
   gem 'builder', '~> 3.3.0'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/grape/test/test_helper.rb
+++ b/instrumentation/grape/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/grape/test/test_helper.rb
+++ b/instrumentation/grape/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 require 'graphql'
 
 require 'minitest/autorun'

--- a/instrumentation/graphql/test/test_helper.rb
+++ b/instrumentation/graphql/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 require 'graphql'
 
 require 'minitest/autorun'

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -6,8 +6,11 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in opentelemetry-instrumentation-grpc.gemspec
 gemspec
+
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
 
 group :test do
   gem 'appraisal', '~> 2.5.0'
@@ -21,7 +24,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/grpc/test/test_helper.rb
+++ b/instrumentation/grpc/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/grpc/test/test_helper.rb
+++ b/instrumentation/grpc/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-test-helpers', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/gruf/test/test_helper.rb
+++ b/instrumentation/gruf/test/test_helper.rb
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'simplecov'
+require 'bundler/setup'
+Bundler.require(:default, :test)
+
 require 'opentelemetry/sdk'
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/gruf/test/test_helper.rb
+++ b/instrumentation/gruf/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry/sdk'
 require 'minitest/autorun'

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/http_client/test/test_helper.rb
+++ b/instrumentation/http_client/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/http_client/test/test_helper.rb
+++ b/instrumentation/http_client/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/httpx/test/test_helper.rb
+++ b/instrumentation/httpx/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/httpx/test/test_helper.rb
+++ b/instrumentation/httpx/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/koala/test/test_helper.rb
+++ b/instrumentation/koala/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/koala/test/test_helper.rb
+++ b/instrumentation/koala/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/lmdb/test/test_helper.rb
+++ b/instrumentation/lmdb/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/lmdb/test/test_helper.rb
+++ b/instrumentation/lmdb/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/logger/Gemfile
+++ b/instrumentation/logger/Gemfile
@@ -12,6 +12,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -24,7 +28,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/logger/Gemfile
+++ b/instrumentation/logger/Gemfile
@@ -12,8 +12,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/logger/test/test_helper.rb
+++ b/instrumentation/logger/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/logger/test/test_helper.rb
+++ b/instrumentation/logger/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'logger'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -16,7 +16,6 @@ group :local do
 end
 
 group :test do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
   gem 'minitest', '~> 6.0.0'

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -8,11 +8,20 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-helpers-mysql'
+    gem 'opentelemetry-helpers-sql'
+    gem 'opentelemetry-helpers-sql-processor'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
+    gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+    gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -8,11 +8,15 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
+  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
   gem 'minitest', '~> 6.0.0'

--- a/instrumentation/mysql2/test/test_helper.rb
+++ b/instrumentation/mysql2/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/mysql2/test/test_helper.rb
+++ b/instrumentation/mysql2/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'net/http'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 # Define custom HTTP method for testing unknown method handling
 module Net

--- a/instrumentation/net_http/test/test_helper.rb
+++ b/instrumentation/net_http/test/test_helper.rb
@@ -7,7 +7,7 @@
 require 'simplecov'
 require 'net/http'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 # Define custom HTTP method for testing unknown method handling
 module Net

--- a/instrumentation/net_ldap/Gemfile
+++ b/instrumentation/net_ldap/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/net_ldap/Gemfile
+++ b/instrumentation/net_ldap/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/net_ldap/test/test_helper.rb
+++ b/instrumentation/net_ldap/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'net/ldap'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/net_ldap/test/test_helper.rb
+++ b/instrumentation/net_ldap/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'net/ldap'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/openai/Gemfile
+++ b/instrumentation/openai/Gemfile
@@ -8,8 +8,17 @@ source 'https://rubygems.org'
 
 gemspec
 
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
+end
+
 group :test do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'appraisal', '~> 2.5.0'
   gem 'bundler', '~> 4.0.13'
   gem 'minitest', '~> 6.0.6'

--- a/instrumentation/openai/test/test_helper.rb
+++ b/instrumentation/openai/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/openai/test/test_helper.rb
+++ b/instrumentation/openai/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/pg/Gemfile
+++ b/instrumentation/pg/Gemfile
@@ -8,10 +8,18 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-helpers-sql'
+    gem 'opentelemetry-helpers-sql-processor'
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+    gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/pg/Gemfile
+++ b/instrumentation/pg/Gemfile
@@ -8,6 +8,12 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -19,9 +25,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
   gem 'activerecord', '>= 7.0.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_record'
 

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_record'
 

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -8,11 +8,20 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-pg', path: '../pg'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-helpers-sql'
+    gem 'opentelemetry-helpers-sql-processor'
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-pg'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+    gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-pg', path: '../pg'
+  end
 end
 
 group :test do

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -8,6 +8,13 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-pg', path: '../pg'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -19,10 +26,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-pg', path: '../pg'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/que/test/test_helper.rb
+++ b/instrumentation/que/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-instrumentation-que'
 

--- a/instrumentation/que/test/test_helper.rb
+++ b/instrumentation/que/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-instrumentation-que'
 

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -8,9 +8,17 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :test do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
+end
 
+group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
   gem 'minitest', '~> 6.0.0'

--- a/instrumentation/racecar/test/test_helper.rb
+++ b/instrumentation/racecar/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_support'
 

--- a/instrumentation/racecar/test/test_helper.rb
+++ b/instrumentation/racecar/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_support'
 

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -21,7 +25,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'rack-test', '~> 2.2.0'
   if RUBY_VERSION >= '3.4'
     gem 'base64'

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 require 'rack/events'
 require 'opentelemetry-instrumentation-rack'
 

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 require 'rack/events'
 require 'opentelemetry-instrumentation-rack'
 

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -8,17 +8,32 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-action_mailer', path: '../action_mailer'
-  gem 'opentelemetry-instrumentation-action_pack', path: '../action_pack'
-  gem 'opentelemetry-instrumentation-active_job', path: '../active_job'
-  gem 'opentelemetry-instrumentation-active_record', path: '../active_record'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-active_storage', path: '../active_storage'
-  gem 'opentelemetry-instrumentation-action_view', path: '../action_view'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../concurrent_ruby'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-action_mailer'
+    gem 'opentelemetry-instrumentation-action_pack'
+    gem 'opentelemetry-instrumentation-active_job'
+    gem 'opentelemetry-instrumentation-active_record'
+    gem 'opentelemetry-instrumentation-active_support'
+    gem 'opentelemetry-instrumentation-active_storage'
+    gem 'opentelemetry-instrumentation-action_view'
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-concurrent_ruby'
+    gem 'opentelemetry-instrumentation-rack'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-action_mailer', path: '../action_mailer'
+    gem 'opentelemetry-instrumentation-action_pack', path: '../action_pack'
+    gem 'opentelemetry-instrumentation-active_job', path: '../active_job'
+    gem 'opentelemetry-instrumentation-active_record', path: '../active_record'
+    gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+    gem 'opentelemetry-instrumentation-active_storage', path: '../active_storage'
+    gem 'opentelemetry-instrumentation-action_view', path: '../action_view'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../concurrent_ruby'
+    gem 'opentelemetry-instrumentation-rack', path: '../rack'
+  end
 end
 
 group :test do

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -8,6 +8,19 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-action_mailer', path: '../action_mailer'
+  gem 'opentelemetry-instrumentation-action_pack', path: '../action_pack'
+  gem 'opentelemetry-instrumentation-active_job', path: '../active_job'
+  gem 'opentelemetry-instrumentation-active_record', path: '../active_record'
+  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
+  gem 'opentelemetry-instrumentation-active_storage', path: '../active_storage'
+  gem 'opentelemetry-instrumentation-action_view', path: '../action_view'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../concurrent_ruby'
+  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -20,17 +33,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../concurrent_ruby'
-  gem 'opentelemetry-instrumentation-active_job', path: '../active_job'
-  gem 'opentelemetry-instrumentation-action_mailer', path: '../action_mailer'
-  gem 'opentelemetry-instrumentation-action_pack', path: '../action_pack'
-  gem 'opentelemetry-instrumentation-active_record', path: '../active_record'
-  gem 'opentelemetry-instrumentation-active_support', path: '../active_support'
-  gem 'opentelemetry-instrumentation-active_storage', path: '../active_storage'
-  gem 'opentelemetry-instrumentation-action_view', path: '../action_view'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'drb'

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -7,7 +7,7 @@
 require 'logger'
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rack/test'

--- a/instrumentation/rails/test/instrumentation/test_helper.rb
+++ b/instrumentation/rails/test/instrumentation/test_helper.rb
@@ -7,7 +7,7 @@
 require 'logger'
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rack/test'

--- a/instrumentation/rails/test/railtie/test_helper.rb
+++ b/instrumentation/rails/test/railtie/test_helper.rb
@@ -12,7 +12,7 @@ require 'logger'
 require 'simplecov'
 
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 require 'drb'
 
 require_relative '../../test/railtie/dummy/config/environment'

--- a/instrumentation/rails/test/railtie/test_helper.rb
+++ b/instrumentation/rails/test/railtie/test_helper.rb
@@ -12,7 +12,7 @@ require 'logger'
 require 'simplecov'
 
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 require 'drb'
 
 require_relative '../../test/railtie/dummy/config/environment'

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,7 +23,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/rake/test/test_helper.rb
+++ b/instrumentation/rake/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/rake/test/test_helper.rb
+++ b/instrumentation/rake/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -20,7 +24,6 @@ group :test do
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-sdk', '~> 1.13.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/rdkafka/test/test_helper.rb
+++ b/instrumentation/rdkafka/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/rdkafka/test/test_helper.rb
+++ b/instrumentation/rdkafka/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -18,7 +22,6 @@ group :test do
   gem 'rubocop-performance', '~> 1.27.0'
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/redis/test/test_helper.rb
+++ b/instrumentation/redis/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/redis/test/test_helper.rb
+++ b/instrumentation/redis/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 

--- a/instrumentation/resque/Gemfile
+++ b/instrumentation/resque/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/resque/Gemfile
+++ b/instrumentation/resque/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -21,7 +25,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/resque/test/test_helper.rb
+++ b/instrumentation/resque/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'active_job'
 

--- a/instrumentation/resque/test/test_helper.rb
+++ b/instrumentation/resque/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'active_job'
 

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -8,8 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+  end
 end
 
 group :test do

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -8,6 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -21,7 +25,6 @@ group :test do
   gem 'yard', '~> 0.9.0'
   gem 'opentelemetry-sdk', '~> 1.13.0'
   gem 'rspec', '~> 3.13.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'logger'

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-redis', path: '../redis'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-redis'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-redis', path: '../redis'
+  end
 end
 
 group :test do

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-redis', path: '../redis'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -20,8 +25,6 @@ group :test do
   gem 'yard', '~> 0.9.0'
   gem 'rails', '>= 7.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-redis', path: '../redis'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -8,9 +8,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-instrumentation-rack'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-instrumentation-rack', path: '../rack'
+  end
 end
 
 group :test do

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -8,6 +8,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-instrumentation-rack', path: '../rack'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'minitest', '~> 6.0.0'
@@ -19,8 +24,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'webmock', '~> 3.26.0'
   gem 'yard', '~> 0.9.0'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-instrumentation-rack', path: '../rack'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'mutex_m'

--- a/instrumentation/sinatra/test/test_helper.rb
+++ b/instrumentation/sinatra/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['APP_ENV'] = 'test'
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rack/test'

--- a/instrumentation/sinatra/test/test_helper.rb
+++ b/instrumentation/sinatra/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['APP_ENV'] = 'test'
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rack/test'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -8,6 +8,14 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :local do
+  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
+  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+  gem 'opentelemetry-instrumentation-base', path: '../base'
+  gem 'opentelemetry-propagator-vitess', path: '../../propagator/vitess'
+end
+
 group :test do
   gem 'appraisal', '~> 2.5.0'
   gem 'dotenv', '~> 3.2.0'
@@ -20,11 +28,6 @@ group :test do
   gem 'simplecov', '~> 1.1.0'
   gem 'yard', '~> 0.9.0'
   gem 'rspec-mocks', '~> 3.13.7'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-propagator-vitess', path: '../../propagator/vitess'
   if RUBY_VERSION >= '3.4'
     gem 'base64'
     gem 'bigdecimal'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -8,12 +8,22 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :local do
-  gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
-  gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
-  gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
-  gem 'opentelemetry-instrumentation-base', path: '../base'
-  gem 'opentelemetry-propagator-vitess', path: '../../propagator/vitess'
+if ENV['OTEL_GEM_CACHE_DIR']
+  source "file://#{ENV['OTEL_GEM_CACHE_DIR']}" do
+    gem 'opentelemetry-helpers-mysql'
+    gem 'opentelemetry-helpers-sql'
+    gem 'opentelemetry-helpers-sql-processor'
+    gem 'opentelemetry-instrumentation-base'
+    gem 'opentelemetry-propagator-vitess'
+  end
+elsif ENV['USE_PUBLISHED_GEMS'] != 'true'
+  group :local do
+    gem 'opentelemetry-helpers-mysql', path: '../../helpers/mysql'
+    gem 'opentelemetry-helpers-sql', path: '../../helpers/sql'
+    gem 'opentelemetry-helpers-sql-processor', path: '../../helpers/sql-processor'
+    gem 'opentelemetry-instrumentation-base', path: '../base'
+    gem 'opentelemetry-propagator-vitess', path: '../../propagator/vitess'
+  end
 end
 
 group :test do

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -9,7 +9,7 @@ Dotenv.load('.env', '../.env')
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/processor/baggage/test/test_helper.rb
+++ b/processor/baggage/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/processor/baggage/test/test_helper.rb
+++ b/processor/baggage/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'

--- a/propagator/google_cloud_trace_context/test/test_helper.rb
+++ b/propagator/google_cloud_trace_context/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-propagator-google_cloud_trace_context'
 require 'minitest/autorun'

--- a/propagator/google_cloud_trace_context/test/test_helper.rb
+++ b/propagator/google_cloud_trace_context/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-propagator-google_cloud_trace_context'
 require 'minitest/autorun'

--- a/propagator/ottrace/test/test_helper.rb
+++ b/propagator/ottrace/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-propagator-ottrace'
 require 'minitest/autorun'

--- a/propagator/ottrace/test/test_helper.rb
+++ b/propagator/ottrace/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-propagator-ottrace'
 require 'minitest/autorun'

--- a/propagator/vitess/test/test_helper.rb
+++ b/propagator/vitess/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-propagator-vitess'
 require 'minitest/autorun'

--- a/propagator/vitess/test/test_helper.rb
+++ b/propagator/vitess/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-propagator-vitess'
 require 'minitest/autorun'

--- a/propagator/xray/test/test_helper.rb
+++ b/propagator/xray/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-propagator-xray'
 require 'minitest/autorun'

--- a/propagator/xray/test/test_helper.rb
+++ b/propagator/xray/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-propagator-xray'
 require 'minitest/autorun'

--- a/resources/aws/test/test_helper.rb
+++ b/resources/aws/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-resource-detector-aws'
 require 'minitest/autorun'

--- a/resources/aws/test/test_helper.rb
+++ b/resources/aws/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-resource-detector-aws'
 require 'minitest/autorun'

--- a/resources/azure/test/test_helper.rb
+++ b/resources/azure/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-resource-detector-azure'
 require 'minitest/autorun'

--- a/resources/azure/test/test_helper.rb
+++ b/resources/azure/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-resource-detector-azure'
 require 'minitest/autorun'

--- a/resources/container/test/test_helper.rb
+++ b/resources/container/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-resource-detector-container'
 require 'minitest/autorun'

--- a/resources/container/test/test_helper.rb
+++ b/resources/container/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-resource-detector-container'
 require 'minitest/autorun'

--- a/resources/google_cloud_platform/test/test_helper.rb
+++ b/resources/google_cloud_platform/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-resource-detector-google_cloud_platform'
 require 'minitest/autorun'

--- a/resources/google_cloud_platform/test/test_helper.rb
+++ b/resources/google_cloud_platform/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-resource-detector-google_cloud_platform'
 require 'minitest/autorun'

--- a/resources/os/test/test_helper.rb
+++ b/resources/os/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-resource-detector-os'
 require 'minitest/autorun'

--- a/sampler/xray/test/test_helper.rb
+++ b/sampler/xray/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :development, :test)
+Bundler.require(:default, :test)
 
 require 'opentelemetry-sampler-xray'
 require 'minitest/autorun'

--- a/sampler/xray/test/test_helper.rb
+++ b/sampler/xray/test/test_helper.rb
@@ -6,7 +6,7 @@
 
 require 'simplecov'
 require 'bundler/setup'
-Bundler.require(:default, :test)
+Bundler.require(:default, :local, :test)
 
 require 'opentelemetry-sampler-xray'
 require 'minitest/autorun'


### PR DESCRIPTION
This moves rubocop into a development group and remove this group from the bundler loader in the test_helper.

This reduces the dependencies loaded. This was needed to eliminate warnings from conflicts in the combined build.

Also local dependencies have been moved to a local group which is loaded so that they could be excluded  from generated appraisals hence would trigger download of gems etc.

The gemfile now was the following modes
- **`ENV['OTEL_GEM_CACHE_DIR']` set**: install local gems from pre-built cache and ignore local path
- **`ENV['USE_PUBLISHED_GEMS'] == 'true'`**: install gems from public registry and ignore local path
- **fallback**: use local path/source rather than gem

In the future ci could:
- leverage these modes to pre-build all gems and run the tests/installation using the pre-built gems before they are published rather than source
- Replace existing installation test with the 2nd mode

Note The index needs to be generated for that directory which is done by gem generate_index --directory abc