### PR TITLE
ci: update labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,12 @@ deprecated:
           - "instrumentation/mongo/**"
           - "instrumentation/restclient/**"
           - "instrumentation/ruby_kafka/**"
+everything:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".simplecov"
+          - "Gemfile"
+          - "Rakefile"
 
 helpers-mysql:
   - changed-files:
@@ -221,7 +227,7 @@ instrumentation-restclient:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/restclient/**"
-instrumentation-respec:
+instrumentation-rspec:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/rspec/**"


### PR DESCRIPTION
This adds an everything label when a file is changed which impacts everything which is produced/tested both locally & in ci. For instance rakefile, root gemfile etc.

This is useful when gems import dependencies from the root gemfile.

Also a typo in an existing label is fixed.