### PR TITLE
feat: Update OpenAI instrumentation for logs and CI

### DIFF
--- a/.github/workflows/ci-instrumentation-full.yml
+++ b/.github/workflows/ci-instrumentation-full.yml
@@ -37,6 +37,7 @@ on:
       - "instrumentation/logger/**"
       - "instrumentation/net_http/**"
       - "instrumentation/net_ldap/**"
+      - "instrumentation/openai/**"
       - "instrumentation/rack/**"
       - "instrumentation/rails/**"
       - "instrumentation/rake/**"
@@ -104,6 +105,7 @@ jobs:
           - logger
           - net_http
           - net_ldap
+          - openai
           - rack
           - rails
           - rake

--- a/instrumentation/openai/Appraisals
+++ b/instrumentation/openai/Appraisals
@@ -6,14 +6,16 @@
 
 %w[0.66.0 0.80.0].each do |version|
   appraise "openai-#{version}" do
-    gem 'openai', "~> #{version}"
+    # JRuby and TruffleRuby support is best effort for the openai gem
+    # as of 2026-09-02. This may change in the future and we can test it.
+    gem 'openai', "~> #{version}", platform: :mri
   end
 
   # Logs support is opt-in, based on the presence of the
   # opentelemetry-logs-api and opentelemetry-logs-sdk gems.
   # This Appraisal tests behavior with them present.
   appraise "openai-#{version}-logs" do
-    gem 'openai', "~> #{version}"
+    gem 'openai', "~> #{version}", platform: :mri
     gem 'opentelemetry-logs-api', '= 0.4.1'
     gem 'opentelemetry-logs-sdk', '= 0.6.1'
   end

--- a/instrumentation/openai/Appraisals
+++ b/instrumentation/openai/Appraisals
@@ -11,7 +11,7 @@
 
   # Logs support is opt-in, based on the presence of the
   # opentelemetry-logs-api and opentelemetry-logs-sdk gems.
-  # Run some tests with these gems present.
+  # This Appraisal tests behavior with them present.
   appraise "openai-#{version}-logs" do
     gem 'openai', "~> #{version}"
     gem 'opentelemetry-logs-api', '= 0.4.1'

--- a/instrumentation/openai/Appraisals
+++ b/instrumentation/openai/Appraisals
@@ -8,4 +8,13 @@
   appraise "openai-#{version}" do
     gem 'openai', "~> #{version}"
   end
+
+  # Logs support is opt-in, based on the presence of the
+  # opentelemetry-logs-api and opentelemetry-logs-sdk gems.
+  # Run some tests with these gems present.
+  appraise "openai-#{version}-logs" do
+    gem 'openai', "~> #{version}"
+    gem 'opentelemetry-logs-api', '= 0.4.1'
+    gem 'opentelemetry-logs-sdk', '= 0.6.1'
+  end
 end

--- a/instrumentation/openai/Gemfile
+++ b/instrumentation/openai/Gemfile
@@ -14,7 +14,6 @@ group :test do
   gem 'bundler', '~> 4.0.13'
   gem 'minitest', '~> 6.0.6'
   gem 'opentelemetry-sdk', '~> 1.12.0'
-  gem 'opentelemetry-logs-sdk', '~> 0.6.0'
   gem 'opentelemetry-test-helpers', '~> 0.9.0'
   gem 'rake', '~> 13.4.2'
   gem 'rubocop', '~> 1.90.0'

--- a/instrumentation/openai/Gemfile
+++ b/instrumentation/openai/Gemfile
@@ -11,7 +11,6 @@ gemspec
 group :test do
   gem 'opentelemetry-instrumentation-base', path: '../base'
   gem 'appraisal', '~> 2.5.0'
-  gem 'bundler', '~> 4.0.13'
   gem 'minitest', '~> 6.0.6'
   gem 'opentelemetry-sdk', '~> 1.12.0'
   gem 'opentelemetry-test-helpers', '~> 0.9.0'

--- a/instrumentation/openai/README.md
+++ b/instrumentation/openai/README.md
@@ -64,7 +64,8 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 [GenAI semantic conventions define events to emit with instrumentation][genai-semconv-events]. Events are emitted using the Logs signal. The `opentelemetry-instrumentation-openai` gem does not depend on the `opentelemetry-logs-api` gem because it has not reached stability. However, if you have the Logs API and Logs SDK gems installed in your Gemfile, it will emit Log Records for the GenAI events.
 
 To enable the instrumentation to emit logs, add the following to your Gemfile:
-```
+
+```ruby
 gem 'opentelemetry-logs-api'
 gem 'opentelemetry-logs-sdk'
 ```

--- a/instrumentation/openai/README.md
+++ b/instrumentation/openai/README.md
@@ -59,6 +59,16 @@ environment variable:
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 ```
 
+## Emitting log events
+
+[GenAI semantic conventions define events to emit with instrumentation][genai-semconv-events]. Events are emitted using the Logs signal. The `opentelemetry-instrumentation-openai` gem does not depend on the `opentelemetry-logs-api` gem because it has not reached stability. However, if you have the Logs API and Logs SDK gems installed in your Gemfile, it will emit Log Records for the GenAI events.
+
+To enable the instrumentation to emit logs, add the following to your Gemfile:
+```
+gem 'opentelemetry-logs-api'
+gem 'opentelemetry-logs-sdk'
+```
+
 ## Examples
 
 See [example/trace_demonstration.rb][example-github] for a runnable example that instruments chat completion, streaming, and embeddings requests and prints spans and log records to the console. Set the `OPENAI_API_KEY` environment variable before running it.
@@ -87,3 +97,4 @@ The `opentelemetry-instrumentation-openai` gem is distributed under the Apache 2
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
 [semconv-genai]: https://github.com/open-telemetry/semantic-conventions-genai
 [example-github]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/openai/example/trace_demonstration.rb
+[genai-semconv-events]: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai.rb
@@ -6,7 +6,6 @@
 
 require 'opentelemetry'
 require 'opentelemetry-instrumentation-base'
-require 'opentelemetry-logs-api'
 
 module OpenTelemetry
   module Instrumentation

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
@@ -64,11 +64,13 @@ module OpenTelemetry
         def create_logger
           # Users must install the OpenTelemetry Logs API and SDK gems to
           # create log events. The Logs API is still unstable, unlike the
-          # Traces API, so we require users to isntall it themselves.
+          # Traces API, so we require users to install it themselves.
+          # If the libraries are not detected, Instrumentation.instance.logger
+          # will be nil.
           if defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
             @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
           elsif defined?(OpenTelemetry::Logs)
-            # If there is no Logs SDK, we can still have a NOOP_LOGGER running
+            # If the Logs SDK is missing, we can still run a NOOP_LOGGER
             # if the API is present.
             @logger = OpenTelemetry::Logs::LoggerProvider::NOOP_LOGGER
           end

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
@@ -62,7 +62,16 @@ module OpenTelemetry
         end
 
         def create_logger
-          @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
+          # Users must install the OpenTelemetry Logs API and SDK gems to
+          # create log events. The Logs API is still unstable, unlike the
+          # Traces API, so we require users to isntall it themselves.
+          if defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
+            @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
+          elsif defined?(OpenTelemetry::Logs)
+            # If there is no Logs SDK, we can still have a NOOP_LOGGER running
+            # if the API is present.
+            @logger = OpenTelemetry::Logs::LoggerProvider::NOOP_LOGGER
+          end
         end
 
         def patch_client

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
@@ -69,10 +69,6 @@ module OpenTelemetry
           # will be nil.
           if defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
             @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
-          elsif defined?(OpenTelemetry::Logs)
-            # If the Logs SDK is missing, we can still run a NOOP_LOGGER
-            # if the API is present.
-            @logger = OpenTelemetry::Logs::LoggerProvider::NOOP_LOGGER
           end
         end
 

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
@@ -67,9 +67,9 @@ module OpenTelemetry
           # Traces API, so we require users to install it themselves.
           # If the libraries are not detected, Instrumentation.instance.logger
           # will be nil.
-          if defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
-            @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
-          end
+          return unless defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
+
+          @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
         end
 
         def patch_client

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/patches/utils.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/patches/utils.rb
@@ -114,7 +114,9 @@ module OpenTelemetry
 
           # Emits a structured log record through the OpenTelemetry Logs API.
           def log_structured_event(event)
-            OpenAI::Instrumentation.instance.logger.on_emit(
+            return unless Instrumentation.instance.logger
+
+            Instrumentation.instance.logger.on_emit(
               timestamp: Time.now,
               severity_text: 'INFO',
               severity_number: OpenTelemetry::Logs::SeverityNumber::SEVERITY_NUMBER_INFO,

--- a/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
+++ b/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.3'
 
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
-  spec.add_dependency 'opentelemetry-logs-api', '~> 0.4.1'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
+++ b/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.description = 'OpenAI instrumentation for the OpenTelemetry framework'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
+  spec.platform    = Gem::Platform::RUBY
 
   spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('*.md') +

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/client_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/client_test.rb
@@ -117,34 +117,66 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::Client do
       _(client_span.attributes['gen_ai.request.reasoning.level']).must_equal 'high'
     end
 
-    it 'captures message content when enabled' do
-      # Content capture is emitted as log records through the Logs API,
-      # not as span events.
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install
-      instrumentation.config[:capture_content] = true
+    describe 'capturing message content' do
+      describe 'without logs installed' do
+        before { skip if defined?(OpenTelemetry::SDK::Logs) }
 
-      client = OpenAI::Client.new(api_key: 'test-token')
-      client.chat.completions.create(
-        model: model,
-        messages: messages
-      )
+        it 'does not capture message content when enabled' do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+          instrumentation.config[:capture_content] = true
 
-      _(client_span).wont_be_nil
+          # No Logs SDK means the instrumentation's logger stays nil, which is
+          # what makes log_structured_event a no-op (see Utils#log_structured_event).
+          _(instrumentation.logger).must_be_nil
 
-      log_records = LOG_EXPORTER.emitted_log_records
-      event_names = log_records.map(&:event_name)
-      _(event_names).must_include 'gen_ai.user.message'
-      _(event_names).must_include 'gen_ai.choice'
+          client = OpenAI::Client.new(api_key: 'test-token')
+          client.chat.completions.create(
+            model: model,
+            messages: messages
+          )
 
-      user_message = log_records.find { |r| r.event_name == 'gen_ai.user.message' }
-      _(user_message.attributes['gen_ai.provider.name']).must_equal 'openai'
-      _(user_message.body[:content]).must_equal 'Hello!'
+          _(client_span).wont_be_nil
+          _(client_span.attributes['gen_ai.operation.name']).must_equal 'chat'
+          _(client_span.attributes['gen_ai.response.finish_reasons']).must_equal ['stop']
 
-      choice = log_records.find { |r| r.event_name == 'gen_ai.choice' }
-      _(choice.attributes['gen_ai.provider.name']).must_equal 'openai'
-      _(choice.body[:message][:content]).must_equal 'Hello! How can I assist you today?'
-      _(choice.body[:finish_reason]).must_equal 'stop'
+          _(LOG_EXPORTER.emitted_log_records).must_be_empty
+        end
+      end
+
+      describe 'with logs installed' do
+        before { skip unless defined?(OpenTelemetry::SDK::Logs) }
+
+        it 'captures message content when enabled' do
+          # Content capture is emitted as log records through the Logs API,
+          # not as span events.
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install
+          instrumentation.config[:capture_content] = true
+
+          client = OpenAI::Client.new(api_key: 'test-token')
+          client.chat.completions.create(
+            model: model,
+            messages: messages
+          )
+
+          _(client_span).wont_be_nil
+
+          log_records = LOG_EXPORTER.emitted_log_records
+          event_names = log_records.map(&:event_name)
+          _(event_names).must_include 'gen_ai.user.message'
+          _(event_names).must_include 'gen_ai.choice'
+
+          user_message = log_records.find { |r| r.event_name == 'gen_ai.user.message' }
+          _(user_message.attributes['gen_ai.provider.name']).must_equal 'openai'
+          _(user_message.body[:content]).must_equal 'Hello!'
+
+          choice = log_records.find { |r| r.event_name == 'gen_ai.choice' }
+          _(choice.attributes['gen_ai.provider.name']).must_equal 'openai'
+          _(choice.body[:message][:content]).must_equal 'Hello! How can I assist you today?'
+          _(choice.body[:finish_reason]).must_equal 'stop'
+        end
+      end
     end
   end
 

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/client_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/client_test.rb
@@ -126,8 +126,6 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::Client do
           instrumentation.install
           instrumentation.config[:capture_content] = true
 
-          # No Logs SDK means the instrumentation's logger stays nil, which is
-          # what makes log_structured_event a no-op (see Utils#log_structured_event).
           _(instrumentation.logger).must_be_nil
 
           client = OpenAI::Client.new(api_key: 'test-token')

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/stream_wrapper_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/stream_wrapper_test.rb
@@ -397,11 +397,6 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper do
         before { skip if defined?(OpenTelemetry::SDK::Logs) }
 
         it 'does not find log records when streaming' do
-          # No Logs SDK means the instrumentation's logger stays nil, which is
-          # what makes log_structured_event a no-op (see Utils#log_structured_event).
-          # LOG_EXPORTER itself is a stub in this configuration that always
-          # returns [] (see test_helper.rb), so the logger check above is the
-          # assertion that actually exercises this code path.
           _(instrumentation.logger).must_be_nil
 
           span = tracer.start_root_span('test_span', kind: :client)

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/stream_wrapper_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/stream_wrapper_test.rb
@@ -218,61 +218,6 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper do
       _(span.attributes['openai.response.service_tier']).must_equal 'default'
     end
 
-    it 'accumulates streaming content correctly' do
-      span = tracer.start_root_span('test_span', kind: :client)
-
-      chunks = [
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content, :role).new('Hello', :assistant),
-              nil
-            )
-          ]
-        ),
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content).new(' world'),
-              nil
-            )
-          ]
-        ),
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content).new('!'),
-              :stop
-            )
-          ]
-        )
-      ]
-
-      stream = chunks.each
-      wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
-        stream,
-        span,
-        true
-      )
-
-      wrapper.each { |_chunk| }
-
-      choice = LOG_EXPORTER.emitted_log_records.find { |r| r.event_name == 'gen_ai.choice' }
-      _(choice).wont_be_nil
-      _(choice.attributes['gen_ai.provider.name']).must_equal 'openai'
-      _(choice.body[:finish_reason]).must_equal 'stop'
-      _(choice.body[:message][:content]).must_equal 'Hello world!'
-    end
-
     it 'handles streaming with usage information including token details' do
       span = tracer.start_root_span('test_span', kind: :client)
 
@@ -361,135 +306,6 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper do
       _(span_without_start.attributes).wont_include 'gen_ai.response.time_to_first_chunk'
     end
 
-    it 'handles streaming with tool calls' do
-      span = tracer.start_root_span('test_span', kind: :client)
-
-      chunks = [
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:role, :tool_calls).new(
-                :assistant,
-                [
-                  Struct.new(:index, :id, :function).new(
-                    0,
-                    'call_123',
-                    Struct.new(:name, :arguments).new('get_weather', '{"loc')
-                  )
-                ]
-              ),
-              nil
-            )
-          ]
-        ),
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:tool_calls).new(
-                [
-                  Struct.new(:index, :function).new(
-                    0,
-                    Struct.new(:arguments).new('ation":"NYC"}')
-                  )
-                ]
-              ),
-              nil
-            )
-          ]
-        ),
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content).new(nil),
-              :tool_calls
-            )
-          ]
-        )
-      ]
-
-      stream = chunks.each
-      wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
-        stream,
-        span,
-        true
-      )
-
-      wrapper.each { |_chunk| }
-
-      choice = LOG_EXPORTER.emitted_log_records.find { |r| r.event_name == 'gen_ai.choice' }
-      _(choice).wont_be_nil
-      tool_calls = choice.body[:message][:tool_calls]
-      _(tool_calls).wont_be_nil
-      _(tool_calls.first[:function][:name]).must_equal 'get_weather'
-      _(tool_calls.first[:function][:arguments]).must_include 'location'
-      _(tool_calls.first[:function][:arguments]).must_include 'NYC'
-    end
-
-    it 'handles multiple choices in streaming' do
-      span = tracer.start_root_span('test_span', kind: :client)
-
-      chunks = [
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content, :role).new('Choice 1', :assistant),
-              nil
-            ),
-            Struct.new(:index, :delta, :finish_reason).new(
-              1,
-              Struct.new(:content, :role).new('Choice 2', :assistant),
-              nil
-            )
-          ]
-        ),
-        Struct.new(:id, :model, :choices).new(
-          'chatcmpl-123',
-          'gpt-4',
-          [
-            Struct.new(:index, :delta, :finish_reason).new(
-              0,
-              Struct.new(:content).new(nil),
-              :stop
-            ),
-            Struct.new(:index, :delta, :finish_reason).new(
-              1,
-              Struct.new(:content).new(nil),
-              :stop
-            )
-          ]
-        )
-      ]
-
-      stream = chunks.each
-      wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
-        stream,
-        span,
-        true
-      )
-
-      wrapper.each { |_chunk| }
-
-      _(span.attributes['gen_ai.response.finish_reasons']).must_equal %w[stop stop]
-
-      choice_contents = LOG_EXPORTER.emitted_log_records
-                                    .select { |r| r.event_name == 'gen_ai.choice' }
-                                    .map { |r| r.body[:message][:content] }
-      _(choice_contents).must_include 'Choice 1'
-      _(choice_contents).must_include 'Choice 2'
-    end
-
     it 'handles errors during streaming' do
       span = tracer.start_root_span('test_span', kind: :client)
 
@@ -574,6 +390,440 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper do
       wrapper.each { |_chunk| }
 
       _(LOG_EXPORTER.emitted_log_records).must_be_empty
+    end
+
+    describe 'log records' do
+      describe 'without logs installed (default)' do
+        before { skip if defined?(OpenTelemetry::SDK::Logs) }
+
+        it 'does not find log records when streaming' do
+          # No Logs SDK means the instrumentation's logger stays nil, which is
+          # what makes log_structured_event a no-op (see Utils#log_structured_event).
+          # LOG_EXPORTER itself is a stub in this configuration that always
+          # returns [] (see test_helper.rb), so the logger check above is the
+          # assertion that actually exercises this code path.
+          _(instrumentation.logger).must_be_nil
+
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Hello', :assistant),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(' world'),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new('!'),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(span.attributes['gen_ai.response.finish_reasons']).must_equal ['stop']
+          _(LOG_EXPORTER.emitted_log_records).must_be_empty
+        end
+
+        it 'handles multiple choices in streaming' do
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Choice 1', :assistant),
+                  nil
+                ),
+                Struct.new(:index, :delta, :finish_reason).new(
+                  1,
+                  Struct.new(:content, :role).new('Choice 2', :assistant),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(nil),
+                  :stop
+                ),
+                Struct.new(:index, :delta, :finish_reason).new(
+                  1,
+                  Struct.new(:content).new(nil),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(span.attributes['gen_ai.response.finish_reasons']).must_equal %w[stop stop]
+        end
+
+        it 'does not log content when capture_content is false' do
+          _(instrumentation.logger).must_be_nil
+
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Secret content', :assistant),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            false # capture_content disabled
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(span.attributes['gen_ai.response.finish_reasons']).must_equal ['stop']
+          _(LOG_EXPORTER.emitted_log_records).must_be_empty
+        end
+
+        it 'handles streaming with tool calls without raising and without emitting logs' do
+          _(instrumentation.logger).must_be_nil
+
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:role, :tool_calls).new(
+                    :assistant,
+                    [
+                      Struct.new(:index, :id, :function).new(
+                        0,
+                        'call_123',
+                        Struct.new(:name, :arguments).new('get_weather', '{"loc')
+                      )
+                    ]
+                  ),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:tool_calls).new(
+                    [
+                      Struct.new(:index, :function).new(
+                        0,
+                        Struct.new(:arguments).new('ation":"NYC"}')
+                      )
+                    ]
+                  ),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(nil),
+                  :tool_calls
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(span.attributes['gen_ai.response.finish_reasons']).must_equal ['tool_calls']
+          _(LOG_EXPORTER.emitted_log_records).must_be_empty
+        end
+      end
+
+      describe 'with logs installed' do
+        before { skip unless defined?(OpenTelemetry::SDK::Logs) }
+
+        it 'accumulates streaming content correctly' do
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Hello', :assistant),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(' world'),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new('!'),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          choice = LOG_EXPORTER.emitted_log_records.find { |r| r.event_name == 'gen_ai.choice' }
+          _(choice).wont_be_nil
+          _(choice.attributes['gen_ai.provider.name']).must_equal 'openai'
+          _(choice.body[:finish_reason]).must_equal 'stop'
+          _(choice.body[:message][:content]).must_equal 'Hello world!'
+        end
+
+        it 'handles multiple choices in streaming' do
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Choice 1', :assistant),
+                  nil
+                ),
+                Struct.new(:index, :delta, :finish_reason).new(
+                  1,
+                  Struct.new(:content, :role).new('Choice 2', :assistant),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(nil),
+                  :stop
+                ),
+                Struct.new(:index, :delta, :finish_reason).new(
+                  1,
+                  Struct.new(:content).new(nil),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(span.attributes['gen_ai.response.finish_reasons']).must_equal %w[stop stop]
+
+          choice_contents = LOG_EXPORTER.emitted_log_records
+                                        .select { |r| r.event_name == 'gen_ai.choice' }
+                                        .map { |r| r.body[:message][:content] }
+          _(choice_contents).must_include 'Choice 1'
+          _(choice_contents).must_include 'Choice 2'
+        end
+
+        it 'does not log content when capture_content is false' do
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content, :role).new('Secret content', :assistant),
+                  :stop
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            false # capture_content disabled
+          )
+
+          wrapper.each { |_chunk| }
+
+          _(LOG_EXPORTER.emitted_log_records).must_be_empty
+        end
+
+        it 'handles streaming with tool calls' do
+          span = tracer.start_root_span('test_span', kind: :client)
+
+          chunks = [
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:role, :tool_calls).new(
+                    :assistant,
+                    [
+                      Struct.new(:index, :id, :function).new(
+                        0,
+                        'call_123',
+                        Struct.new(:name, :arguments).new('get_weather', '{"loc')
+                      )
+                    ]
+                  ),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:tool_calls).new(
+                    [
+                      Struct.new(:index, :function).new(
+                        0,
+                        Struct.new(:arguments).new('ation":"NYC"}')
+                      )
+                    ]
+                  ),
+                  nil
+                )
+              ]
+            ),
+            Struct.new(:id, :model, :choices).new(
+              'chatcmpl-123',
+              'gpt-4',
+              [
+                Struct.new(:index, :delta, :finish_reason).new(
+                  0,
+                  Struct.new(:content).new(nil),
+                  :tool_calls
+                )
+              ]
+            )
+          ]
+
+          stream = chunks.each
+          wrapper = OpenTelemetry::Instrumentation::OpenAI::Patches::StreamWrapper.new(
+            stream,
+            span,
+            true
+          )
+
+          wrapper.each { |_chunk| }
+
+          choice = LOG_EXPORTER.emitted_log_records.find { |r| r.event_name == 'gen_ai.choice' }
+          _(choice).wont_be_nil
+          tool_calls = choice.body[:message][:tool_calls]
+          _(tool_calls).wont_be_nil
+          _(tool_calls.first[:function][:name]).must_equal 'get_weather'
+          _(tool_calls.first[:function][:arguments]).must_include 'location'
+          _(tool_calls.first[:function][:arguments]).must_include 'NYC'
+        end
+      end
     end
   end
 end

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/utils_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/utils_test.rb
@@ -302,43 +302,62 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::Utils do
   end
 
   describe '#log_structured_event' do
-    before do
-      LOG_EXPORTER.reset
+    describe 'without logs gems installed' do
+      before do
+        skip if defined?(OpenTelemetry::Logs)
+      end
+
+      it 'returns nil' do
+        event = {
+          event_name: 'gen_ai.user.message',
+          attributes: { 'gen_ai.provider.name' => 'openai' },
+          body: { content: 'Hello' }
+        }
+
+        assert_nil utils_class.log_structured_event(event)
+      end
     end
 
-    it 'emits the event as a log record through the Logs API' do
-      event = {
-        event_name: 'gen_ai.user.message',
-        attributes: { 'gen_ai.provider.name' => 'openai' },
-        body: { content: 'Hello' }
-      }
+    describe 'with logs gems installed (default)' do
+      before do
+        skip unless defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
+        LOG_EXPORTER.reset
+      end
 
-      utils_class.log_structured_event(event)
+      it 'emits the event as a log record through the Logs API' do
+        event = {
+          event_name: 'gen_ai.user.message',
+          attributes: { 'gen_ai.provider.name' => 'openai' },
+          body: { content: 'Hello' }
+        }
 
-      log_records = LOG_EXPORTER.emitted_log_records
-      _(log_records.size).must_equal 1
+        utils_class.log_structured_event(event)
 
-      log_record = log_records.first
-      _(log_record.event_name).must_equal 'gen_ai.user.message'
-      _(log_record.attributes['gen_ai.provider.name']).must_equal 'openai'
-      _(log_record.body[:content]).must_equal 'Hello'
-    end
+        log_records = LOG_EXPORTER.emitted_log_records
+        _(log_records.size).must_equal 1
 
-    it 'handles events with nil body' do
-      event = {
-        event_name: 'gen_ai.user.message',
-        attributes: { 'gen_ai.provider.name' => 'openai' },
-        body: nil
-      }
+        log_record = log_records.first
+        _(log_record.event_name).must_equal 'gen_ai.user.message'
+        _(log_record.attributes['gen_ai.provider.name']).must_equal 'openai'
+        _(log_record.body[:content]).must_equal 'Hello'
+      end
 
-      utils_class.log_structured_event(event)
+      it 'handles events with nil body' do
+        event = {
+          event_name: 'gen_ai.user.message',
+          attributes: { 'gen_ai.provider.name' => 'openai' },
+          body: nil
+        }
 
-      log_records = LOG_EXPORTER.emitted_log_records
-      _(log_records.size).must_equal 1
+        utils_class.log_structured_event(event)
 
-      log_record = log_records.first
-      _(log_record.event_name).must_equal 'gen_ai.user.message'
-      _(log_record.body).must_be_nil
+        log_records = LOG_EXPORTER.emitted_log_records
+        _(log_records.size).must_equal 1
+
+        log_record = log_records.first
+        _(log_record.event_name).must_equal 'gen_ai.user.message'
+        _(log_record.body).must_be_nil
+      end
     end
   end
 end

--- a/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/utils_test.rb
+++ b/instrumentation/openai/test/opentelemetry/instrumentation/openai/patches/utils_test.rb
@@ -302,7 +302,17 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::Utils do
   end
 
   describe '#log_structured_event' do
-    describe 'without logs gems installed' do
+    let(:instrumentation) { OpenTelemetry::Instrumentation::OpenAI::Instrumentation.instance }
+
+    before do
+      instrumentation.install
+    end
+
+    after do
+      instrumentation.instance_variable_set(:@installed, false)
+    end
+
+    describe 'without logs gems installed (default)' do
       before do
         skip if defined?(OpenTelemetry::Logs)
       end
@@ -318,7 +328,7 @@ describe OpenTelemetry::Instrumentation::OpenAI::Patches::Utils do
       end
     end
 
-    describe 'with logs gems installed (default)' do
+    describe 'with logs gems installed' do
       before do
         skip unless defined?(OpenTelemetry::Logs) && defined?(OpenTelemetry::SDK::Logs)
         LOG_EXPORTER.reset

--- a/instrumentation/openai/test/test_helper.rb
+++ b/instrumentation/openai/test/test_helper.rb
@@ -22,6 +22,7 @@ if defined?(OpenTelemetry::SDK::Logs)
 else
   LogExporter = Struct.new do
     def reset; end
+
     def emitted_log_records
       []
     end

--- a/instrumentation/openai/test/test_helper.rb
+++ b/instrumentation/openai/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)
 

--- a/instrumentation/openai/test/test_helper.rb
+++ b/instrumentation/openai/test/test_helper.rb
@@ -16,8 +16,20 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 # global opentelemetry-logs-sdk setup:
-LOG_EXPORTER = OpenTelemetry::SDK::Logs::Export::InMemoryLogRecordExporter.new
-log_record_processor = OpenTelemetry::SDK::Logs::Export::SimpleLogRecordProcessor.new(LOG_EXPORTER)
+if defined?(OpenTelemetry::SDK::Logs)
+  LOG_EXPORTER = OpenTelemetry::SDK::Logs::Export::InMemoryLogRecordExporter.new
+  log_record_processor = OpenTelemetry::SDK::Logs::Export::SimpleLogRecordProcessor.new(LOG_EXPORTER)
+else
+  LogExporter = Struct.new do
+    def reset; end
+    def emitted_log_records
+      []
+    end
+  end
+
+  LOG_EXPORTER = LogExporter.new
+  log_record_processor = nil
+end
 
 OpenTelemetry::SDK.configure do |c|
   c.error_handler = ->(exception:, message:) { raise(exception || message) }


### PR DESCRIPTION
This PR now makes a few changes:
1. It removes `opentelemetry-logs-api` as a dependency to the library. It was added because the instrumentation emits GenAI events using its methods. Since the Logs API is not stable, we need to avoid mixing stability within the same package. Now, if the instrumentation detects the Logs API and Logs SDK are already installed, the user will receive GenAI events. 

2. OpenAI changes won't initiate a full CI run because the gem is missing from the ci-instrumentation-full.yml workflow.

I first observed this with #2545 which only updates the openai gem, but didn't run the tests for it. 
<img width="1142" height="857" alt="Screenshot 2026-08-31 at 3 37 07 PM" src="https://github.com/user-attachments/assets/82e1bfa8-9262-4c60-a701-3c1327711f37" />

3. JRuby is excluded from testing. OpenAI makes a "best effort" to support JRuby, but it is not included in their CI. There is currently a require issue within the gem that prevents JRuby from running on it. 