### PR TITLE
chore: Restrict testing on JRuby

### DIFF
--- a/.github/workflows/ci-instrumentation-with-services.yml
+++ b/.github/workflows/ci-instrumentation-with-services.yml
@@ -95,3 +95,8 @@ jobs:
           ruby: "3.3"
           yard: true
           build: true
+      - name: "Test JRuby"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "opentelemetry-instrumentation-${{ matrix.gem }}"
+          ruby: "jruby-10.0"

--- a/instrumentation/mongo/test/test_helper.rb
+++ b/instrumentation/mongo/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'dotenv'
 Dotenv.load('.env', '../.env')
 

--- a/instrumentation/mysql2/Appraisals
+++ b/instrumentation/mysql2/Appraisals
@@ -2,6 +2,6 @@
 
 %w[0.5.0 0.5.7].each do |version|
   appraise "mysql2-#{version}" do
-    gem 'mysql2', "~> #{version}"
+    gem 'mysql2', "~> #{version}", platform: :mri
   end
 end

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Mysql2 instrumentation for the OpenTelemetry framework'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
+  spec.platform    = Gem::Platform::RUBY
 
   spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('*.md') +

--- a/instrumentation/mysql2/test/test_helper.rb
+++ b/instrumentation/mysql2/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'dotenv'
 Dotenv.load('.env', '../.env')
 

--- a/instrumentation/pg/Appraisals
+++ b/instrumentation/pg/Appraisals
@@ -2,6 +2,6 @@
 
 %w[1.5.0 1.6.3].each do |version|
   appraise "pg-#{version}" do
-    gem 'pg', "~> #{version}"
+    gem 'pg', "~> #{version}", platform: :mri
   end
 end

--- a/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
+++ b/instrumentation/pg/opentelemetry-instrumentation-pg.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.description = 'PG (PostgreSQL) instrumentation for the OpenTelemetry framework'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
+  spec.platform    = Gem::Platform::RUBY
 
   spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('*.md') +

--- a/instrumentation/pg/test/test_helper.rb
+++ b/instrumentation/pg/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'dotenv'
 Dotenv.load('.env', '../.env')
 

--- a/instrumentation/que/Appraisals
+++ b/instrumentation/que/Appraisals
@@ -7,11 +7,11 @@
 appraise 'que-2.x' do
   gem 'que', '~> 2.4'
   gem 'activerecord', '~> 7.2.0'
-  gem 'pg', '~> 1.5'
+  gem 'pg', '~> 1.5', platform: :mri
 end
 
 appraise 'que-latest' do
   gem 'que'
   gem 'activerecord'
-  gem 'pg'
+  gem 'pg', platform: :mri
 end

--- a/instrumentation/que/opentelemetry-instrumentation-que.gemspec
+++ b/instrumentation/que/opentelemetry-instrumentation-que.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Que instrumentation for the OpenTelemetry framework'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
+  spec.platform    = Gem::Platform::RUBY
 
   spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('*.md') +

--- a/instrumentation/que/test/test_helper.rb
+++ b/instrumentation/que/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'dotenv'
 Dotenv.load('.env', '../.env')
 

--- a/instrumentation/trilogy/Appraisals
+++ b/instrumentation/trilogy/Appraisals
@@ -14,7 +14,7 @@ semconv_stability = %w[old stable dup]
 semconv_stability.each do |mode|
   %w[2.11.0 2.12.6].each do |version|
     appraise "trilogy-#{version}-#{mode}" do
-      gem 'trilogy', "~> #{version}"
+      gem 'trilogy', "~> #{version}", platform: :mri
     end
   end
 end

--- a/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
+++ b/instrumentation/trilogy/opentelemetry-instrumentation-trilogy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Adds auto instrumentation that includes SQL metadata'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby-contrib'
   spec.license     = 'Apache-2.0'
+  spec.platform    = Gem::Platform::RUBY
 
   spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('*.md') +

--- a/instrumentation/trilogy/test/test_helper.rb
+++ b/instrumentation/trilogy/test/test_helper.rb
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if RUBY_ENGINE == 'jruby'
+  warn 'Skipping tests on JRuby: Runtime not supported'
+  exit 0
+end
+
 require 'dotenv'
 Dotenv.load('.env', '../.env')
 


### PR DESCRIPTION
This adds the jruby exclusions when needed for gems which use services. These exclusions are tested now that jruby has been added as a target.

This pr is an extension of #2429 