### PR TITLE
fix(net_http): omit nil attributes on spans

### DIFF
--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/dup/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/dup/instrumentation.rb
@@ -30,7 +30,7 @@ module OpenTelemetry
                                OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => @address,
                                OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => @port, 'url.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
                                'server.address' => @address,
-                               'server.port' => @port }
+                               'server.port' => @port }.compact
                 path, query = split_path_and_query(req.path)
                 attributes['url.path'] = path
                 attributes['url.query'] = query if query
@@ -68,7 +68,7 @@ module OpenTelemetry
                   OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port,
                   'server.address' => conn_address,
                   'server.port' => conn_port
-                }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+                }.compact.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
                 if use_ssl? && proxy?
                   span_name = 'CONNECT'

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/old/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/old/instrumentation.rb
@@ -28,7 +28,7 @@ module OpenTelemetry
                 attributes = { OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME => USE_SSL_TO_SCHEME[use_ssl?],
                                OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => req.path,
                                OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => @address,
-                               OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => @port }.merge!(span_data.attributes)
+                               OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => @port }.compact.merge!(span_data.attributes)
 
                 tracer.in_span(
                   span_data.span_name,
@@ -59,7 +59,7 @@ module OpenTelemetry
                 attributes = {
                   OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => conn_address,
                   OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port
-                }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+                }.compact.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
                 if use_ssl? && proxy?
                   span_name = 'HTTP CONNECT'

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/stable/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/stable/instrumentation.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
 
                 attributes = { 'url.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
                                'server.address' => @address,
-                               'server.port' => @port }
+                               'server.port' => @port }.compact
                 path, query = split_path_and_query(req.path)
                 attributes['url.path'] = path
                 attributes['url.query'] = query if query
@@ -63,7 +63,7 @@ module OpenTelemetry
                 attributes = {
                   'server.address' => conn_address,
                   'server.port' => conn_port
-                }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+                }.compact.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
                 if use_ssl? && proxy?
                   span_name = 'CONNECT'

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
@@ -389,6 +389,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       allow(TCPSocket).to receive(:open).and_return(fake_socket)
       Net::HTTP.new(nil, 80).send(:connect)
 
+      _(span.name).must_equal 'connect'
       _(span.attributes.key?('net.peer.name')).must_equal false
       _(span.attributes.key?('server.address')).must_equal false
     end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
@@ -380,6 +380,20 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       WebMock.disable_net_connect!
     end
 
+    it 'does not record a nil net.peer.name and server.address' do
+      fake_socket = Object.new
+      def fake_socket.setsockopt(*args); end
+      def fake_socket.close; end
+
+      # Replace the TCP socket creation with our fake socket
+      allow(TCPSocket).to receive(:open).and_return(fake_socket)
+      Net::HTTP.new(nil, 80).send(:connect)
+
+      _(span.name).must_equal 'connect'
+      _(span.attributes['net.peer.name']).must_be_nil
+      _(span.attributes['server.address']).must_be_nil
+    end
+
     it 'uses url.template in span name when present in client context' do
       client_context_attrs = { 'url.template' => '/users/{id}' }
       OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/dup/instrumentation_test.rb
@@ -389,9 +389,8 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       allow(TCPSocket).to receive(:open).and_return(fake_socket)
       Net::HTTP.new(nil, 80).send(:connect)
 
-      _(span.name).must_equal 'connect'
-      _(span.attributes['net.peer.name']).must_be_nil
-      _(span.attributes['server.address']).must_be_nil
+      _(span.attributes.key?('net.peer.name')).must_equal false
+      _(span.attributes.key?('server.address')).must_equal false
     end
 
     it 'uses url.template in span name when present in client context' do

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
@@ -335,5 +335,18 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     ensure
       WebMock.disable_net_connect!
     end
+
+    it 'does not record a nil net.peer.name' do
+      fake_socket = Object.new
+      def fake_socket.setsockopt(*args); end
+      def fake_socket.close; end
+
+      # Replace the TCP socket creation with our fake socket
+      allow(TCPSocket).to receive(:open).and_return(fake_socket)
+      Net::HTTP.new(nil, 80).send(:connect)
+
+      _(span.name).must_equal 'connect'
+      _(span.attributes['net.peer.name']).must_be_nil
+    end
   end
 end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/old/instrumentation_test.rb
@@ -346,7 +346,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       Net::HTTP.new(nil, 80).send(:connect)
 
       _(span.name).must_equal 'connect'
-      _(span.attributes['net.peer.name']).must_be_nil
+      _(span.attributes.key?('net.peer.name')).must_equal false
     end
   end
 end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
@@ -363,7 +363,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       Net::HTTP.new(nil, 80).send(:connect)
 
       _(span.name).must_equal 'connect'
-      _(span.attributes['server.address']).must_be_nil
+      _(span.attributes.key?('server.address')).must_equal false
     end
 
     it 'uses url.template in span name when present in client context' do

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/stable/instrumentation_test.rb
@@ -353,6 +353,19 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       WebMock.disable_net_connect!
     end
 
+    it 'does not record a nil server.address' do
+      fake_socket = Object.new
+      def fake_socket.setsockopt(*args); end
+      def fake_socket.close; end
+
+      # Replace the TCP socket creation with our fake socket
+      allow(TCPSocket).to receive(:open).and_return(fake_socket)
+      Net::HTTP.new(nil, 80).send(:connect)
+
+      _(span.name).must_equal 'connect'
+      _(span.attributes['server.address']).must_be_nil
+    end
+
     it 'uses url.template in span name when present in client context' do
       client_context_attrs = { 'url.template' => '/users/{id}' }
       OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do


### PR DESCRIPTION
 The SDK rejects `nil` attribute values and logs an error message. This PR compacts attributes and quiets the errors. 

closes #2541