### PR TITLE
fix(http_client): omit nil attributes on spans

### DIFF
--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/dup/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/dup/client.rb
@@ -34,7 +34,7 @@ module OpenTelemetry
                 'url.full' => url,
                 'server.address' => uri.host,
                 'server.port' => uri.port
-              }.merge!(span_data.attributes)
+              }.compact.merge!(span_data.attributes)
 
               attributes['url.query'] = uri.query unless uri.query.nil?
 

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/old/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/old/client.rb
@@ -29,7 +29,7 @@ module OpenTelemetry
                 'http.url' => url,
                 'net.peer.name' => uri.host,
                 'net.peer.port' => uri.port
-              }.merge!(span_data.attributes)
+              }.compact.merge!(span_data.attributes)
 
               tracer.in_span(span_data.span_name, attributes: attributes, kind: :client) do |span|
                 OpenTelemetry.propagation.inject(req.header)

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/stable/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/stable/client.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
                              'url.path' => uri.path,
                              'url.full' => url,
                              'server.address' => uri.host,
-                             'server.port' => uri.port }.merge!(span_data.attributes)
+                             'server.port' => uri.port }.compact.merge!(span_data.attributes)
 
               attributes['url.query'] = uri.query unless uri.query.nil?
 

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/dup/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/dup/client_test.rb
@@ -198,5 +198,20 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Dup::Client do
         headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
+
+    it 'omits nil attributes' do
+      stub_request(:get, 'http://success/').to_return(status: 200)
+      HTTPClient.new.get('/success')
+
+      _(span.name).must_equal 'GET'
+      _(span.attributes['http.target']).must_equal '/success'
+      _(span.attributes['url.path']).must_equal '/success'
+      _(span.attributes.key?('http.scheme')).must_equal false
+      _(span.attributes.key?('net.peer.name')).must_equal false
+      _(span.attributes.key?('net.peer.port')).must_equal false
+      _(span.attributes.key?('url.scheme')).must_equal false
+      _(span.attributes.key?('server.address')).must_equal false
+      _(span.attributes.key?('server.port')).must_equal false
+    end
   end
 end

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/old/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/old/client_test.rb
@@ -145,5 +145,16 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Old::Client do
         headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
+
+    it 'omits nil attributes' do
+      stub_request(:get, 'http://success/').to_return(status: 200)
+      HTTPClient.new.get('/success')
+
+      _(span.name).must_equal 'HTTP GET'
+      _(span.attributes['http.target']).must_equal '/success'
+      _(span.attributes.key?('http.scheme')).must_equal false
+      _(span.attributes.key?('net.peer.name')).must_equal false
+      _(span.attributes.key?('net.peer.port')).must_equal false
+    end
   end
 end

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/stable/client_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/stable/client_test.rb
@@ -161,5 +161,16 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Stable::Client do
         headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
+
+    it 'omits nil attributes' do
+      stub_request(:get, 'http://success/').to_return(status: 200)
+      HTTPClient.new.get('/success')
+
+      _(span.name).must_equal 'GET'
+      _(span.attributes['url.path']).must_equal '/success'
+      _(span.attributes.key?('url.scheme')).must_equal false
+      _(span.attributes.key?('server.address')).must_equal false
+      _(span.attributes.key?('server.port')).must_equal false
+    end
   end
 end


### PR DESCRIPTION
 The SDK rejects `nil` attribute values and logs an error message. This PR compacts attributes and quiets the errors. 

This issue was originally surfaced in #2541, and follows the fix in #2558. This is more of a preventative fix vs something that was noticed by a user.