### PR TITLE
chore: Check file system for consistency

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -207,6 +207,10 @@ instrumentation-rails:
   - changed-files:
       - any-glob-to-any-file:
           - "instrumentation/rails/**"
+instrumentation-rake:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "instrumentation/rake/**"
 instrumentation-rdkafka:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -1,8 +1,10 @@
 name: File Checks
 
 on:
-  pull_request:
-  merge_group:
+  workflow_call:
+    secrets:
+      abc:
+        required: true
 
 permissions:
   contents: read
@@ -30,9 +32,6 @@ jobs:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby-contrib' }}
     name: Markdown Link Check
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      pull-requests: write # required for posting PR review comments
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -42,7 +41,6 @@ jobs:
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@568ec8d29fa92b31fd9ea5381e155c51e922af83 # v1.5.5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-annotations
           fail_on_error: true
 
@@ -146,7 +144,6 @@ jobs:
       - name: Lint
         uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689 # v3.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           dotenv_linter_flags: --recursive
           fail_level: warning
 

--- a/.github/workflows/ci-markdown-checks.yml
+++ b/.github/workflows/ci-markdown-checks.yml
@@ -2,9 +2,6 @@ name: File Checks
 
 on:
   workflow_call:
-    secrets:
-      abc:
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/file_review-ci_setup.yml
+++ b/.github/workflows/file_review-ci_setup.yml
@@ -1,0 +1,33 @@
+name: CI Setup
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  labels:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          bundler-cache: true
+          ruby-version: "3.3.12"
+      - run: bundle exec rake check_labeler_config
+  toys:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          bundler-cache: true
+          ruby-version: "3.3.12"
+      - run: bundle exec rake check_releases_defined

--- a/.github/workflows/file_review-filesystem.yml
+++ b/.github/workflows/file_review-filesystem.yml
@@ -1,0 +1,16 @@
+name: File System
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  ls-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd # v2.3.1

--- a/.github/workflows/file_review.yml
+++ b/.github/workflows/file_review.yml
@@ -1,0 +1,24 @@
+name: File Review
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  filesystem:
+    uses: ./.github/workflows/file_review-filesystem.yml
+  ci:
+    uses: ./.github/workflows/file_review-ci_setup.yml
+  checks:
+    uses: ./.github/workflows/ci-markdown-checks.yml
+    secrets:
+      abc: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/file_review.yml
+++ b/.github/workflows/file_review.yml
@@ -20,5 +20,3 @@ jobs:
     uses: ./.github/workflows/file_review-ci_setup.yml
   checks:
     uses: ./.github/workflows/ci-markdown-checks.yml
-    secrets:
-      abc: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/file_review.yml
+++ b/.github/workflows/file_review.yml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   filesystem:
-    uses: ./.github/workflows/file_review-filesystem.yml
+    uses: $/.github/workflows/file_review-filesystem.yml
   ci:
-    uses: ./.github/workflows/file_review-ci_setup.yml
+    uses: $/.github/workflows/file_review-ci_setup.yml
   checks:
-    uses: ./.github/workflows/ci-markdown-checks.yml
+    uses: $/.github/workflows/ci-markdown-checks.yml

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,17 @@
+ls:
+  "{helpers,instrumentation,processor,propagator,resources,sampler}":
+    .dir: snake_case
+    "*":
+      .: regex:(Appraisals|Gemfile|LICENSE|Rakefile) | exists:4
+      .gemspec: regex:(opentelemetry-${1}-${0}|opentelemetry-resource-detector-${0}) | exists:1
+      .md: regex:(CHANGELOG|README) | exists:2
+      .rubocop.yml: exists:1
+      .yardopts: exists:1
+      "{.docker,example,lib,test}":
+        .dir: lowercase
+
+ignore:
+  - .git
+  - node_modules
+  - "**/.yardoc"
+  - "**/vendor"

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -49,6 +49,10 @@ gems:
   - name: opentelemetry-helpers-mysql
     directory: helpers/mysql
 
+  - name: opentelemetry-helpers-sql-obfuscation
+    directory: helpers/sql-obfuscation
+    version_rb_path: lib/opentelemetry/helpers/sql_obfuscation/version.rb
+
   - name: opentelemetry-helpers-sql-processor
     directory: helpers/sql-processor
     version_rb_path: lib/opentelemetry/helpers/sql_processor/version.rb

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require "yaml"
+
+LABELER_FILE = ".github/labeler.yml"
+TOYS_FILE    = ".toys/.data/releases.yml"
+
 namespace :each do
   task :bundle_install do
     foreach_gem('bundle install')
@@ -49,24 +54,111 @@ task build: ['each:build']
 task install: ['each:install']
 task yard: ['each:yard']
 
+task :check_labeler_config do
+  labeler = nil
+  begin
+    labeler = YAML.load_file(LABELER_FILE)
+  rescue Errno::ENOENT
+    puts "Labeler file missing: #{LABELER_FILE}"
+    labeler == {}
+  end
+
+  issue_count = 0
+
+  discover_gems.each do |gem|
+    parent_dir  = gem[:dir]
+    name = gem[:name]
+
+    labeler_key = name.sub(/^opentelemetry-/, "")
+    expected_glob = "#{parent_dir}/**"
+
+    # --- Labeler key existence ---
+    unless labeler == {} || labeler.key?(labeler_key)
+      puts "::error:: Missing labeler key: #{labeler_key}"
+      issue_count += 1
+      next
+    end
+
+    # Extract globs for THIS key only
+    globs =
+      labeler[labeler_key]
+        .flat_map { |entry| entry["changed-files"] }
+        .compact
+        .flat_map { |cf| cf["any-glob-to-any-file"] }
+        .compact
+
+    # --- Labeler directory glob ---
+    unless labeler == {} || globs.include?(expected_glob)
+      puts "::error:: Labeler key #{labeler_key} missing glob #{expected_glob}"
+      issue_count += 1
+    end
+
+    # --- compose.yml rule ---
+    compose_file = File.join(parent_dir, "test", "compose.yml")
+    docker_dir = File.join(parent_dir, ".docker")
+    if File.exist?(compose_file) && !Dir.exist?(docker_dir)
+      unless globs.any? { |glob| glob.start_with?(".docker/infra") }
+        puts "::error:: compose.yml found for #{parent_dir}/test, but labeler key #{labeler_key} missing .docker/infra/** glob"
+        issue_count += 1
+      end
+    end
+  end
+
+  puts "Issues: #{issue_count}"
+
+  abort if issue_count > 0
+end
+
+task :check_releases_defined do
+  toys = YAML.load_file(TOYS_FILE)
+
+  toys_by_name = toys.fetch("gems", []).map { |g| [g["name"], g] }.to_h
+
+  issue_count = 0
+
+  discover_gems.each do |gem|
+    parent_dir  = gem[:dir]
+    name = gem[:name]
+
+    # --- Toys entry existence ---
+    toys_entry = toys_by_name[name]
+    if toys_entry.nil?
+      puts "::error:: Missing toys entry for #{name}"
+      issue_count += 1
+    else
+      # --- Toys name match ---
+      if toys_entry['directory'] != parent_dir
+        puts "::error:: Toys directory mismatch for #{name}: expected #{parent_dir}, got #{toys_entry['directory']}"
+        issue_count += 1
+      end
+    end
+  end
+
+  puts "Issues: #{issue_count}"
+
+  abort if issue_count > 0
+end
+
 task default: [:each]
 
 EXCLUDED_DIRS = %w[vendor]
 
+def discover_gems
+  Dir.glob("**/opentelemetry-*.gemspec")
+     .reject { |path|
+       EXCLUDED_DIRS.any? { |d| path.include?("/#{d}/") || path.start_with?("#{d}/") }
+     }
+     .map { |gemspec|
+       { dir: File.dirname(gemspec), name: File.basename(gemspec, ".gemspec") }
+     }
+     .sort_by { |h| h[:dir] }
+end
+
 def foreach_gem(cmds)
   cmds = Array(cmds)  # string → ["string"], array stays array
-  gemspecs =
-    Dir.glob("**/opentelemetry-*.gemspec")
-       .reject do |path|
-         EXCLUDED_DIRS.any? do |d|
-           path.include?("/#{d}/") || path.start_with?("#{d}/")
-         end
-       end
-       .sort
 
-  gemspecs.each do |gemspec|
-    name = File.basename(gemspec, ".gemspec")
-    dir = File.dirname(gemspec)
+  discover_gems.each do |gemspec|
+    dir  = gem[:dir]
     puts "**** Entering #{dir}"
     Dir.chdir(dir) do
       if defined?(Bundler)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@ls-lint/ls-lint": "2.3.1",
         "@prantlf/jsonlint": "17.0.1",
         "@umbrelladocs/linkspector": "0.5.6",
         "cspell": "10.0.1",
@@ -1443,6 +1444,27 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ls-lint/ls-lint": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@ls-lint/ls-lint/-/ls-lint-2.3.1.tgz",
+      "integrity": "sha512-vPe6IDByQnQRTxcAYjTxrmga/tSIui50VBFTB5KIJWY3OOFmxE2VtymjeSEfQfiMbhZV/ZPAqYy2lt8pZFQ0Rw==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "s390x",
+        "ppc64le"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "ls-lint": "bin/cli.js"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "scripts": {
-    "check": "npm run check:lint && npm run check:format && npm run check:links && npm run check:spelling && npm run check:source",
+    "check": "npm run check:lint && npm run check:format && npm run check:filesystem && npm run check:github && npm run check:links && npm run check:spelling && npm run check:source && npm run check:toys",
+    "check:filesystem": "node_modules/.bin/ls-lint",
     "check:format": "npm run check:format:ruby && prettier . --check",
     "check:format:json": "prettier **/*.json --check",
     "check:format:markdown": "prettier **/*.md --check",
     "check:format:ruby": "rubocop --only Layout",
+    "check:github": "npm run check:github:labels",
+    "check:github:labels": "bundle exec rake check_labeler_config",
     "check:links": "node bin/link-check.cjs",
     "check:lint": "npm run check:lint:json && npm run check:lint:markdown && npm run check:lint:ruby",
     "check:lint:json": "uname >/dev/null 2>&1 && jsonlint --config .jsonlintrc.yml || true",
@@ -14,6 +17,8 @@
     "check:source": "npm run check:source:ruby",
     "check:source:ruby": "rubocop --only Bundler,Gemspec,Metrics,Migration,Minitest,Performance,Rake,RSpec,Security",
     "check:spelling": "cspell -c .cspell.yml .",
+    "check:toys": "npm run check:toys:releases",
+    "check:toys:releases": "bundle exec rake check_releases_defined",
     "test:renovate:dryrun": "renovate --dry-run=full --autodiscover --autodiscover-filter open-telemetry/opentelemetry-ruby-contrib",
     "write": "npm run write:lint && npm run write:format && npm run write:source:ruby",
     "write:format": "npm run write:format:ruby && prettier . --write",
@@ -28,9 +33,10 @@
     "write:source:ruby": "npm run check:source:ruby -- --autocorrect-all"
   },
   "devDependencies": {
+    "@ls-lint/ls-lint": "2.3.1",
+    "@prantlf/jsonlint": "17.0.1",
     "@umbrelladocs/linkspector": "0.5.6",
     "cspell": "10.0.1",
-    "@prantlf/jsonlint": "17.0.1",
     "markdownlint-cli2": "0.23.2",
     "prettier": "3.9.6",
     "renovate": "44.39.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "check": "npm run check:lint && npm run check:format && npm run check:filesystem && npm run check:github && npm run check:links && npm run check:spelling && npm run check:source && npm run check:toys",
-    "check:filesystem": "node_modules/.bin/ls-lint",
+    "check:filesystem": "ls-lint",
     "check:format": "npm run check:format:ruby && prettier . --check",
     "check:format:json": "prettier **/*.json --check",
     "check:format:markdown": "prettier **/*.md --check",

--- a/resources/os/.rubocop.yml
+++ b/resources/os/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../../.rubocop.yml

--- a/resources/os/.yardopts
+++ b/resources/os/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Resource Detector OS
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/resource/detector/**/*.rb
+./lib/opentelemetry/resource/detector.rb
+-
+README.md
+CHANGELOG.md


### PR DESCRIPTION
This is a response to the latest issues we have faced where things were missed during the addition of new gems which caused issues.

As can be seen in https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/34013226191 it will fail ci if a violation exists & https://github.com/open-telemetry/opentelemetry-ruby-contrib/actions/runs/34013326727 shows it passes once fixed

## Issues tackled

### Gems missing from release

This enforces that every single gem is configured in the releases file. This occured in otel-ruby with otlp-common missing.

### Appraisals missing

This forces each gem to contain an Appraisals file as without it the ci will fail

### Yard options missing

This will flag when a gem doesn't contain a yardopts file as is the case with the resources-os gem

### Labels missing

This identifed that there was no rake instrumentation label.

## Additional context

Note this has also added additional consistency checks for folders such as