### PR TITLE
fix(instrumentation-aws_lambda): only flush a meter provider that can be flushed

### DIFF
--- a/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
+++ b/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
@@ -60,7 +60,10 @@ module OpenTelemetry
           end
 
           OpenTelemetry.tracer_provider.force_flush(timeout: flush_timeout)
-          OpenTelemetry.meter_provider.force_flush(timeout: flush_timeout) if OpenTelemetry.respond_to?(:meter_provider)
+
+          # Only the metrics SDK supplies a meter provider that can be flushed.
+          meter_provider = OpenTelemetry.meter_provider if OpenTelemetry.respond_to?(:meter_provider)
+          meter_provider.force_flush(timeout: flush_timeout) if meter_provider.respond_to?(:force_flush)
 
           raise original_handler_error if original_handler_error
 

--- a/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
@@ -170,6 +170,44 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
     end
   end
 
+  describe 'meter provider flushing' do
+    let(:otel_wrapper) { OpenTelemetry::Instrumentation::AwsLambda::Handler.new }
+
+    after do
+      OpenTelemetry.singleton_class.send(:remove_method, :meter_provider) if OpenTelemetry.singleton_class.method_defined?(:meter_provider, false)
+    end
+
+    it 'flushes a meter provider that can be flushed' do
+      flushed = []
+      provider = Class.new do
+        def initialize(flushed)
+          @flushed = flushed
+        end
+
+        def force_flush(timeout: nil)
+          @flushed << timeout
+        end
+      end.new(flushed)
+      OpenTelemetry.define_singleton_method(:meter_provider) { provider }
+
+      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
+      otel_wrapper.call_wrapped(event: event_v1, context: context)
+
+      _(flushed).must_equal [30_000]
+    end
+
+    it 'skips a meter provider that cannot be flushed' do
+      # neither the no-op meter provider in the metrics API nor its proxy defines force_flush
+      provider = Object.new
+      OpenTelemetry.define_singleton_method(:meter_provider) { provider }
+
+      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
+      otel_wrapper.call_wrapped(event: event_v1, context: context)
+
+      _(last_span.name).must_equal 'sample.test'
+    end
+  end
+
   describe 'validate_error_handling' do
     it 'handle error if original handler cause issue' do
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new


### PR DESCRIPTION
A Lambda invocation fails after the handler has already run and returned, when the metrics API is loaded without the metrics SDK. This is because a `ProxyMeterProvider` does not have a `force_flush` method.

This PR guards on the provider, so the flush happens only when there is something to flush