### PR TITLE
refactor!: make metrics and logs instrumentation-only

### DIFF
--- a/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
+++ b/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb
@@ -60,7 +60,10 @@ module OpenTelemetry
           end
 
           OpenTelemetry.tracer_provider.force_flush(timeout: flush_timeout)
-          OpenTelemetry.meter_provider.force_flush(timeout: flush_timeout) if OpenTelemetry.respond_to?(:meter_provider)
+
+          # Only the metrics SDK supplies a meter provider that can be flushed.
+          meter_provider = OpenTelemetry.meter_provider if OpenTelemetry.respond_to?(:meter_provider)
+          meter_provider.force_flush(timeout: flush_timeout) if meter_provider.respond_to?(:force_flush)
 
           raise original_handler_error if original_handler_error
 

--- a/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_lambda/test/opentelemetry/instrumentation_test.rb
@@ -170,6 +170,42 @@ describe OpenTelemetry::Instrumentation::AwsLambda do
     end
   end
 
+  describe 'meter provider flushing' do
+    let(:otel_wrapper) { OpenTelemetry::Instrumentation::AwsLambda::Handler.new }
+
+    after do
+      OpenTelemetry.singleton_class.send(:remove_method, :meter_provider) if OpenTelemetry.singleton_class.method_defined?(:meter_provider, false)
+    end
+
+    it 'flushes a meter provider that can be flushed' do
+      flushed = []
+      provider = Class.new do
+        def initialize(flushed)
+          @flushed = flushed
+        end
+
+        def force_flush(timeout: nil)
+          @flushed << timeout
+        end
+      end.new(flushed)
+      OpenTelemetry.define_singleton_method(:meter_provider) { provider }
+
+      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
+      otel_wrapper.call_wrapped(event: event_v1, context: context)
+
+      _(flushed).must_equal [30_000]
+    end
+
+    it 'skips a meter provider that cannot be flushed' do
+      OpenTelemetry.define_singleton_method(:meter_provider) { OpenTelemetry::Metrics::MeterProvider.new }
+
+      allow(otel_wrapper).to receive(:call_original_handler).and_return({})
+      otel_wrapper.call_wrapped(event: event_v1, context: context)
+
+      _(last_span.name).must_equal 'sample.test'
+    end
+  end
+
   describe 'validate_error_handling' do
     it 'handle error if original handler cause issue' do
       otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new

--- a/instrumentation/base/lib/opentelemetry/instrumentation.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation.rb
@@ -6,6 +6,11 @@
 
 require 'opentelemetry'
 require 'opentelemetry-registry'
+# These carry the Metrics and Logs API classes and the internal provider slots
+# that Instrumentation::Base reads. Neither defines a top-level provider
+# accessor, so requiring them exposes nothing to users of an instrumentation.
+require 'opentelemetry-logs-api'
+require 'opentelemetry-metrics-api'
 require 'opentelemetry/instrumentation/base'
 
 module OpenTelemetry

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -229,10 +229,11 @@ module OpenTelemetry
         @config = config_options(config)
         return false unless installable?(config)
 
-        instance_exec(@config, &@install_blk)
         @tracer = OpenTelemetry.tracer_provider.tracer(name, version)
         @meter = OpenTelemetry::Internal.meter_provider.meter(name, version: version)
         @logger = OpenTelemetry::Internal.logger_provider.logger(name: name, version: version)
+
+        instance_exec(@config, &@install_blk)
         @installed = true
       end
 

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -49,9 +49,16 @@ module OpenTelemetry
     # SDKs for instrumentation discovery and installation.
     #
     # Instrumentation libraries can use the instrumentation subclass to easily gain
-    # a reference to its named tracer. For example:
+    # a reference to its named tracer, meter, and logger. For example:
     #
     # OpenTelemetry::Instrumentation::Sinatra.instance.tracer
+    # OpenTelemetry::Instrumentation::Sinatra.instance.meter
+    # OpenTelemetry::Instrumentation::Sinatra.instance.logger
+    #
+    # The meter and logger emit no telemetry unless the user has opted into the
+    # Metrics or Logs SDK. Both APIs are unstable, so the top-level
+    # OpenTelemetry.meter_provider and OpenTelemetry.logger_provider accessors
+    # are not available to users who have only installed instrumentation.
     #
     # The instrumentation class establishes a convention for disabling an instrumentation
     # by environment variable and local configuration. An instrumentation disabled
@@ -189,7 +196,7 @@ module OpenTelemetry
         end
       end
 
-      attr_reader :name, :version, :config, :installed, :tracer
+      attr_reader :name, :version, :config, :installed, :tracer, :meter, :logger
 
       alias installed? installed
 
@@ -207,6 +214,8 @@ module OpenTelemetry
         @config = Hash.new { |_, k| defaults[k] }
         @installed = false
         @tracer = OpenTelemetry::Trace::Tracer.new
+        @meter = OpenTelemetry::Metrics::Meter.new
+        @logger = OpenTelemetry::Logs::Logger.new
       end
 
       # Install instrumentation with the given config. The present? and compatible?
@@ -222,6 +231,8 @@ module OpenTelemetry
 
         instance_exec(@config, &@install_blk)
         @tracer = OpenTelemetry.tracer_provider.tracer(name, version)
+        @meter = OpenTelemetry::Internal.meter_provider.meter(name, version: version)
+        @logger = OpenTelemetry::Internal.logger_provider.logger(name: name, version: version)
         @installed = true
       end
 

--- a/instrumentation/base/opentelemetry-instrumentation-base.gemspec
+++ b/instrumentation/base/opentelemetry-instrumentation-base.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.7'
   spec.add_dependency 'opentelemetry-common', '~> 0.21'
+  # TODO: The logs and metrics api version numbers are aniticipated. Confirm when released.
+  spec.add_dependency 'opentelemetry-logs-api', '~> 0.5'
+  spec.add_dependency 'opentelemetry-metrics-api', '~> 0.8'
   spec.add_dependency 'opentelemetry-registry', '~> 0.1'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -509,6 +509,36 @@ describe OpenTelemetry::Instrumentation::Base do
     end
   end
 
+  describe 'provider resolution' do
+    let(:captures_providers) do
+      captured = @captured = {}
+
+      Class.new(OpenTelemetry::Instrumentation::Base) do
+        instrumentation_name 'captures_providers'
+        instrumentation_version '0.2.0'
+
+        present { true }
+
+        install do |_config|
+          captured[:tracer] = tracer
+          captured[:meter] = meter
+          captured[:logger] = logger
+          true
+        end
+      end
+    end
+
+    it 'resolves the tracer, meter and logger before running the install block' do
+      instance = captures_providers.instance
+
+      instance.install
+
+      _(@captured[:tracer]).must_be_same_as(instance.tracer)
+      _(@captured[:meter]).must_be_same_as(instance.meter)
+      _(@captured[:logger]).must_be_same_as(instance.logger)
+    end
+  end
+
   describe 'the unstable APIs' do
     it 'does not expose the top-level provider accessors to users' do
       refute_respond_to(OpenTelemetry, :meter_provider)

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -439,6 +439,83 @@ describe OpenTelemetry::Instrumentation::Base do
     end
   end
 
+  describe '#meter' do
+    # Records the instrumentation scope it was asked for, so the scope Base
+    # passes through can be asserted without a real Metrics SDK.
+    let(:recording_meter_provider) do
+      Class.new(OpenTelemetry::Metrics::MeterProvider) do
+        attr_reader :requested
+
+        def meter(name, version: nil, attributes: nil)
+          @requested = { name: name, version: version }
+          super
+        end
+      end.new
+    end
+
+    after { OpenTelemetry::Internal.instance_variable_set(:@meter_provider, OpenTelemetry::Internal::ProxyMeterProvider.new) }
+
+    it 'returns a noop api meter if not installed' do
+      _(instrumentation_with_callbacks.instance.meter).must_be_kind_of(OpenTelemetry::Metrics::Meter)
+    end
+
+    it 'returns a meter from the internal provider if installed' do
+      instance = instrumentation_with_callbacks.instance
+      instance.install
+      _(instance.meter).must_be_kind_of(OpenTelemetry::Metrics::Meter)
+    end
+
+    it 'requests the meter using the instrumentation name and version' do
+      OpenTelemetry::Internal.instance_variable_set(:@meter_provider, recording_meter_provider)
+      instance = instrumentation_with_callbacks.instance
+
+      instance.install
+
+      _(recording_meter_provider.requested).must_equal(name: 'test_instrumentation', version: '0.1.1')
+    end
+  end
+
+  describe '#logger' do
+    let(:recording_logger_provider) do
+      Class.new(OpenTelemetry::Logs::LoggerProvider) do
+        attr_reader :requested
+
+        def logger(name:, version: nil)
+          @requested = { name: name, version: version }
+          super
+        end
+      end.new
+    end
+
+    after { OpenTelemetry::Internal.instance_variable_set(:@logger_provider, OpenTelemetry::Internal::ProxyLoggerProvider.new) }
+
+    it 'returns a noop api logger if not installed' do
+      _(instrumentation_with_callbacks.instance.logger).must_be_kind_of(OpenTelemetry::Logs::Logger)
+    end
+
+    it 'returns a logger from the internal provider if installed' do
+      instance = instrumentation_with_callbacks.instance
+      instance.install
+      _(instance.logger).must_be_kind_of(OpenTelemetry::Logs::Logger)
+    end
+
+    it 'requests the logger using the instrumentation name and version' do
+      OpenTelemetry::Internal.instance_variable_set(:@logger_provider, recording_logger_provider)
+      instance = instrumentation_with_callbacks.instance
+
+      instance.install
+
+      _(recording_logger_provider.requested).must_equal(name: 'test_instrumentation', version: '0.1.1')
+    end
+  end
+
+  describe 'the unstable APIs' do
+    it 'does not expose the top-level provider accessors to users' do
+      refute_respond_to(OpenTelemetry, :meter_provider)
+      refute_respond_to(OpenTelemetry, :logger_provider)
+    end
+  end
+
   describe 'namespaced instrumentation' do
     before do
       define_instrumentation_subclass('OTel::Instrumentation::Sinatra::Instrumentation', '2.1.0')

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger.rb
@@ -11,7 +11,6 @@ module OpenTelemetry
   module Instrumentation
     # Contains the OpenTelemetry instrumentation for the Logger gem
     module Logger
-      NAME = 'opentelemetry-instrumentation-logger'
     end
   end
 end

--- a/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
+++ b/instrumentation/logger/lib/opentelemetry/instrumentation/logger/patches/logger.rb
@@ -29,10 +29,8 @@ module OpenTelemetry
 
             Thread.current[IN_OTEL_EMIT_KEY] = true
             begin
-              OpenTelemetry.logger_provider.logger(
-                name: OpenTelemetry::Instrumentation::Logger::NAME,
-                version: OpenTelemetry::Instrumentation::Logger::VERSION
-              ).on_emit(
+              otel_logger = OpenTelemetry::Instrumentation::Logger::Instrumentation.instance.logger
+              otel_logger.on_emit(
                 severity_text: severity,
                 severity_number: severity_number(severity),
                 timestamp: datetime,

--- a/instrumentation/logger/opentelemetry-instrumentation-logger.gemspec
+++ b/instrumentation/logger/opentelemetry-instrumentation-logger.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.3'
 
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.27'
   spec.add_dependency 'opentelemetry-logs-api', '~> 0.1'
 
   if spec.respond_to?(:metadata)

--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
@@ -34,9 +34,10 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::Logger do
     end
 
     it 'sets the OTel logger instrumentation name and version (default case)' do
+      instrumentation = OpenTelemetry::Instrumentation::Logger::Instrumentation.instance
       ruby_logger.debug(msg)
-      assert_equal(OpenTelemetry::Instrumentation::Logger::NAME, log_record.instrumentation_scope.name)
-      assert_equal(OpenTelemetry::Instrumentation::Logger::VERSION, log_record.instrumentation_scope.version)
+      assert_equal(instrumentation.name, log_record.instrumentation_scope.name)
+      assert_equal(instrumentation.version, log_record.instrumentation_scope.version)
     end
 
     it 'sets log record attributes based on the Ruby log' do

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai.rb
@@ -12,7 +12,6 @@ module OpenTelemetry
   module Instrumentation
     # Contains the OpenTelemetry instrumentation for the openai gem
     module OpenAI
-      NAME = 'opentelemetry-instrumentation-openai'
     end
   end
 end

--- a/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
+++ b/instrumentation/openai/lib/opentelemetry/instrumentation/openai/instrumentation.rb
@@ -15,7 +15,6 @@ module OpenTelemetry
         install do |_config|
           require_dependencies
           determine_the_content_mode
-          create_logger
           patch_client
         end
 
@@ -44,8 +43,6 @@ module OpenTelemetry
         # embeddings), the operations currently implemented and tested.
         option :allowed_operations, default: ALLOWED_OPERATIONS, validate: :array
 
-        attr_reader :logger
-
         private
 
         def gem_version
@@ -59,10 +56,6 @@ module OpenTelemetry
 
         def require_dependencies
           require_relative 'patches/client'
-        end
-
-        def create_logger
-          @logger = OpenTelemetry.logger_provider.logger(name: NAME, version: VERSION)
         end
 
         def patch_client

--- a/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
+++ b/instrumentation/openai/opentelemetry-instrumentation-openai.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.3'
 
-  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.25'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.27'
   spec.add_dependency 'opentelemetry-logs-api', '~> 0.4.1'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Draft for discussion. Contrib half of open-telemetry/opentelemetry-ruby#2384.

## Point

Instrumentation should be able to emit metrics and log records the same way it emits spans, without the unstable metrics and logs APIs becoming part of a user's public surface. Users opt in by requiring the SDKs. That lets us exercise and evolve these APIs against our instrumentation without committing users to them, and gives us much more confidence before we stabilize.

## Change

`Instrumentation::Base` gains `#meter` and `#logger` alongside `#tracer`, resolved at install
time:

```ruby
@tracer = OpenTelemetry.tracer_provider.tracer(name, version)
@meter  = OpenTelemetry::Internal.meter_provider.meter(name, version: version)
@logger = OpenTelemetry::Internal.logger_provider.logger(name: name, version: version)
```

With no SDK loaded these are no-ops, so instrumentation can create instruments and emit records and the user sees nothing until they opt in.

`instrumentation-openai`, `instrumentation-logger`, switch over to using `Base#logger.

## Notes
- Includes bugfix that has a separate PR: #2568
- `instrumentation-logger` has breaking bug-fix: its log records change instrumentation scope name from
  `opentelemetry-instrumentation-logger` to `OpenTelemetry::Instrumentation::Logger`
- This is will require careful release sequencing along with the core counterpart PR.
- Tests are expected to fail on this branch because instrumentation updates will require the changes to `Instrumentation::Base` to be released.