### PR TITLE
feat(lmdb): trace has and drop operations

### DIFF
--- a/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/database.rb
+++ b/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/database.rb
@@ -24,6 +24,16 @@ module OpenTelemetry
             end
           end
 
+          def has?(key, value = nil)
+            attributes = { 'db.system' => 'lmdb' }
+            attributes['db.statement'] = formatted_statement('HAS', "HAS #{key} #{value}".strip) if config[:db_statement] == :include
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+
+            tracer.in_span("HAS #{key}", attributes: attributes, kind: :client) do
+              super
+            end
+          end
+
           def delete(key, value = nil)
             attributes = { 'db.system' => 'lmdb' }
             attributes['db.statement'] = formatted_statement('DELETE', "DELETE #{key} #{value}".strip) if config[:db_statement] == :include
@@ -50,6 +60,16 @@ module OpenTelemetry
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             tracer.in_span('CLEAR', attributes: attributes, kind: :client) do
+              super
+            end
+          end
+
+          def drop
+            attributes = { 'db.system' => 'lmdb' }
+            attributes['db.statement'] = 'DROP' if config[:db_statement] == :include
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+
+            tracer.in_span('DROP', attributes: attributes, kind: :client) do
               super
             end
           end

--- a/instrumentation/lmdb/test/instrumentation/lmdb/patches/database_test.rb
+++ b/instrumentation/lmdb/test/instrumentation/lmdb/patches/database_test.rb
@@ -122,6 +122,18 @@ describe OpenTelemetry::Instrumentation::LMDB::Patches::Database do
     end
   end
 
+  describe '#has?' do
+    it 'traces' do
+      lmdb.database['foo'] = 'bar'
+      lmdb.database.has?('foo', 'bar')
+
+      _(last_span.name).must_equal('HAS foo')
+      _(last_span.kind).must_equal(:client)
+      _(last_span.attributes['db.system']).must_equal('lmdb')
+      _(last_span.attributes['db.statement']).must_equal('HAS foo bar')
+    end
+  end
+
   describe '#delete' do
     it 'traces' do
       lmdb.database['foo'] = 'bar'
@@ -154,6 +166,18 @@ describe OpenTelemetry::Instrumentation::LMDB::Patches::Database do
       _(last_span.kind).must_equal(:client)
       _(last_span.attributes['db.system']).must_equal('lmdb')
       _(last_span.attributes).wont_include('db.statement')
+    end
+  end
+
+  describe '#drop' do
+    it 'traces' do
+      lmdb.database['foo'] = 'bar'
+      lmdb.database.drop
+
+      _(last_span.name).must_equal('DROP')
+      _(last_span.kind).must_equal(:client)
+      _(last_span.attributes['db.system']).must_equal('lmdb')
+      _(last_span.attributes['db.statement']).must_equal('DROP')
     end
   end
 end


### PR DESCRIPTION
Fixes #2563.

Add spans for `LMDB::Database#has?` and `LMDB::Database#drop`, matching the existing database instrumentation and preserving the optional `db.statement` and `peer.service` behavior. Focused tests cover both operations.

Validation:
- `git diff --check` passed.
- Ruby, Bundler, and Appraisal are unavailable in this environment, so the gem test suite could not be run locally.

AI assistance: Codex assisted with implementation and test drafting; the patch was reviewed before submission.
