### PR TITLE
test: Set json < 3 for koala, que, active_storage

### DIFF
--- a/instrumentation/active_storage/Appraisals
+++ b/instrumentation/active_storage/Appraisals
@@ -11,6 +11,7 @@
     gem 'image_processing', '= 2.0.3'
     gem 'mini_magick', '= 5.3.3'
     gem 'rails', "~> #{version}"
+    gem 'json', '< 3'
   end
 end
 
@@ -21,6 +22,7 @@ if RUBY_ENGINE == 'ruby'
       gem 'sqlite3', '= 2.9.6'
       gem 'image_processing', '= 2.0.3'
       gem 'mini_magick', '= 5.3.3'
+      gem 'json', '< 3'
     end
   end
 end
@@ -32,6 +34,7 @@ if RUBY_ENGINE == 'jruby'
       gem 'image_processing', '= 2.0.3'
       gem 'mini_magick', '= 5.3.3'
       gem 'rails', '~> 8.0.0'
+      gem 'json', '< 3'
     end
   end
 end

--- a/instrumentation/koala/Appraisals
+++ b/instrumentation/koala/Appraisals
@@ -6,5 +6,6 @@
 %w[3.7.0 3.7.0].each do |version|
   appraise "koala-#{version}" do
     gem 'koala', "~> #{version}"
+    gem 'json', '< 3'
   end
 end

--- a/instrumentation/que/Appraisals
+++ b/instrumentation/que/Appraisals
@@ -8,10 +8,12 @@ appraise 'que-2.x' do
   gem 'que', '~> 2.4'
   gem 'activerecord', '~> 7.2.0'
   gem 'pg', '~> 1.5', platform: :mri
+  gem 'json', '< 3'
 end
 
 appraise 'que-latest' do
   gem 'que'
   gem 'activerecord'
   gem 'pg', platform: :mri
+  gem 'json', '< 3'
 end


### PR DESCRIPTION
Version 3.0 of the JSON gem has breaking changes that cause problems within the gems themselves, not our instrumentation. Pin the version of JSON until the gems address the issue.